### PR TITLE
XAUUSD Killer XM: trend-follow + SMC-lite single-file MT5 EA

### DIFF
--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -1,568 +1,1284 @@
 //+------------------------------------------------------------------+
-//|                                                    GROK 3xAI     |
-//|        Expert Advisor Multi-Conferma - MetaTrader 5 (MQL5)       |
+//|                                     XAUUSD Killer XM (MT5)       |
+//|   Trend-follow + SMC light - production-safe single file EA      |
 //+------------------------------------------------------------------+
 #property strict
-#include <Trade\Trade.mqh>
+#include <Trade/Trade.mqh>
 
 CTrade trade;
 
-string Trim(string text)
+enum RegimeState
 {
-   return StringTrimLeft(StringTrimRight(text));
+   REGIME_RANGE = 0,
+   REGIME_TRANSITION = 1,
+   REGIME_TREND = 2,
+   REGIME_EXPANSION = 3
+};
+
+enum TradeDir
+{
+   DIR_NONE = 0,
+   DIR_LONG = 1,
+   DIR_SHORT = -1
+};
+
+input string InpSymbolOverride = "";
+input long   InpMagic = 3011;
+input double InpPipPrice = 0.10; // if 0 -> auto Point*10
+input int    InpMaxSpreadPoints = 35;
+input int    InpMaxSlippagePoints = 35;
+input int    InpMaxRetries = 2;
+input int    InpRetryDelayMs = 350;
+
+input bool   InpUseSpreadMultiple = true;
+input double InpSpreadMultiple = 3.0;
+input int    InpSpreadMultipleBlockMin = 45; // minutes
+
+input bool   InpUseRolloverBlock = true;
+input string InpRolloverStart = "23:55";
+input string InpRolloverEnd = "00:15";
+
+input bool InpUseSessionFilter = true;
+input int  InpStartHour = 6;
+input int  InpEndHour = 23;
+
+input int    InpATRPeriod = 14;
+input int    InpADXPeriod = 14;
+input int    InpRSIPeriod = 14;
+input int    InpEMA_Fast = 50;
+input int    InpEMA_Slow = 200;
+
+input int    InpRegimeConfirmBarsH1 = 2;
+input int    InpRegimeLockBarsH1 = 4;
+
+input int    InpPivotLen = 3;
+input int    InpPivotConfirmBars = 2;
+
+input bool   InpUseBreakRetest = true;
+input double InpRetestTolATR = 0.15;
+
+input double InpKeyLevelStepPrice = 3.0;
+input double InpKeyNearPrice = 0.35;
+input double InpKeyChaseMaxDistPrice = 0.90;
+
+input bool   InpUseFVGFeature = true;
+input int    InpFVGScanBars = 30;
+input double InpFVGMaxDistATR = 1.2;
+
+input bool   InpUseFibFilter = true;
+input double InpFibBaseMin = 0.50;
+input double InpFibBaseMax = 0.618;
+input double InpFibTolPrice = 0.20;
+input bool   InpUseOTEBonus = true;
+input double InpOTEMin = 0.62;
+input double InpOTEMax = 0.79;
+input int    InpOTEBonusPoints = 6;
+
+input bool   InpUseFootprintProxy = true;
+input int    InpFP_VolMAPeriod = 48;
+input double InpFP_VolSpikeRatio = 1.35;
+input double InpFP_BodyMinRatio = 0.55;
+input double InpFP_CloseSideMin = 0.65;
+input double InpFP_AbsorpVolRatio = 1.50;
+input double InpFP_AbsorpRangeATR = 0.45;
+input bool   InpFP_RequireAcceptance = true;
+input int    InpFP_ScoreBonus = 10;
+
+input bool   InpUseSpikeGuard = true;
+input double InpSpikeMultATR = 2.5;
+
+input double InpSL_ATR_Mult = 0.25;
+input double InpSL_MinBufferPrice = 0.15;
+
+input bool   InpUseMMSL = true;
+input int    InpMMSL_Pips = 35;
+input double InpMMSL_ExtraBufferPrice = 0.00;
+
+input double InpTP_RR_Main = 2.0;
+input double InpMinRRAllowed = 1.5;
+
+input bool   InpUseTP1Partial = true;
+input double InpTP1_CloseFrac = 0.50;
+input bool   InpTP1_UseKeyLevelFirst = true;
+
+input bool   InpUseSmartBE = true;
+input double InpBE_MinProfitR = 1.0;
+input double InpBE_OffsetPrice = 0.05;
+
+input bool   InpUseATRTrailAfterTP1 = true;
+input double InpTrailATR_Mult = 1.20;
+input double InpTrailMinImprovePrice = 0.10;
+input bool   InpTrailOnNewBarOnly = true;
+
+input double InpBaseRiskPct = 3.0;
+input double InpMaxLotCap = 2.0;
+
+input bool   InpUseLowVolFilter = true;
+input ENUM_TIMEFRAMES InpVolTF = PERIOD_H1;
+input int    InpVolMAPeriod = 48;
+input double InpLowVolFactor = 0.75;
+
+input bool   InpUseSpreadInstability = true;
+input int    InpSpreadAvgBarsH1 = 24;
+input double InpSpreadSpikeFactor = 1.6;
+input int    InpSpreadSpikeBlockMin = 60;
+
+input bool   InpUseDailyTradeControl = true;
+input int    InpHardMaxTradesPerDay = 4;
+
+input bool   InpUseMaxDailyLossLock = true;
+input double InpMaxDailyLossPct = 4.0;
+
+input bool   InpUseSoftEquityLock = true;
+input double InpSoftEqTrigger1 = 2.0;
+input double InpSoftEqFloor1 = 0.8;
+input double InpSoftEqTrigger2 = 4.0;
+input double InpSoftEqFloor2 = 2.0;
+
+input int    InpCooldownBarsAfterEntry = 2;
+
+input bool   InpUseAntiChop = true;
+input int    InpLossBlock2_Hours = 4;
+input int    InpLossBlock3_Hours = 12;
+input double InpRiskMultAfter3Loss = 0.70;
+input int    InpRiskCutAfter3Loss_H = 24;
+
+input bool   InpUseRSIAfterLoss = true;
+input int    InpLossStreakForRSI = 1;
+
+input bool   InpUsePyramiding = true;
+input int    InpMaxAdds = 2;
+input double InpPyramidMinProfitR = 0.8;
+input bool   InpPyramidRequireMainBE = true;
+input double InpPyramidSpacingATR = 0.7;
+input bool   InpPyramidOnlyInTrend = true;
+input bool   InpPyramidRequireAdxRising = true;
+input bool   InpPyramidUsePeakDDCap = true;
+input double InpPyramidMaxPeakDDPct = 2.0;
+input double InpAddRiskMult1 = 0.50;
+input double InpAddRiskMult2 = 0.35;
+
+input bool   InpEnableCSV = true;
+input string InpCSVName = "xauusd_killer_v314_xm_gold.csv";
+
+const int SETUP_MIN = 50;
+const int TIMING_MIN = 15;
+const int TOTAL_MIN = 68;
+
+string g_symbol = "";
+int g_digits = 2;
+datetime g_lastM15Bar = 0;
+datetime g_lastH1Bar = 0;
+double g_spreadEma = 0.0;
+
+string GVName(const string key)
+{
+   return "XK_" + key + "_" + g_symbol + "_" + (string)InpMagic;
 }
 
-#ifndef OP_BUY
-#define OP_BUY 0
-#endif
-#ifndef OP_SELL
-#define OP_SELL 1
-#endif
-
-input int SL_Pips = 30;
-input double RR_Low = 2.0;
-input double RR_High = 3.0;
-input double Risk_Low = 2.5;
-input double Risk_High = 20.0;
-input double ATRMultiplier = 1.5;
-input int    MaxTrades     = 3;  // limite operazioni aperte
-
-// Variabili aggiornabili da Telegram
-input double riskPercent   = 2.0; // percentuale di rischio predefinita
-input int    takeProfitPips = 60; // TP iniziale in pips
-input int    stopLossPips   = 30; // SL iniziale in pips
-
-datetime lastTradeTime = 0;
-double initialBalance, maxEquity;
-
-int OnInit() {
-    initialBalance = AccountInfoDouble(ACCOUNT_BALANCE);
-    maxEquity = initialBalance;
-    return(INIT_SUCCEEDED);
+double GVGetDouble(const string key, double defval)
+{
+   string name = GVName(key);
+   if(!GlobalVariableCheck(name))
+   {
+      GlobalVariableSet(name, defval);
+      return defval;
+   }
+   return GlobalVariableGet(name);
 }
 
-//+------------------------------------------------------------------+
-//| Funzione per leggere il controllo da Telegram                    |
-//+------------------------------------------------------------------+
-bool IsEAEnabled()
+void GVSetDouble(const string key, double val)
 {
-   int fileHandle = FileOpen("ea_control.txt", FILE_READ|FILE_ANSI);
-   if(fileHandle==INVALID_HANDLE)
+   GlobalVariableSet(GVName(key), val);
+}
+
+int GVGetInt(const string key, int defval)
+{
+   return (int)GVGetDouble(key, defval);
+}
+
+void GVSetInt(const string key, int val)
+{
+   GVSetDouble(key, (double)val);
+}
+
+bool IsNewBar(ENUM_TIMEFRAMES tf, datetime &lastBarTime)
+{
+   datetime t = iTime(g_symbol, tf, 0);
+   if(t != lastBarTime)
+   {
+      lastBarTime = t;
+      return true;
+   }
+   return false;
+}
+
+string ResolveSymbol()
+{
+   if(StringLen(InpSymbolOverride) > 0)
+      return InpSymbolOverride;
+   return _Symbol;
+}
+
+double PipPrice()
+{
+   if(InpPipPrice > 0.0)
+      return InpPipPrice;
+   return _Point * 10.0;
+}
+
+double SpreadPoints()
+{
+   double ask = SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   double bid = SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   return (ask - bid) / _Point;
+}
+
+bool TimeInRange(const string start, const string end)
+{
+   datetime now = TimeCurrent();
+   int sh = StringToInteger(StringSubstr(start, 0, 2));
+   int sm = StringToInteger(StringSubstr(start, 3, 2));
+   int eh = StringToInteger(StringSubstr(end, 0, 2));
+   int em = StringToInteger(StringSubstr(end, 3, 2));
+
+   datetime s = StructToTime(BuildTimeStruct(now, sh, sm));
+   datetime e = StructToTime(BuildTimeStruct(now, eh, em));
+
+   if(e < s)
+      return (now >= s || now <= e);
+   return (now >= s && now <= e);
+}
+
+MqlDateTime BuildTimeStruct(datetime t, int hour, int min)
+{
+   MqlDateTime dt;
+   TimeToStruct(t, dt);
+   dt.hour = hour;
+   dt.min = min;
+   dt.sec = 0;
+   return dt;
+}
+
+void UpdateSpreadEMA()
+{
+   double spread = SpreadPoints();
+   double alpha = 2.0 / (InpSpreadAvgBarsH1 + 1.0);
+   if(g_spreadEma <= 0.0)
+      g_spreadEma = spread;
+   else
+      g_spreadEma = alpha * spread + (1.0 - alpha) * g_spreadEma;
+}
+
+bool SpreadMultipleBlocked()
+{
+   if(!InpUseSpreadMultiple)
       return false;
 
-   string status = FileReadString(fileHandle);
-   FileClose(fileHandle);
-   status = Trim(status);
-   return (status=="ACTIVE");
+   double spread = SpreadPoints();
+   if(g_spreadEma <= 0.0)
+      return false;
+
+   if(spread > g_spreadEma * InpSpreadMultiple)
+   {
+      datetime until = TimeCurrent() + InpSpreadMultipleBlockMin * 60;
+      GVSetDouble("spreadBlockUntil", (double)until);
+   }
+
+   datetime blockUntil = (datetime)GVGetDouble("spreadBlockUntil", 0.0);
+   return (blockUntil > TimeCurrent());
 }
 
-//+------------------------------------------------------------------+
-//| Gestione comandi avanzati da file Telegram                       |
-//+------------------------------------------------------------------+
-void CheckTelegramCommands()
+bool SpreadInstabilityBlocked()
 {
-   string command="";
-   int handle = FileOpen("ea_command.txt", FILE_READ|FILE_ANSI);
-   if(handle==INVALID_HANDLE)
+   if(!InpUseSpreadInstability || g_spreadEma <= 0.0)
+      return false;
+
+   double spread = SpreadPoints();
+   if(spread > g_spreadEma * InpSpreadSpikeFactor)
+   {
+      datetime until = TimeCurrent() + InpSpreadSpikeBlockMin * 60;
+      GVSetDouble("spreadSpikeUntil", (double)until);
+   }
+
+   datetime blockUntil = (datetime)GVGetDouble("spreadSpikeUntil", 0.0);
+   return (blockUntil > TimeCurrent());
+}
+
+bool SessionAllowed()
+{
+   if(!InpUseSessionFilter)
+      return true;
+   int hour = TimeHour(TimeCurrent());
+   if(InpStartHour <= InpEndHour)
+      return (hour >= InpStartHour && hour <= InpEndHour);
+   return (hour >= InpStartHour || hour <= InpEndHour);
+}
+
+bool RolloverBlocked()
+{
+   if(!InpUseRolloverBlock)
+      return false;
+   return TimeInRange(InpRolloverStart, InpRolloverEnd);
+}
+
+double ATR(ENUM_TIMEFRAMES tf, int shift)
+{
+   return iATR(g_symbol, tf, InpATRPeriod, shift);
+}
+
+double ADX(ENUM_TIMEFRAMES tf, int shift)
+{
+   return iADX(g_symbol, tf, InpADXPeriod, PRICE_CLOSE, MODE_MAIN, shift);
+}
+
+double RSI(ENUM_TIMEFRAMES tf, int shift)
+{
+   return iRSI(g_symbol, tf, InpRSIPeriod, PRICE_CLOSE, shift);
+}
+
+double EMA(ENUM_TIMEFRAMES tf, int period, int shift)
+{
+   return iMA(g_symbol, tf, period, 0, MODE_EMA, PRICE_CLOSE, shift);
+}
+
+double VolumeMA(ENUM_TIMEFRAMES tf, int period, int shift)
+{
+   double sum = 0.0;
+   for(int i = shift; i < shift + period; i++)
+      sum += (double)iVolume(g_symbol, tf, i);
+   return sum / MathMax(1, period);
+}
+
+bool LowVolumeBlocked()
+{
+   if(!InpUseLowVolFilter)
+      return false;
+
+   double vol = (double)iVolume(g_symbol, InpVolTF, 0);
+   double avg = VolumeMA(InpVolTF, InpVolMAPeriod, 1);
+   if(avg <= 0.0)
+      return false;
+   return vol < avg * InpLowVolFactor;
+}
+
+TradeDir BiasH1()
+{
+   double emaFast = EMA(PERIOD_H1, InpEMA_Fast, 1);
+   double emaSlow = EMA(PERIOD_H1, InpEMA_Slow, 1);
+   double close = iClose(g_symbol, PERIOD_H1, 1);
+   if(emaFast > emaSlow && close > emaFast)
+      return DIR_LONG;
+   if(emaFast < emaSlow && close < emaFast)
+      return DIR_SHORT;
+   return DIR_NONE;
+}
+
+RegimeState ClassifyRegime()
+{
+   double atr = ATR(PERIOD_H1, 1);
+   double close = iClose(g_symbol, PERIOD_H1, 1);
+   double atrRel = (close > 0.0) ? (atr / close) * 100.0 : 0.0;
+   bool isExpansion = atrRel > 0.18;
+   double adx = ADX(PERIOD_H1, 1);
+   TradeDir bias = BiasH1();
+
+   if(isExpansion && adx < 18.0)
+      return REGIME_EXPANSION;
+   if(adx >= 25.0 && bias != DIR_NONE)
+      return REGIME_TREND;
+   if(adx >= 18.0)
+      return REGIME_TRANSITION;
+   return REGIME_RANGE;
+}
+
+RegimeState UpdateRegime()
+{
+   RegimeState current = (RegimeState)GVGetInt("regime", REGIME_RANGE);
+   int lockBars = GVGetInt("regimeLock", 0);
+   int confirmBars = GVGetInt("regimeConfirm", 0);
+
+   RegimeState next = ClassifyRegime();
+
+   if(lockBars > 0)
+   {
+      GVSetInt("regimeLock", lockBars - 1);
+      return current;
+   }
+
+   if(next != current)
+   {
+      confirmBars++;
+      if(confirmBars >= InpRegimeConfirmBarsH1)
+      {
+         current = next;
+         GVSetInt("regime", (int)current);
+         GVSetInt("regimeConfirm", 0);
+         GVSetInt("regimeLock", InpRegimeLockBarsH1);
+         return current;
+      }
+      GVSetInt("regimeConfirm", confirmBars);
+      return current;
+   }
+
+   GVSetInt("regimeConfirm", 0);
+   return current;
+}
+
+bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, double &prevLow)
+{
+   int foundHigh = 0;
+   int foundLow = 0;
+   lastHigh = prevHigh = 0.0;
+   lastLow = prevLow = 0.0;
+
+   int start = InpPivotConfirmBars;
+   int end = 100;
+   for(int i = start; i < end; i++)
+   {
+      bool isHigh = true;
+      bool isLow = true;
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      for(int j = 1; j <= InpPivotLen; j++)
+      {
+         if(high <= iHigh(g_symbol, PERIOD_M15, i - j) || high <= iHigh(g_symbol, PERIOD_M15, i + j))
+            isHigh = false;
+         if(low >= iLow(g_symbol, PERIOD_M15, i - j) || low >= iLow(g_symbol, PERIOD_M15, i + j))
+            isLow = false;
+      }
+      if(isHigh)
+      {
+         if(foundHigh == 0)
+            lastHigh = high;
+         else if(foundHigh == 1)
+            prevHigh = high;
+         foundHigh++;
+      }
+      if(isLow)
+      {
+         if(foundLow == 0)
+            lastLow = low;
+         else if(foundLow == 1)
+            prevLow = low;
+         foundLow++;
+      }
+      if(foundHigh >= 2 && foundLow >= 2)
+         return true;
+   }
+   return false;
+}
+
+bool BreakRetestOk(TradeDir dir, double bosLevel, double atrM15)
+{
+   if(!InpUseBreakRetest)
+      return true;
+
+   double tol = MathMax(atrM15 * InpRetestTolATR, 5 * _Point);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+
+   if(dir == DIR_LONG)
+      return (low1 <= bosLevel + tol && close1 > bosLevel);
+   if(dir == DIR_SHORT)
+      return (high1 >= bosLevel - tol && close1 < bosLevel);
+   return false;
+}
+
+double NearestKeyLevel(double price)
+{
+   double step = InpKeyLevelStepPrice;
+   if(step <= 0.0)
+      return price;
+   return MathRound(price / step) * step;
+}
+
+double KeyBelow(double price)
+{
+   double step = InpKeyLevelStepPrice;
+   return MathFloor(price / step) * step;
+}
+
+double KeyAbove(double price)
+{
+   double step = InpKeyLevelStepPrice;
+   return MathCeil(price / step) * step;
+}
+
+bool KeyLevelOk(TradeDir dir, double mid)
+{
+   double nearest = NearestKeyLevel(mid);
+   if(MathAbs(mid - nearest) > InpKeyNearPrice)
+      return false;
+
+   if(dir == DIR_LONG)
+      return (mid - KeyBelow(mid) <= InpKeyChaseMaxDistPrice);
+   if(dir == DIR_SHORT)
+      return (KeyAbove(mid) - mid <= InpKeyChaseMaxDistPrice);
+   return false;
+}
+
+int FVGDirection(double &zoneMid, double atrM15)
+{
+   if(!InpUseFVGFeature)
+      return 0;
+
+   for(int i = 1; i <= InpFVGScanBars; i++)
+   {
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      double low2 = iLow(g_symbol, PERIOD_M15, i + 2);
+      double high2 = iHigh(g_symbol, PERIOD_M15, i + 2);
+
+      if(low > high2)
+      {
+         zoneMid = (low + high2) / 2.0;
+         return DIR_LONG;
+      }
+      if(high < low2)
+      {
+         zoneMid = (high + low2) / 2.0;
+         return DIR_SHORT;
+      }
+   }
+   return 0;
+}
+
+bool FVGOk(TradeDir dir, double mid, double atrM15)
+{
+   if(!InpUseFVGFeature)
+      return true;
+
+   double zoneMid = 0.0;
+   int fvgDir = FVGDirection(zoneMid, atrM15);
+   if(fvgDir == 0 || fvgDir != dir)
+      return false;
+
+   return MathAbs(mid - zoneMid) <= atrM15 * InpFVGMaxDistATR;
+}
+
+bool FibFilterOk(TradeDir dir, double mid, double lastLow, double lastHigh, bool &oteBonus)
+{
+   oteBonus = false;
+   if(!InpUseFibFilter)
+      return true;
+
+   double range = MathAbs(lastHigh - lastLow);
+   if(range <= 0.0)
+      return false;
+
+   double lvl50 = 0.0;
+   double lvl618 = 0.0;
+   if(dir == DIR_LONG)
+   {
+      lvl50 = lastHigh - range * InpFibBaseMin;
+      lvl618 = lastHigh - range * InpFibBaseMax;
+   }
+   else
+   {
+      lvl50 = lastLow + range * InpFibBaseMin;
+      lvl618 = lastLow + range * InpFibBaseMax;
+   }
+
+   double minLvl = MathMin(lvl50, lvl618) - InpFibTolPrice;
+   double maxLvl = MathMax(lvl50, lvl618) + InpFibTolPrice;
+   bool inBase = (mid >= minLvl && mid <= maxLvl);
+
+   if(InpUseOTEBonus)
+   {
+      double otemin = 0.0;
+      double otemax = 0.0;
+      if(dir == DIR_LONG)
+      {
+         otemin = lastHigh - range * InpOTEMax;
+         otemax = lastHigh - range * InpOTEMin;
+      }
+      else
+      {
+         otemin = lastLow + range * InpOTEMin;
+         otemax = lastLow + range * InpOTEMax;
+      }
+      double omin = MathMin(otemin, otemax);
+      double omax = MathMax(otemin, otemax);
+      if(mid >= omin && mid <= omax)
+         oteBonus = true;
+   }
+
+   return inBase;
+}
+
+bool FootprintOk(TradeDir dir, double atrM15, bool &absorption, bool &accepted)
+{
+   absorption = false;
+   accepted = true;
+   if(!InpUseFootprintProxy)
+      return true;
+
+   double vol = (double)iVolume(g_symbol, PERIOD_M15, 1);
+   double volMA = VolumeMA(PERIOD_M15, InpFP_VolMAPeriod, 2);
+   double volRatio = (volMA > 0.0) ? vol / volMA : 0.0;
+   double high = iHigh(g_symbol, PERIOD_M15, 1);
+   double low = iLow(g_symbol, PERIOD_M15, 1);
+   double open = iOpen(g_symbol, PERIOD_M15, 1);
+   double close = iClose(g_symbol, PERIOD_M15, 1);
+   double range = high - low;
+   double body = MathAbs(close - open);
+   double bodyRatio = (range > 0.0) ? body / range : 0.0;
+   double closeSide = 0.5;
+   if(range > 0.0)
+   {
+      if(dir == DIR_LONG)
+         closeSide = (close - low) / range;
+      else
+         closeSide = 1.0 - (close - low) / range;
+   }
+
+   accepted = (volRatio >= InpFP_VolSpikeRatio && bodyRatio >= InpFP_BodyMinRatio && closeSide >= InpFP_CloseSideMin);
+
+   if(volRatio >= InpFP_AbsorpVolRatio && range <= atrM15 * InpFP_AbsorpRangeATR && closeSide < 0.55)
+      absorption = true;
+
+   if(InpFP_RequireAcceptance)
+      return accepted && !absorption;
+   return !absorption;
+}
+
+bool SpikeGuardOk(double atrM15)
+{
+   if(!InpUseSpikeGuard)
+      return true;
+
+   double high = iHigh(g_symbol, PERIOD_M15, 1);
+   double low = iLow(g_symbol, PERIOD_M15, 1);
+   return (high - low) <= atrM15 * InpSpikeMultATR;
+}
+
+bool RSIAfterLossOk(TradeDir dir)
+{
+   if(!InpUseRSIAfterLoss)
+      return true;
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   if(lossStreak < InpLossStreakForRSI)
+      return true;
+
+   double rsi1 = RSI(PERIOD_M15, 1);
+   double rsi2 = RSI(PERIOD_M15, 2);
+   if(dir == DIR_LONG)
+      return (rsi1 >= 52.0 && rsi1 > rsi2);
+   if(dir == DIR_SHORT)
+      return (rsi1 <= 48.0 && rsi1 < rsi2);
+   return false;
+}
+
+bool HasPosition()
+{
+   return PositionSelect(g_symbol);
+}
+
+bool DailyLossLocked()
+{
+   if(!InpUseMaxDailyLossLock)
+      return false;
+
+   double startEquity = GVGetDouble("dayEquityStart", AccountInfoDouble(ACCOUNT_EQUITY));
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   double pct = (startEquity > 0.0) ? (equity - startEquity) / startEquity * 100.0 : 0.0;
+   if(pct <= -InpMaxDailyLossPct)
+   {
+      GVSetInt("dayLocked", 1);
+      return true;
+   }
+   return false;
+}
+
+bool SoftEquityLocked()
+{
+   if(!InpUseSoftEquityLock)
+      return false;
+
+   double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   if(equity > peak)
+   {
+      peak = equity;
+      GVSetDouble("dayEquityPeak", peak);
+   }
+
+   double start = GVGetDouble("dayEquityStart", equity);
+   double gainPct = (peak - start) / start * 100.0;
+   double curPct = (equity - start) / start * 100.0;
+   if((gainPct >= InpSoftEqTrigger2 && curPct <= InpSoftEqFloor2) ||
+      (gainPct >= InpSoftEqTrigger1 && curPct <= InpSoftEqFloor1))
+   {
+      GVSetInt("dayLocked", 1);
+      return true;
+   }
+   return false;
+}
+
+int DailyScore(RegimeState regime)
+{
+   double adx = ADX(PERIOD_H1, 1);
+   double vol = (double)iVolume(g_symbol, PERIOD_H1, 1);
+   double volAvg = VolumeMA(PERIOD_H1, InpVolMAPeriod, 2);
+   double volScore = (volAvg > 0.0) ? MathMin(30.0, (vol / volAvg) * 15.0) : 0.0;
+   double adxScore = MathMin(30.0, adx);
+
+   double spreadScore = 20.0;
+   if(g_spreadEma > 0.0)
+   {
+      double spread = SpreadPoints();
+      spreadScore = 20.0 * MathMax(0.0, 1.0 - (spread / (g_spreadEma * InpSpreadSpikeFactor)));
+   }
+
+   double regimeScore = 0.0;
+   if(regime == REGIME_TREND)
+      regimeScore = 20.0;
+   else if(regime == REGIME_TRANSITION)
+      regimeScore = 10.0;
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   double lossPenalty = lossStreak * 5.0;
+   if(SpreadMultipleBlocked() || SpreadInstabilityBlocked() || RolloverBlocked())
+      lossPenalty += 10.0;
+
+   double score = volScore + adxScore + spreadScore + regimeScore - lossPenalty;
+   if(score < 0.0)
+      score = 0.0;
+   if(score > 100.0)
+      score = 100.0;
+   return (int)score;
+}
+
+bool DailyTradeAllowed(int dailyScore, int &maxTrades, double &riskMult, bool &pyramidOk)
+{
+   maxTrades = 0;
+   riskMult = 0.0;
+   pyramidOk = false;
+   if(dailyScore >= 70)
+   {
+      maxTrades = 3;
+      riskMult = 1.0;
+      pyramidOk = true;
+   }
+   else if(dailyScore >= 50)
+   {
+      maxTrades = 2;
+      riskMult = 0.8;
+      pyramidOk = true;
+   }
+   else if(dailyScore >= 30)
+   {
+      maxTrades = 1;
+      riskMult = 0.6;
+      pyramidOk = false;
+   }
+   return maxTrades > 0;
+}
+
+bool CooldownActive()
+{
+   int lastEntryBar = GVGetInt("lastEntryBar", 0);
+   int currentBar = (int)iBars(g_symbol, PERIOD_M15);
+   return (currentBar - lastEntryBar) <= InpCooldownBarsAfterEntry;
+}
+
+void UpdateDailyReset()
+{
+   datetime dayStart = (datetime)GVGetDouble("dayStart", 0.0);
+   datetime now = TimeCurrent();
+   if(TimeDay(dayStart) != TimeDay(now) || dayStart == 0)
+   {
+      GVSetDouble("dayStart", (double)now);
+      double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+      GVSetDouble("dayEquityStart", equity);
+      GVSetDouble("dayEquityPeak", equity);
+      GVSetInt("dayLocked", 0);
+      GVSetInt("dayTrades", 0);
+   }
+}
+
+bool HardGuardsOk()
+{
+   if(!SessionAllowed())
+      return false;
+   if(RolloverBlocked())
+      return false;
+   if(SpreadPoints() > InpMaxSpreadPoints)
+      return false;
+   if(SpreadMultipleBlocked())
+      return false;
+   if(SpreadInstabilityBlocked())
+      return false;
+   if(LowVolumeBlocked())
+      return false;
+   if(DailyLossLocked() || SoftEquityLocked())
+      return false;
+   if(GVGetInt("dayLocked", 0) == 1)
+      return false;
+   if(CooldownActive())
+      return false;
+   return true;
+}
+
+bool LossBlocksActive()
+{
+   if(!InpUseAntiChop)
+      return false;
+
+   datetime blockUntil = (datetime)GVGetDouble("blockUntil", 0.0);
+   return (blockUntil > TimeCurrent());
+}
+
+void UpdateLossBlock(int lossStreak)
+{
+   if(!InpUseAntiChop)
       return;
 
-   command = FileReadString(handle);
-   FileClose(handle);
-   command = Trim(command);
-
-      if(command == "/emergency_stop")
-      {
-         CloseAllPositions();
-         int h=FileOpen("ea_control.txt", FILE_WRITE|FILE_ANSI);
-         if(h!=INVALID_HANDLE)
-         {
-            FileWriteString(h, "INACTIVE");
-            FileClose(h);
-         }
-         Print("Emergency Stop attivato!");
-      }
-      else if(StringFind(command, "/set_risk") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 10));
-         riskPercent = val;
-         Print("Risk aggiornato: ", riskPercent);
-      }
-      else if(StringFind(command, "/set_tp") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 8));
-         takeProfitPips = (int)val;
-         Print("TakeProfit aggiornato: ", takeProfitPips);
-      }
-      else if(StringFind(command, "/set_sl") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 8));
-         stopLossPips = (int)val;
-         Print("StopLoss aggiornato: ", stopLossPips);
-      }
+   if(lossStreak >= 3)
+   {
+      GVSetDouble("blockUntil", TimeCurrent() + InpLossBlock3_Hours * 3600.0);
+      GVSetDouble("riskCutUntil", TimeCurrent() + InpRiskCutAfter3Loss_H * 3600.0);
+   }
+   else if(lossStreak == 2)
+   {
+      GVSetDouble("blockUntil", TimeCurrent() + InpLossBlock2_Hours * 3600.0);
+   }
 }
 
-//+------------------------------------------------------------------+
-//| Funzione per chiudere tutte le operazioni                        |
-//+------------------------------------------------------------------+
-void CloseAllPositions()
+double CurrentRiskMultiplier(double dailyRiskMult)
 {
-   for(int i=PositionsTotal()-1; i>=0; i--)
+   double mult = dailyRiskMult;
+   datetime riskCutUntil = (datetime)GVGetDouble("riskCutUntil", 0.0);
+   if(riskCutUntil > TimeCurrent())
+      mult *= InpRiskMultAfter3Loss;
+   return mult;
+}
+
+double CalcLots(double slDist, double riskPct)
+{
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   double riskMoney = equity * (riskPct / 100.0);
+   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   if(tickSize <= 0.0 || tickValue <= 0.0 || slDist <= 0.0)
+      return 0.0;
+
+   double moneyPerLot = (slDist / tickSize) * tickValue;
+   if(moneyPerLot <= 0.0)
+      return 0.0;
+
+   double lot = riskMoney / moneyPerLot;
+   double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+   double maxLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MAX);
+   double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+
+   lot = MathMax(minLot, lot);
+   if(InpMaxLotCap > 0.0)
+      maxLot = MathMin(maxLot, InpMaxLotCap);
+   lot = MathMin(lot, maxLot);
+   lot = MathFloor(lot / step) * step;
+   return NormalizeDouble(lot, 2);
+}
+
+void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
+            int dailyScore, int setup, int timing, int total, int skipMask, int entryMask)
+{
+   if(!InpEnableCSV)
+      return;
+
+   int handle = FileOpen(InpCSVName, FILE_READ | FILE_WRITE | FILE_CSV | FILE_ANSI);
+   if(handle == INVALID_HANDLE)
+      handle = FileOpen(InpCSVName, FILE_WRITE | FILE_CSV | FILE_ANSI);
+
+   if(handle == INVALID_HANDLE)
+      return;
+
+   if(FileSize(handle) == 0)
    {
-      if(PositionSelectByIndex(i))
+      FileWrite(handle, "time", "sym", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
+                "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
+                "setup", "timing", "total");
+   }
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   RegimeState reg = (RegimeState)GVGetInt("regime", REGIME_RANGE);
+   TradeDir bias = BiasH1();
+   double adx = ADX(PERIOD_H1, 1);
+   double atrM15 = ATR(PERIOD_M15, 1);
+   double atrH1 = ATR(PERIOD_H1, 1);
+
+   FileWrite(handle,
+             TimeToString(TimeCurrent(), TIME_DATE|TIME_MINUTES),
+             g_symbol,
+             (string)InpMagic,
+             event,
+             (int)dir,
+             DoubleToString(entry, g_digits),
+             DoubleToString(sl, g_digits),
+             DoubleToString(tp, g_digits),
+             DoubleToString(tp1, g_digits),
+             DoubleToString(lot, 2),
+             DoubleToString(SpreadPoints(), 1),
+             (int)reg,
+             (int)bias,
+             DoubleToString(adx, 2),
+             DoubleToString(atrM15, 2),
+             DoubleToString(atrH1, 2),
+             dailyScore,
+             lossStreak,
+             skipMask,
+             entryMask,
+             setup,
+             timing,
+             total);
+
+   FileClose(handle);
+}
+
+bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                    int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask)
+{
+   setupScore = 0;
+   timingScore = 0;
+   totalScore = 0;
+   skipMask = 0;
+   entryMask = 0;
+   dir = DIR_NONE;
+
+   TradeDir bias = BiasH1();
+   if(bias == DIR_NONE)
+      return false;
+   dir = bias;
+   setupScore += 20;
+
+   double lastHigh = 0.0, prevHigh = 0.0, lastLow = 0.0, prevLow = 0.0;
+   if(!FindRecentPivots(lastHigh, prevHigh, lastLow, prevLow))
+      return false;
+
+   if(dir == DIR_LONG && !(lastLow > prevLow))
+      return false;
+   if(dir == DIR_SHORT && !(lastHigh < prevHigh))
+      return false;
+   setupScore += 10;
+
+   double bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
+   double atrM15 = ATR(PERIOD_M15, 1);
+
+   bool brOk = BreakRetestOk(dir, bosLevel, atrM15);
+   if(!closeConfirm && !brOk)
+      return false;
+   timingScore += 10;
+
+   double mid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   if(!KeyLevelOk(dir, mid))
+      return false;
+   setupScore += 10;
+
+   if(!FVGOk(dir, mid, atrM15))
+      return false;
+   setupScore += 5;
+
+   bool oteBonus = false;
+   if(!FibFilterOk(dir, mid, lastLow, lastHigh, oteBonus))
+      return false;
+   setupScore += 15;
+   if(oteBonus)
+      setupScore += InpOTEBonusPoints;
+
+   bool absorption = false;
+   bool acceptance = true;
+   if(!FootprintOk(dir, atrM15, absorption, acceptance))
+      return false;
+   if(acceptance)
+      timingScore += InpFP_ScoreBonus;
+
+   if(!SpikeGuardOk(atrM15))
+      return false;
+
+   if(!RSIAfterLossOk(dir))
+      return false;
+
+   entry = (dir == DIR_LONG) ? SymbolInfoDouble(g_symbol, SYMBOL_ASK) : SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   double atrBuf = atrM15 * InpSL_ATR_Mult;
+   double spreadBuf = SpreadPoints() * _Point * 0.5;
+   double buffer = MathMax(InpSL_MinBufferPrice, MathMax(atrBuf, spreadBuf));
+
+   sl = (dir == DIR_LONG) ? (lastLow - buffer) : (lastHigh + buffer);
+   riskR = MathAbs(entry - sl);
+   if(riskR <= 0.0)
+      return false;
+
+   if(InpUseMMSL)
+   {
+      double mmsl = InpMMSL_Pips * PipPrice() + InpMMSL_ExtraBufferPrice;
+      if(riskR < mmsl)
+         return false;
+   }
+
+   tp = (dir == DIR_LONG) ? (entry + riskR * InpTP_RR_Main) : (entry - riskR * InpTP_RR_Main);
+   double rr = MathAbs(tp - entry) / riskR;
+   if(rr < InpMinRRAllowed)
+      return false;
+
+   tp1 = (dir == DIR_LONG) ? (entry + riskR) : (entry - riskR);
+   if(InpUseTP1Partial && InpTP1_UseKeyLevelFirst)
+   {
+      double key = NearestKeyLevel(entry);
+      double dist = MathAbs(key - entry);
+      if(dist > PipPrice() && dist < MathAbs(tp1 - entry))
+         tp1 = (dir == DIR_LONG) ? MathMax(entry + dist, tp1) : MathMin(entry - dist, tp1);
+   }
+
+   totalScore = setupScore + timingScore;
+   return true;
+}
+
+bool ShouldEnterTrade(int setupScore, int timingScore, int totalScore, RegimeState regime)
+{
+   int totalMin = TOTAL_MIN;
+   int lossStreak = GVGetInt("lossStreak", 0);
+
+   if(regime == REGIME_TRANSITION)
+      totalMin += 3;
+   else if(regime == REGIME_EXPANSION)
+      totalMin += 8;
+
+   if(lossStreak == 1)
+      totalMin += 5;
+   else if(lossStreak >= 2)
+      totalMin += 10;
+
+   return (setupScore >= SETUP_MIN && timingScore >= TIMING_MIN && totalScore >= totalMin);
+}
+
+void ManagePosition(double riskR)
+{
+   if(!PositionSelect(g_symbol))
+      return;
+
+   ulong ticket = PositionGetInteger(POSITION_TICKET);
+   int type = (int)PositionGetInteger(POSITION_TYPE);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   double sl = PositionGetDouble(POSITION_SL);
+   double tp = PositionGetDouble(POSITION_TP);
+   double volume = PositionGetDouble(POSITION_VOLUME);
+   double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+
+   double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
+
+   bool tp1done = GVGetInt("tp1done", 0) == 1;
+   double tp1price = GVGetDouble("tp1price", 0.0);
+
+   if(InpUseTP1Partial && !tp1done && profitR >= 1.0)
+   {
+      double closeVol = volume * InpTP1_CloseFrac;
+      closeVol = NormalizeDouble(closeVol, 2);
+      if(closeVol >= SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN))
       {
-         ulong ticket = PositionGetInteger(POSITION_TICKET);
-         if(!trade.PositionClose(ticket))
-            Print("Errore chiusura posizione: ", ticket);
+         trade.PositionClosePartial(ticket, closeVol);
+         GVSetInt("tp1done", 1);
+         GVSetDouble("tp1price", price);
+         LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0);
+      }
+   }
+
+   if(InpUseSmartBE && profitR >= InpBE_MinProfitR)
+   {
+      double newSL = (type == POSITION_TYPE_BUY) ? (entry + InpBE_OffsetPrice) : (entry - InpBE_OffsetPrice);
+      if((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl))
+         trade.PositionModify(ticket, newSL, tp);
+   }
+
+   if(InpUseATRTrailAfterTP1 && tp1done)
+   {
+      if(!InpTrailOnNewBarOnly || IsNewBar(PERIOD_M15, g_lastM15Bar))
+      {
+         double atr = ATR(PERIOD_M15, 1);
+         double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * InpTrailATR_Mult) : (price + atr * InpTrailATR_Mult);
+         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice)
+            trade.PositionModify(ticket, newSL, tp);
+         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice)
+            trade.PositionModify(ticket, newSL, tp);
       }
    }
 }
 
-void OnTick() {
-    if(!IsEAEnabled())
-        return;
-
-    CheckTelegramCommands();
-
-    if(!NewsFilter() || DailyDrawdownExceeded())
-        return;
-
-    if(!(Period()==PERIOD_M5 || Period()==PERIOD_M15))
-        return;
-
-    if(PositionsTotal() >= MaxTrades)
-        return;
-
-    if(!TimeFilter() || SpreadTooHigh() || !ATRCheck() || !TrendConfirmed() || (TimeCurrent() - lastTradeTime < 180))
-        return;
-
-    int confirmations = CheckConfirmations();
-    double score = CalculateConfidenceScore();
-    if(score < 50 || confirmations < 3)
-        return;
-
-    double stoploss = (stopLossPips * _Point) + ATRMultiplier * iATR(_Symbol, PERIOD_M5, 14, 0);
-    double rr = 2.0;
-    if(score >= 90)
-        rr = 4.0;
-    else if(score >= 70)
-        rr = 3.0;
-    double takeprofit = (takeProfitPips > 0) ? takeProfitPips * _Point : stoploss * rr;
-    double risk = riskPercent;
-    if(score >= 90)
-        risk = MathMin(riskPercent*1.5, Risk_High);
-    double lot = CalculateRiskLot(stoploss, risk);
-    int direction = EntryDirection();
-
-    double sl, tp;
-    if(direction == 1)
-    {
-        double ask = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
-        sl = ask - stoploss;
-        tp = ask + takeprofit;
-        trade.Buy(lot, _Symbol, ask, sl, tp, "Buy");
-    }
-    else if(direction == -1)
-    {
-        double bid = SymbolInfoDouble(_Symbol, SYMBOL_BID);
-        sl = bid + stoploss;
-        tp = bid - takeprofit;
-        trade.Sell(lot, _Symbol, bid, sl, tp, "Sell");
-    }
-
-    ManageRunnerTrade();
-
-    lastTradeTime = TimeCurrent();
-}
-
-bool TimeFilter() {
-    int hour = TimeHour(TimeCurrent());
-    return (hour >= 8 && hour <= 22);
-}
-
-bool SpreadTooHigh() {
-    double spread = (SymbolInfoDouble(_Symbol, SYMBOL_ASK) - SymbolInfoDouble(_Symbol, SYMBOL_BID)) / _Point;
-    return spread > 50;
-}
-
-bool ATRCheck() {
-    double atr_now = iATR(_Symbol, PERIOD_M5, 14, 0);
-    double atr_avg = iATR(_Symbol, PERIOD_M5, 50, 0);
-    return atr_now < (2.3 * atr_avg);
-}
-
-bool NewsFilter()
+void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
 {
-    int h = FileOpen("news_time.txt", FILE_READ|FILE_ANSI);
-    if(h!=INVALID_HANDLE)
-    {
-        datetime t = (datetime)FileReadNumber(h);
-        FileClose(h);
-        if(MathAbs(TimeCurrent()-t) <= 900)
-            return false;
-    }
-    return true;
+   if(!InpUsePyramiding || !pyramidAllowed)
+      return;
+   if(!PositionSelect(g_symbol))
+      return;
+
+   int addCount = GVGetInt("addCount", 0);
+   if(addCount >= InpMaxAdds)
+      return;
+
+   int type = (int)PositionGetInteger(POSITION_TYPE);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   double sl = PositionGetDouble(POSITION_SL);
+   double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
+
+   if(profitR < InpPyramidMinProfitR)
+      return;
+
+   double lastAddPrice = GVGetDouble("lastAddPrice", entry);
+   double atr = ATR(PERIOD_M15, 1);
+   if(MathAbs(price - lastAddPrice) < atr * InpPyramidSpacingATR)
+      return;
+
+   if(InpPyramidOnlyInTrend && regime != REGIME_TREND)
+      return;
+
+   if(InpPyramidRequireAdxRising)
+   {
+      double adx1 = ADX(PERIOD_H1, 1);
+      double adx2 = ADX(PERIOD_H1, 2);
+      if(adx1 <= adx2)
+         return;
+   }
+
+   if(InpPyramidUsePeakDDCap)
+   {
+      double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
+      double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+      double dd = (peak - equity) / peak * 100.0;
+      if(dd > InpPyramidMaxPeakDDPct)
+         return;
+   }
+
+   double riskMult = (addCount == 0) ? InpAddRiskMult1 : InpAddRiskMult2;
+   double addLots = CalcLots(riskR, InpBaseRiskPct * riskMult);
+   if(addLots <= 0.0)
+      return;
+
+   bool result = false;
+   if(type == POSITION_TYPE_BUY)
+      result = trade.Buy(addLots, g_symbol, price, sl, price + riskR * InpTP_RR_Main, "PYR");
+   else
+      result = trade.Sell(addLots, g_symbol, price, sl, price - riskR * InpTP_RR_Main, "PYR");
+
+   if(result)
+   {
+      GVSetInt("addCount", addCount + 1);
+      GVSetDouble("lastAddPrice", price);
+      LogCSV("PYR", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), price, sl, 0.0, 0.0, addLots, 0, 0, 0, 0, 0, 0);
+   }
 }
 
-bool DailyDrawdownExceeded()
+int OnInit()
 {
-    static double startEquity = 0;
-    static datetime startTime = 0;
+   g_symbol = ResolveSymbol();
+   g_digits = (int)SymbolInfoInteger(g_symbol, SYMBOL_DIGITS);
 
-    if(TimeDay(startTime) != TimeDay(TimeCurrent()))
-    {
-        startTime = TimeCurrent();
-        startEquity = AccountInfoDouble(ACCOUNT_EQUITY);
-    }
+   trade.SetExpertMagicNumber((uint)InpMagic);
+   trade.SetDeviationInPoints(InpMaxSlippagePoints);
 
-    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
-    double dd = (startEquity - equity) / startEquity * 100.0;
-    return dd > 20.0;
+   UpdateDailyReset();
+
+   return INIT_SUCCEEDED;
 }
 
-bool TrendConfirmed()
+void OnTick()
 {
-    double ema50 = iMA(_Symbol, PERIOD_H4, 50, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema200 = iMA(_Symbol, PERIOD_H4, 200, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double price = iClose(_Symbol, PERIOD_H4, 0);
-    if(ema50 > ema200 && price > ema50) return true;
-    if(ema50 < ema200 && price < ema50) return true;
-    return false;
+   if(g_symbol == "")
+      return;
+
+   UpdateDailyReset();
+
+   if(IsNewBar(PERIOD_H1, g_lastH1Bar))
+      UpdateSpreadEMA();
+
+   RegimeState regime = UpdateRegime();
+
+   if(HasPosition())
+   {
+      double riskR = GVGetDouble("origRisk", 0.0);
+      ManagePosition(riskR);
+      int dailyScore = DailyScore(regime);
+      bool pyramidAllowed = false;
+      int maxTrades = 0;
+      double dailyRiskMult = 0.0;
+      DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed);
+      TryPyramiding(riskR, pyramidAllowed, regime);
+      return;
+   }
+
+   if(LossBlocksActive())
+      return;
+   if(!HardGuardsOk())
+      return;
+
+   int dayTrades = GVGetInt("dayTrades", 0);
+   if(InpUseDailyTradeControl && dayTrades >= InpHardMaxTradesPerDay)
+      return;
+
+   int dailyScore = DailyScore(regime);
+   int maxTrades = 0;
+   double dailyRiskMult = 0.0;
+   bool pyramidAllowed = false;
+   if(InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
+      return;
+
+   TradeDir dir;
+   double entry = 0.0, sl = 0.0, tp = 0.0, tp1 = 0.0, riskR = 0.0;
+   int setupScore = 0, timingScore = 0, totalScore = 0, skipMask = 0, entryMask = 0;
+
+   if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask))
+      return;
+
+   if(!ShouldEnterTrade(setupScore, timingScore, totalScore, regime))
+      return;
+
+   double riskMult = CurrentRiskMultiplier(dailyRiskMult);
+   double lots = CalcLots(riskR, InpBaseRiskPct * riskMult);
+   if(lots <= 0.0)
+      return;
+
+   bool sent = false;
+   if(dir == DIR_LONG)
+      sent = trade.Buy(lots, g_symbol, entry, sl, tp, "ENTRY");
+   else if(dir == DIR_SHORT)
+      sent = trade.Sell(lots, g_symbol, entry, sl, tp, "ENTRY");
+
+   if(sent)
+   {
+      GVSetInt("dayTrades", dayTrades + 1);
+      GVSetInt("lastEntryBar", (int)iBars(g_symbol, PERIOD_M15));
+      GVSetDouble("origRisk", riskR);
+      GVSetInt("tp1done", 0);
+      GVSetDouble("tp1price", tp1);
+      GVSetInt("addCount", 0);
+      GVSetDouble("lastAddPrice", entry);
+
+      LogCSV("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask);
+   }
 }
 
-bool IsStopHunt()
+void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest &request, const MqlTradeResult &result)
 {
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double high1 = iHigh(_Symbol, PERIOD_M5, 1);
-    double low1  = iLow(_Symbol, PERIOD_M5, 1);
+   if(trans.type != TRADE_TRANSACTION_DEAL_ADD)
+      return;
+   if(trans.symbol != g_symbol)
+      return;
 
-    double upper = high1 - MathMax(open1, close1);
-    double lower = MathMin(open1, close1) - low1;
-    double body  = MathAbs(close1 - open1);
+   double profit = trans.profit + trans.commission + trans.swap;
+   if(trans.entry == DEAL_ENTRY_OUT)
+   {
+      int lossStreak = GVGetInt("lossStreak", 0);
+      if(profit < 0.0)
+         lossStreak++;
+      else
+         lossStreak = 0;
+      GVSetInt("lossStreak", lossStreak);
+      UpdateLossBlock(lossStreak);
 
-    return ((upper > body*2 && close1 < open1) || (lower > body*2 && close1 > open1));
-}
-
-bool IsFailedBreakout()
-{
-    double high1 = iHigh(_Symbol, PERIOD_M5, 1);
-    double high2 = iHigh(_Symbol, PERIOD_M5, 2);
-    double low1  = iLow(_Symbol, PERIOD_M5, 1);
-    double low2  = iLow(_Symbol, PERIOD_M5, 2);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-
-    bool hb = (high1 > high2) && (close1 < high2);
-    bool lb = (low1 < low2)  && (close1 > low2);
-    return hb || lb;
-}
-
-bool IsLiquidityPOI()
-{
-    double vol_now = iVolume(_Symbol, PERIOD_M5, 0);
-    double vol_avg = (iVolume(_Symbol, PERIOD_M5,1)+iVolume(_Symbol, PERIOD_M5,2)+iVolume(_Symbol, PERIOD_M5,3))/3.0;
-    double price = iClose(_Symbol, PERIOD_M5, 0);
-    double high = iHigh(_Symbol, PERIOD_H1, 1);
-    double low  = iLow(_Symbol, PERIOD_H1, 1);
-    bool near = (MathAbs(price-high) < 20*_Point) || (MathAbs(price-low) < 20*_Point);
-    return (vol_now > vol_avg*1.5 && near);
-}
-
-int CheckConfirmations() {
-    int conf = 0;
-
-    // RSI
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 30 || rsi > 70) conf++;
-
-    // EMA trend
-    double ema20 = iMA(_Symbol, PERIOD_M5, 20, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double prev_close = iClose(_Symbol, PERIOD_M5, 1);
-    double close_now = iClose(_Symbol, PERIOD_M5, 0);
-    if((prev_close <= ema20 && close_now > ema20) ||
-       (prev_close >= ema20 && close_now < ema20))
-        conf++;
-
-    // ADX trend
-    double adx = iADX(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, MODE_MAIN, 0);
-    if(adx > 25) conf++;
-
-    // Volume spike
-    if(iVolume(_Symbol, PERIOD_M5, 0) > 1.8 * iVolume(_Symbol, PERIOD_M5, 1)) conf++;
-
-    // 4 EMA alignment
-    double ema57 = iMA(_Symbol, PERIOD_M5, 57, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema114 = iMA(_Symbol, PERIOD_M5, 114, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema150 = iMA(_Symbol, PERIOD_M5, 150, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema214 = iMA(_Symbol, PERIOD_M5, 214, 0, MODE_EMA, PRICE_CLOSE, 0);
-    if(ema57 < ema114 && ema114 < ema150 && ema150 < ema214) conf++;
-
-    // Pivot breakout
-    double pivot = (iHigh(NULL, PERIOD_D1, 1) + iLow(NULL, PERIOD_D1, 1) + iClose(NULL, PERIOD_D1, 1)) / 3;
-    double R1 = 2 * pivot - iLow(NULL, PERIOD_D1, 1);
-    double S1 = 2 * pivot - iHigh(NULL, PERIOD_D1, 1);
-    if((iClose(_Symbol, PERIOD_M5, 0) > R1 + 5 * _Point) || (iClose(_Symbol, PERIOD_M5, 0) < S1 - 5 * _Point))
-        conf++;
-
-    // Fibonacci level (approssimato con distanza % dal massimo/minimo giorno precedente)
-    double high = iHigh(NULL, PERIOD_D1, 1);
-    double low = iLow(NULL, PERIOD_D1, 1);
-    double fib_382 = high - 0.382 * (high - low);
-    double fib_618 = high - 0.618 * (high - low);
-    if(iClose(_Symbol, PERIOD_M5, 0) > fib_618 && iClose(_Symbol, PERIOD_M5, 0) < fib_382)
-        conf++;
-
-    // Prossimità a livelli chiave (simulata)
-    if(MathAbs(iClose(_Symbol, PERIOD_M5, 0) - pivot) < 10 * _Point)
-        conf++;
-
-    return conf;
-}
-
-int EntryDirection() {
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 30) return 1;
-    if(rsi > 70) return -1;
-    return 0;
-}
-
-double CalculateRiskLot(double stop_loss, double risk_percent) {
-    double risk_amount = AccountInfoDouble(ACCOUNT_BALANCE) * (risk_percent / 100.0);
-    double tick_size  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
-    double tick_value = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
-    double lot = risk_amount / (stop_loss / tick_size * tick_value);
-    return NormalizeDouble(lot, 2);
-}
-
-
-void ManageRunnerTrade()
-{
-    for(int i = PositionsTotal() - 1; i >= 0; i--)
-    {
-        if(PositionSelectByIndex(i))
-        {
-            ulong ticket = PositionGetInteger(POSITION_TICKET);
-            string symbol = PositionGetString(POSITION_SYMBOL);
-            int type = (int)PositionGetInteger(POSITION_TYPE);
-            if(symbol == _Symbol && (type == POSITION_TYPE_BUY || type == POSITION_TYPE_SELL))
-            {
-                datetime opentime = (datetime)PositionGetInteger(POSITION_TIME);
-                ENUM_TIMEFRAMES tf = (TimeCurrent() - opentime > 43200) ? PERIOD_H4 : PERIOD_CURRENT;
-                if(tf != PERIOD_H4 && tf != PERIOD_D1)
-                    continue;
-
-                double open_price = PositionGetDouble(POSITION_PRICE_OPEN);
-                double current_price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID) : SymbolInfoDouble(_Symbol, SYMBOL_ASK);
-                double profit_pips = MathAbs(current_price - open_price) / _Point;
-
-                double sl = PositionGetDouble(POSITION_SL);
-                double new_sl;
-
-                // BE: quando profitto supera 2x SL
-                if(profit_pips >= SL_Pips * 2 && sl == 0)
-                {
-                    new_sl = (type == POSITION_TYPE_BUY) ? open_price + (10 * _Point) : open_price - (10 * _Point);
-                    trade.PositionModify(ticket, new_sl, PositionGetDouble(POSITION_TP));
-                }
-
-                // Take Parziale a 3x SL
-                if(profit_pips >= SL_Pips * 3 && PositionGetDouble(POSITION_VOLUME) >= 0.02)
-                {
-                    double partial = NormalizeDouble(PositionGetDouble(POSITION_VOLUME) / 2.0, 2);
-                    trade.PositionClosePartial(ticket, partial);
-                }
-
-                // Trailing dopo 3x SL superato
-                if(profit_pips >= SL_Pips * 3)
-                {
-                    double trail = SL_Pips * _Point;
-                    new_sl = (type == POSITION_TYPE_BUY) ? current_price - trail : current_price + trail;
-                    if((type == POSITION_TYPE_BUY && new_sl > sl) || (type == POSITION_TYPE_SELL && new_sl < sl))
-                        trade.PositionModify(ticket, new_sl, PositionGetDouble(POSITION_TP));
-                }
-
-                // Uscita in caso di inversione forte (ADX < 20 e RSI opposto)
-                double rsi = iRSI(_Symbol, tf, 14, PRICE_CLOSE, 0);
-                double adx = iADX(_Symbol, tf, 14, PRICE_CLOSE, MODE_MAIN, 0);
-                if(adx < 20 && ((type == POSITION_TYPE_BUY && rsi < 40) || (type == POSITION_TYPE_SELL && rsi > 60)))
-                {
-                    trade.PositionClose(ticket);
-                }
-            }
-        }
-    }
-}
-
-double CalculateConfidenceScore()
-{
-    double score = 0;
-
-    // RSI estremo
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 18 || rsi > 82)
-        score += 15;
-
-    // ADX alto
-    double adx = iADX(_Symbol, PERIOD_H1, 14, PRICE_CLOSE, MODE_MAIN, 0);
-    if(adx > 28)
-        score += 15;
-
-    // EMA ben allineate
-    double ema57 = iMA(_Symbol, PERIOD_M5, 57, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema114 = iMA(_Symbol, PERIOD_M5, 114, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema150 = iMA(_Symbol, PERIOD_M5, 150, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema214 = iMA(_Symbol, PERIOD_M5, 214, 0, MODE_EMA, PRICE_CLOSE, 0);
-    if(ema57 > ema114 && ema114 > ema150 && ema150 > ema214)
-        score += 15;
-
-    // Volume spike
-    double vol_now = iVolume(_Symbol, PERIOD_M5, 0);
-    double vol_prev = iVolume(_Symbol, PERIOD_M5, 1);
-    if(vol_now > vol_prev * 1.8)
-        score += 10;
-
-    // Supporti/resistenze, pivot (simulati)
-    double s1 = iLow(_Symbol, PERIOD_D1, 0) - 100 * _Point;
-    double r1 = iHigh(_Symbol, PERIOD_D1, 0) + 100 * _Point;
-    double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
-    if(MathAbs(price - s1) < 30 * _Point || MathAbs(price - r1) < 30 * _Point)
-        score += 10;
-
-    // Order block presente (simulato)
-    if(iClose(_Symbol, PERIOD_M5, 0) > iOpen(_Symbol, PERIOD_M5, 0) && iClose(_Symbol, PERIOD_M5, 1) < iOpen(_Symbol, PERIOD_M5, 1))
-        score += 15;
-
-    // Fibonacci 61.8% (simulato livello)
-    double fib_level = iLow(_Symbol, PERIOD_H1, 1) + 0.618 * (iHigh(_Symbol, PERIOD_H1, 1) - iLow(_Symbol, PERIOD_H1, 1));
-    if(MathAbs(price - fib_level) < 20 * _Point)
-        score += 10;
-
-    // Pitchfork key level (simulato)
-    if(MathAbs(price - iMA(_Symbol, PERIOD_H1, 100, 0, MODE_EMA, PRICE_CLOSE, 0)) < 25 * _Point)
-        score += 5;
-
-    // Onde di Elliott (simulato se 3 candele a zigzag)
-    double c1 = iClose(_Symbol, PERIOD_M5, 2);
-    double c2 = iClose(_Symbol, PERIOD_M5, 1);
-    double c3 = iClose(_Symbol, PERIOD_M5, 0);
-    if((c1 < c2 && c2 > c3) || (c1 > c2 && c2 < c3))
-        score += 5;
-
-    // Elementi istituzionali
-    if(IsStopHunt())
-        score += 15;
-    if(IsFailedBreakout())
-        score += 15;
-    if(IsLiquidityPOI())
-        score += 10;
-    if(IsCandlestickPatternConfirmed())
-        score += 10;
-
-    return score;
-}
-
-
-void CheckAndTrade()
-{
-    double score = CalculateConfidenceScore();
-    double rr_ratio = 2.0; // default
-    double lot = 0.01; // default lotto minimo
-
-    // Skip se score < 50
-    if(score < 50)
-        return;
-
-    // Aggiustamento dinamico lotto e R:R
-    if(score >= 50 && score < 70)
-    {
-        rr_ratio = 2.0;
-        lot = 0.01;
-    }
-    else if(score >= 70 && score < 90)
-    {
-        rr_ratio = 3.0;
-        lot = 0.015; // aumenta leggermente
-    }
-    else if(score >= 90)
-    {
-        rr_ratio = 4.0;
-        lot = 0.02; // lotto massimo consentito per 100€ iniziali
-    }
-
-    // Calcolo direzione trade (semplificato su RSI)
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    int trade_type = -1;
-
-    if(rsi < 18)
-        trade_type = OP_BUY;
-    else if(rsi > 82)
-        trade_type = OP_SELL;
-    else
-        return;
-
-    // Prezzo corrente
-    double price = (trade_type == OP_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_ASK) : SymbolInfoDouble(_Symbol, SYMBOL_BID);
-
-    // StopLoss e TakeProfit dinamici
-    double atr = iATR(_Symbol, PERIOD_M5, 14, 0);
-    double sl_pips = atr * 1.5;
-    double tp_pips = sl_pips * rr_ratio;
-
-    double sl = (trade_type == OP_BUY) ? price - sl_pips : price + sl_pips;
-    double tp = (trade_type == OP_BUY) ? price + tp_pips : price - tp_pips;
-
-    // Invio ordine
-    if(trade_type == OP_BUY)
-        trade.Buy(lot, _Symbol, price, sl, tp, "AutoTrade by Confidence");
-    else
-        trade.Sell(lot, _Symbol, price, sl, tp, "AutoTrade by Confidence");
-}
-
-
-bool IsBullishEngulfing()
-{
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double open0 = iOpen(_Symbol, PERIOD_M5, 0);
-    double close0 = iClose(_Symbol, PERIOD_M5, 0);
-
-    return (close1 < open1 && close0 > open0 && close0 > open1 && open0 < close1);
-}
-
-bool IsBearishEngulfing()
-{
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double open0 = iOpen(_Symbol, PERIOD_M5, 0);
-    double close0 = iClose(_Symbol, PERIOD_M5, 0);
-
-    return (close1 > open1 && close0 < open0 && close0 < open1 && open0 > close1);
-}
-
-bool IsPinBar()
-{
-    double open = iOpen(_Symbol, PERIOD_M5, 0);
-    double close = iClose(_Symbol, PERIOD_M5, 0);
-    double high = iHigh(_Symbol, PERIOD_M5, 0);
-    double low = iLow(_Symbol, PERIOD_M5, 0);
-
-    double body = MathAbs(close - open);
-    double range = high - low;
-
-    return (body < (range * 0.25)); // corpo molto piccolo
-}
-
-
-bool IsCandlestickPatternConfirmed()
-{
-    return (IsBullishEngulfing() || IsBearishEngulfing() || IsPinBar());
-}
-
-bool RequirePatternConfirmation(double score, ENUM_TIMEFRAMES tf)
-{
-    // Per operazioni in H4/D1 runner, il pattern è obbligatorio se score < 80
-    if((tf == PERIOD_H4 || tf == PERIOD_D1) && score < 80)
-        return true;
-
-    // Se score è alto, il pattern può essere bypassato
-    return false;
+      LogCSV("EXIT", DIR_NONE, trans.price, 0.0, 0.0, 0.0, trans.volume, DailyScore((RegimeState)GVGetInt("regime", REGIME_RANGE)), 0, 0, 0, 0, 0);
+   }
 }

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -53,6 +53,7 @@ input int    InpRegimeLockBarsH1 = 4;
 
 input int    InpPivotLen = 3;
 input int    InpPivotConfirmBars = 2;
+input int    InpMaxBarsAfterBOS = 6;
 
 input bool   InpUseBreakRetest = true;
 input double InpRetestTolATR = 0.15;
@@ -167,9 +168,46 @@ const int TOTAL_MIN = 68;
 
 string g_symbol = "";
 int g_digits = 2;
+double g_point = 0.01;
 datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
+
+enum SkipMask
+{
+   SKIP_NONE = 0,
+   SKIP_SESSION = 1 << 0,
+   SKIP_ROLLOVER = 1 << 1,
+   SKIP_SPREAD = 1 << 2,
+   SKIP_SPREAD_MULT = 1 << 3,
+   SKIP_SPREAD_INSTAB = 1 << 4,
+   SKIP_LOWVOL = 1 << 5,
+   SKIP_DAILY_LOCK = 1 << 6,
+   SKIP_COOLDOWN = 1 << 7,
+   SKIP_LOSS_BLOCK = 1 << 8,
+   SKIP_DAILY_MAX = 1 << 9,
+   SKIP_DAILY_SCORE = 1 << 10,
+   SKIP_STOPS = 1 << 11
+};
+
+enum EntryMask
+{
+   ENTRY_NONE = 0,
+   ENTRY_BIAS = 1 << 0,
+   ENTRY_PIVOT = 1 << 1,
+   ENTRY_HL_LH = 1 << 2,
+   ENTRY_BOS_CLOSE = 1 << 3,
+   ENTRY_BOS_RETEST = 1 << 4,
+   ENTRY_KEYLEVEL = 1 << 5,
+   ENTRY_ANTICHASE = 1 << 6,
+   ENTRY_FVG = 1 << 7,
+   ENTRY_FIB = 1 << 8,
+   ENTRY_FOOTPRINT = 1 << 9,
+   ENTRY_SPIKE = 1 << 10,
+   ENTRY_RSI_LOSS = 1 << 11,
+   ENTRY_MMSL = 1 << 12,
+   ENTRY_RR = 1 << 13
+};
 
 string GVName(const string key)
 {
@@ -224,40 +262,37 @@ double PipPrice()
 {
    if(InpPipPrice > 0.0)
       return InpPipPrice;
-   return _Point * 10.0;
+   return g_point * 10.0;
 }
 
 double SpreadPoints()
 {
    double ask = SymbolInfoDouble(g_symbol, SYMBOL_ASK);
    double bid = SymbolInfoDouble(g_symbol, SYMBOL_BID);
-   return (ask - bid) / _Point;
+   return (ask - bid) / g_point;
+}
+
+int MinutesOfDay(datetime t)
+{
+   MqlDateTime dt;
+   TimeToStruct(t, dt);
+   return dt.hour * 60 + dt.min;
 }
 
 bool TimeInRange(const string start, const string end)
 {
-   datetime now = TimeCurrent();
    int sh = StringToInteger(StringSubstr(start, 0, 2));
    int sm = StringToInteger(StringSubstr(start, 3, 2));
    int eh = StringToInteger(StringSubstr(end, 0, 2));
    int em = StringToInteger(StringSubstr(end, 3, 2));
 
-   datetime s = StructToTime(BuildTimeStruct(now, sh, sm));
-   datetime e = StructToTime(BuildTimeStruct(now, eh, em));
+   int startMin = sh * 60 + sm;
+   int endMin = eh * 60 + em;
+   int nowMin = MinutesOfDay(TimeCurrent());
 
-   if(e < s)
-      return (now >= s || now <= e);
-   return (now >= s && now <= e);
-}
-
-MqlDateTime BuildTimeStruct(datetime t, int hour, int min)
-{
-   MqlDateTime dt;
-   TimeToStruct(t, dt);
-   dt.hour = hour;
-   dt.min = min;
-   dt.sec = 0;
-   return dt;
+   if(startMin <= endMin)
+      return (nowMin >= startMin && nowMin < endMin);
+   return (nowMin >= startMin || nowMin < endMin);
 }
 
 void UpdateSpreadEMA()
@@ -425,6 +460,52 @@ RegimeState UpdateRegime()
    return current;
 }
 
+bool IsPivotHigh(int index)
+{
+   double high = iHigh(g_symbol, PERIOD_M15, index);
+   for(int j = 1; j <= InpPivotLen; j++)
+   {
+      if(high <= iHigh(g_symbol, PERIOD_M15, index - j) || high <= iHigh(g_symbol, PERIOD_M15, index + j))
+         return false;
+   }
+   return true;
+}
+
+bool IsPivotLow(int index)
+{
+   double low = iLow(g_symbol, PERIOD_M15, index);
+   for(int j = 1; j <= InpPivotLen; j++)
+   {
+      if(low >= iLow(g_symbol, PERIOD_M15, index - j) || low >= iLow(g_symbol, PERIOD_M15, index + j))
+         return false;
+   }
+   return true;
+}
+
+bool IsConfirmedPivotHigh(int index)
+{
+   if(!IsPivotHigh(index))
+      return false;
+   for(int j = 1; j <= InpPivotConfirmBars; j++)
+   {
+      if(iHigh(g_symbol, PERIOD_M15, index - j) >= iHigh(g_symbol, PERIOD_M15, index))
+         return false;
+   }
+   return true;
+}
+
+bool IsConfirmedPivotLow(int index)
+{
+   if(!IsPivotLow(index))
+      return false;
+   for(int j = 1; j <= InpPivotConfirmBars; j++)
+   {
+      if(iLow(g_symbol, PERIOD_M15, index - j) <= iLow(g_symbol, PERIOD_M15, index))
+         return false;
+   }
+   return true;
+}
+
 bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, double &prevLow)
 {
    int foundHigh = 0;
@@ -432,35 +513,28 @@ bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, doubl
    lastHigh = prevHigh = 0.0;
    lastLow = prevLow = 0.0;
 
-   int start = InpPivotConfirmBars;
-   int end = 100;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int start = InpPivotLen + InpPivotConfirmBars;
+   int end = MathMin(bars - InpPivotLen - 1, 200);
    for(int i = start; i < end; i++)
    {
-      bool isHigh = true;
-      bool isLow = true;
-      double high = iHigh(g_symbol, PERIOD_M15, i);
-      double low = iLow(g_symbol, PERIOD_M15, i);
-      for(int j = 1; j <= InpPivotLen; j++)
-      {
-         if(high <= iHigh(g_symbol, PERIOD_M15, i - j) || high <= iHigh(g_symbol, PERIOD_M15, i + j))
-            isHigh = false;
-         if(low >= iLow(g_symbol, PERIOD_M15, i - j) || low >= iLow(g_symbol, PERIOD_M15, i + j))
-            isLow = false;
-      }
-      if(isHigh)
+      if(i - InpPivotConfirmBars < 0)
+         continue;
+
+      if(IsConfirmedPivotHigh(i))
       {
          if(foundHigh == 0)
-            lastHigh = high;
+            lastHigh = iHigh(g_symbol, PERIOD_M15, i);
          else if(foundHigh == 1)
-            prevHigh = high;
+            prevHigh = iHigh(g_symbol, PERIOD_M15, i);
          foundHigh++;
       }
-      if(isLow)
+      if(IsConfirmedPivotLow(i))
       {
          if(foundLow == 0)
-            lastLow = low;
+            lastLow = iLow(g_symbol, PERIOD_M15, i);
          else if(foundLow == 1)
-            prevLow = low;
+            prevLow = iLow(g_symbol, PERIOD_M15, i);
          foundLow++;
       }
       if(foundHigh >= 2 && foundLow >= 2)
@@ -469,20 +543,48 @@ bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, doubl
    return false;
 }
 
-bool BreakRetestOk(TradeDir dir, double bosLevel, double atrM15)
+void StoreBOS(TradeDir dir, double bosLevel, datetime bosTime)
+{
+   GVSetDouble("bosLevel", bosLevel);
+   GVSetDouble("bosTime", (double)bosTime);
+   GVSetInt("bosDir", (int)dir);
+}
+
+bool BOSStateValid(TradeDir dir, double &bosLevel)
+{
+   int bosDir = GVGetInt("bosDir", 0);
+   if(bosDir != (int)dir)
+      return false;
+
+   bosLevel = GVGetDouble("bosLevel", 0.0);
+   datetime bosTime = (datetime)GVGetDouble("bosTime", 0.0);
+   if(bosTime == 0 || bosLevel <= 0.0)
+      return false;
+
+   int shift = iBarShift(g_symbol, PERIOD_M15, bosTime, true);
+   if(shift < 0)
+      return false;
+   return shift <= InpMaxBarsAfterBOS;
+}
+
+bool BreakRetestOk(TradeDir dir, double atrM15)
 {
    if(!InpUseBreakRetest)
       return true;
 
-   double tol = MathMax(atrM15 * InpRetestTolATR, 5 * _Point);
+   double storedBosLevel = 0.0;
+   if(!BOSStateValid(dir, storedBosLevel))
+      return false;
+
+   double tol = MathMax(atrM15 * InpRetestTolATR, 5 * g_point);
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
    double low1 = iLow(g_symbol, PERIOD_M15, 1);
    double high1 = iHigh(g_symbol, PERIOD_M15, 1);
 
    if(dir == DIR_LONG)
-      return (low1 <= bosLevel + tol && close1 > bosLevel);
+      return (low1 <= storedBosLevel + tol && close1 > storedBosLevel);
    if(dir == DIR_SHORT)
-      return (high1 >= bosLevel - tol && close1 < bosLevel);
+      return (high1 >= storedBosLevel - tol && close1 < storedBosLevel);
    return false;
 }
 
@@ -506,26 +608,44 @@ double KeyAbove(double price)
    return MathCeil(price / step) * step;
 }
 
-bool KeyLevelOk(TradeDir dir, double mid)
+bool KeyLevelNearOk(double mid, double &nearest)
 {
-   double nearest = NearestKeyLevel(mid);
-   if(MathAbs(mid - nearest) > InpKeyNearPrice)
-      return false;
+   nearest = NearestKeyLevel(mid);
+   return MathAbs(mid - nearest) <= InpKeyNearPrice;
+}
+
+bool AntiChaseOk(TradeDir dir, double mid, double nearest)
+{
+   double step = InpKeyLevelStepPrice;
+   if(step <= 0.0)
+      return true;
+   double chaseKey = nearest;
+   if(dir == DIR_LONG && nearest > mid)
+      chaseKey = nearest - step;
+   else if(dir == DIR_SHORT && nearest < mid)
+      chaseKey = nearest + step;
 
    if(dir == DIR_LONG)
-      return (mid - KeyBelow(mid) <= InpKeyChaseMaxDistPrice);
+      return (mid - chaseKey <= InpKeyChaseMaxDistPrice);
    if(dir == DIR_SHORT)
-      return (KeyAbove(mid) - mid <= InpKeyChaseMaxDistPrice);
+      return (chaseKey - mid <= InpKeyChaseMaxDistPrice);
    return false;
 }
 
-int FVGDirection(double &zoneMid, double atrM15)
+int FVGDirection(double &zoneMid, double priceMid)
 {
    if(!InpUseFVGFeature)
       return 0;
 
+   int bars = iBars(g_symbol, PERIOD_M15);
+   double bestDist = DBL_MAX;
+   int bestDir = 0;
+   double bestMid = 0.0;
+
    for(int i = 1; i <= InpFVGScanBars; i++)
    {
+      if(i + 2 >= bars)
+         break;
       double low = iLow(g_symbol, PERIOD_M15, i);
       double high = iHigh(g_symbol, PERIOD_M15, i);
       double low2 = iLow(g_symbol, PERIOD_M15, i + 2);
@@ -533,16 +653,29 @@ int FVGDirection(double &zoneMid, double atrM15)
 
       if(low > high2)
       {
-         zoneMid = (low + high2) / 2.0;
-         return DIR_LONG;
+         double mid = (low + high2) / 2.0;
+         double dist = MathAbs(priceMid - mid);
+         if(dist < bestDist)
+         {
+            bestDist = dist;
+            bestDir = DIR_LONG;
+            bestMid = mid;
+         }
       }
       if(high < low2)
       {
-         zoneMid = (high + low2) / 2.0;
-         return DIR_SHORT;
+         double mid = (high + low2) / 2.0;
+         double dist = MathAbs(priceMid - mid);
+         if(dist < bestDist)
+         {
+            bestDist = dist;
+            bestDir = DIR_SHORT;
+            bestMid = mid;
+         }
       }
    }
-   return 0;
+   zoneMid = bestMid;
+   return bestDir;
 }
 
 bool FVGOk(TradeDir dir, double mid, double atrM15)
@@ -551,7 +684,7 @@ bool FVGOk(TradeDir dir, double mid, double atrM15)
       return true;
 
    double zoneMid = 0.0;
-   int fvgDir = FVGDirection(zoneMid, atrM15);
+   int fvgDir = FVGDirection(zoneMid, mid);
    if(fvgDir == 0 || fvgDir != dir)
       return false;
 
@@ -780,9 +913,13 @@ bool DailyTradeAllowed(int dailyScore, int &maxTrades, double &riskMult, bool &p
 
 bool CooldownActive()
 {
-   int lastEntryBar = GVGetInt("lastEntryBar", 0);
-   int currentBar = (int)iBars(g_symbol, PERIOD_M15);
-   return (currentBar - lastEntryBar) <= InpCooldownBarsAfterEntry;
+   datetime lastEntryTime = (datetime)GVGetDouble("lastEntryTime", 0.0);
+   if(lastEntryTime == 0)
+      return false;
+   int shift = iBarShift(g_symbol, PERIOD_M15, lastEntryTime, true);
+   if(shift < 0)
+      return false;
+   return shift <= InpCooldownBarsAfterEntry;
 }
 
 void UpdateDailyReset()
@@ -800,26 +937,54 @@ void UpdateDailyReset()
    }
 }
 
-bool HardGuardsOk()
+bool HardGuardsOk(int &skipMask)
 {
+   skipMask = SKIP_NONE;
    if(!SessionAllowed())
+   {
+      skipMask |= SKIP_SESSION;
       return false;
+   }
    if(RolloverBlocked())
+   {
+      skipMask |= SKIP_ROLLOVER;
       return false;
+   }
    if(SpreadPoints() > InpMaxSpreadPoints)
+   {
+      skipMask |= SKIP_SPREAD;
       return false;
+   }
    if(SpreadMultipleBlocked())
+   {
+      skipMask |= SKIP_SPREAD_MULT;
       return false;
+   }
    if(SpreadInstabilityBlocked())
+   {
+      skipMask |= SKIP_SPREAD_INSTAB;
       return false;
+   }
    if(LowVolumeBlocked())
+   {
+      skipMask |= SKIP_LOWVOL;
       return false;
+   }
    if(DailyLossLocked() || SoftEquityLocked())
+   {
+      skipMask |= SKIP_DAILY_LOCK;
       return false;
+   }
    if(GVGetInt("dayLocked", 0) == 1)
+   {
+      skipMask |= SKIP_DAILY_LOCK;
       return false;
+   }
    if(CooldownActive())
+   {
+      skipMask |= SKIP_COOLDOWN;
       return false;
+   }
    return true;
 }
 
@@ -857,12 +1022,22 @@ double CurrentRiskMultiplier(double dailyRiskMult)
    return mult;
 }
 
+double TickValue()
+{
+   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE_PROFIT);
+   if(tickValue <= 0.0)
+      tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE_LOSS);
+   if(tickValue <= 0.0)
+      tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   return tickValue;
+}
+
 double CalcLots(double slDist, double riskPct)
 {
    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
    double riskMoney = equity * (riskPct / 100.0);
    double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
-   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   double tickValue = TickValue();
    if(tickSize <= 0.0 || tickValue <= 0.0 || slDist <= 0.0)
       return 0.0;
 
@@ -881,6 +1056,30 @@ double CalcLots(double slDist, double riskPct)
    lot = MathMin(lot, maxLot);
    lot = MathFloor(lot / step) * step;
    return NormalizeDouble(lot, 2);
+}
+
+bool StopsOk(double entry, double sl, double tp)
+{
+   int stopsLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_STOPS_LEVEL);
+   if(stopsLevel <= 0)
+      return true;
+
+   double minDist = stopsLevel * g_point;
+   if(sl > 0.0 && MathAbs(entry - sl) < minDist)
+      return false;
+   if(tp > 0.0 && MathAbs(entry - tp) < minDist)
+      return false;
+   return true;
+}
+
+bool CanModifyStops(double newSl)
+{
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   if(freezeLevel <= 0)
+      return true;
+
+   double price = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   return MathAbs(price - newSl) > freezeLevel * g_point;
 }
 
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
@@ -953,39 +1152,58 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
       return false;
    dir = bias;
    setupScore += 20;
+   entryMask |= ENTRY_BIAS;
 
    double lastHigh = 0.0, prevHigh = 0.0, lastLow = 0.0, prevLow = 0.0;
    if(!FindRecentPivots(lastHigh, prevHigh, lastLow, prevLow))
       return false;
+   entryMask |= ENTRY_PIVOT;
 
    if(dir == DIR_LONG && !(lastLow > prevLow))
       return false;
    if(dir == DIR_SHORT && !(lastHigh < prevHigh))
       return false;
    setupScore += 10;
+   entryMask |= ENTRY_HL_LH;
 
    double bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
    bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
    double atrM15 = ATR(PERIOD_M15, 1);
 
-   bool brOk = BreakRetestOk(dir, bosLevel, atrM15);
+   if(closeConfirm)
+   {
+      entryMask |= ENTRY_BOS_CLOSE;
+      StoreBOS(dir, bosLevel, iTime(g_symbol, PERIOD_M15, 1));
+   }
+
+   bool brOk = BreakRetestOk(dir, atrM15);
+   if(brOk)
+      entryMask |= ENTRY_BOS_RETEST;
    if(!closeConfirm && !brOk)
       return false;
    timingScore += 10;
 
    double mid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
-   if(!KeyLevelOk(dir, mid))
+   double nearest = 0.0;
+   if(!KeyLevelNearOk(mid, nearest))
       return false;
+   entryMask |= ENTRY_KEYLEVEL;
+
+   if(!AntiChaseOk(dir, mid, nearest))
+      return false;
+   entryMask |= ENTRY_ANTICHASE;
    setupScore += 10;
 
    if(!FVGOk(dir, mid, atrM15))
       return false;
+   entryMask |= ENTRY_FVG;
    setupScore += 5;
 
    bool oteBonus = false;
    if(!FibFilterOk(dir, mid, lastLow, lastHigh, oteBonus))
       return false;
+   entryMask |= ENTRY_FIB;
    setupScore += 15;
    if(oteBonus)
       setupScore += InpOTEBonusPoints;
@@ -994,18 +1212,21 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    bool acceptance = true;
    if(!FootprintOk(dir, atrM15, absorption, acceptance))
       return false;
+   entryMask |= ENTRY_FOOTPRINT;
    if(acceptance)
       timingScore += InpFP_ScoreBonus;
 
    if(!SpikeGuardOk(atrM15))
       return false;
+   entryMask |= ENTRY_SPIKE;
 
    if(!RSIAfterLossOk(dir))
       return false;
+   entryMask |= ENTRY_RSI_LOSS;
 
    entry = (dir == DIR_LONG) ? SymbolInfoDouble(g_symbol, SYMBOL_ASK) : SymbolInfoDouble(g_symbol, SYMBOL_BID);
    double atrBuf = atrM15 * InpSL_ATR_Mult;
-   double spreadBuf = SpreadPoints() * _Point * 0.5;
+   double spreadBuf = SpreadPoints() * g_point * 0.5;
    double buffer = MathMax(InpSL_MinBufferPrice, MathMax(atrBuf, spreadBuf));
 
    sl = (dir == DIR_LONG) ? (lastLow - buffer) : (lastHigh + buffer);
@@ -1018,20 +1239,30 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
       double mmsl = InpMMSL_Pips * PipPrice() + InpMMSL_ExtraBufferPrice;
       if(riskR < mmsl)
          return false;
+      entryMask |= ENTRY_MMSL;
    }
 
    tp = (dir == DIR_LONG) ? (entry + riskR * InpTP_RR_Main) : (entry - riskR * InpTP_RR_Main);
    double rr = MathAbs(tp - entry) / riskR;
    if(rr < InpMinRRAllowed)
       return false;
+   entryMask |= ENTRY_RR;
 
    tp1 = (dir == DIR_LONG) ? (entry + riskR) : (entry - riskR);
    if(InpUseTP1Partial && InpTP1_UseKeyLevelFirst)
    {
-      double key = NearestKeyLevel(entry);
-      double dist = MathAbs(key - entry);
-      if(dist > PipPrice() && dist < MathAbs(tp1 - entry))
-         tp1 = (dir == DIR_LONG) ? MathMax(entry + dist, tp1) : MathMin(entry - dist, tp1);
+      if(dir == DIR_LONG)
+      {
+         double key = KeyAbove(entry);
+         if(key < tp1 && (key - entry) > PipPrice())
+            tp1 = key;
+      }
+      else
+      {
+         double key = KeyBelow(entry);
+         if(key > tp1 && (entry - key) > PipPrice())
+            tp1 = key;
+      }
    }
 
    totalScore = setupScore + timingScore;
@@ -1069,6 +1300,8 @@ void ManagePosition(double riskR)
    double volume = PositionGetDouble(POSITION_VOLUME);
    double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
 
+   if(riskR <= 0.0)
+      return;
    double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
 
    bool tp1done = GVGetInt("tp1done", 0) == 1;
@@ -1076,9 +1309,11 @@ void ManagePosition(double riskR)
 
    if(InpUseTP1Partial && !tp1done && profitR >= 1.0)
    {
-      double closeVol = volume * InpTP1_CloseFrac;
+      double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+      double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+      double closeVol = MathFloor((volume * InpTP1_CloseFrac) / step) * step;
       closeVol = NormalizeDouble(closeVol, 2);
-      if(closeVol >= SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN))
+      if(closeVol >= minLot && (volume - closeVol) >= minLot)
       {
          trade.PositionClosePartial(ticket, closeVol);
          GVSetInt("tp1done", 1);
@@ -1090,7 +1325,8 @@ void ManagePosition(double riskR)
    if(InpUseSmartBE && profitR >= InpBE_MinProfitR)
    {
       double newSL = (type == POSITION_TYPE_BUY) ? (entry + InpBE_OffsetPrice) : (entry - InpBE_OffsetPrice);
-      if((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl))
+      if(CanModifyStops(newSL) && StopsOk(entry, newSL, tp) &&
+         ((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl)))
          trade.PositionModify(ticket, newSL, tp);
    }
 
@@ -1100,9 +1336,9 @@ void ManagePosition(double riskR)
       {
          double atr = ATR(PERIOD_M15, 1);
          double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * InpTrailATR_Mult) : (price + atr * InpTrailATR_Mult);
-         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice)
+         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
-         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice)
+         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
       }
    }
@@ -1158,11 +1394,15 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
    if(addLots <= 0.0)
       return;
 
+   double addTp = (type == POSITION_TYPE_BUY) ? (price + riskR * InpTP_RR_Main) : (price - riskR * InpTP_RR_Main);
+   if(!StopsOk(price, sl, addTp))
+      return;
+
    bool result = false;
    if(type == POSITION_TYPE_BUY)
-      result = trade.Buy(addLots, g_symbol, price, sl, price + riskR * InpTP_RR_Main, "PYR");
+      result = trade.Buy(addLots, g_symbol, 0.0, sl, addTp, "PYR");
    else
-      result = trade.Sell(addLots, g_symbol, price, sl, price - riskR * InpTP_RR_Main, "PYR");
+      result = trade.Sell(addLots, g_symbol, 0.0, sl, addTp, "PYR");
 
    if(result)
    {
@@ -1176,6 +1416,7 @@ int OnInit()
 {
    g_symbol = ResolveSymbol();
    g_digits = (int)SymbolInfoInteger(g_symbol, SYMBOL_DIGITS);
+   g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
 
    trade.SetExpertMagicNumber((uint)InpMagic);
    trade.SetDeviationInPoints(InpMaxSlippagePoints);
@@ -1199,7 +1440,11 @@ void OnTick()
 
    if(HasPosition())
    {
-      double riskR = GVGetDouble("origRisk", 0.0);
+      double entryPrice = PositionGetDouble(POSITION_PRICE_OPEN);
+      double slPrice = PositionGetDouble(POSITION_SL);
+      double riskR = MathAbs(entryPrice - slPrice);
+      if(riskR <= 0.0)
+         riskR = GVGetDouble("origRisk", 0.0);
       ManagePosition(riskR);
       int dailyScore = DailyScore(regime);
       bool pyramidAllowed = false;
@@ -1210,21 +1455,40 @@ void OnTick()
       return;
    }
 
+   int skipMask = SKIP_NONE;
    if(LossBlocksActive())
+   {
+      skipMask |= SKIP_LOSS_BLOCK;
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0);
       return;
-   if(!HardGuardsOk())
+   }
+   if(!HardGuardsOk(skipMask))
+   {
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0);
       return;
+   }
 
    int dayTrades = GVGetInt("dayTrades", 0);
-   if(InpUseDailyTradeControl && dayTrades >= InpHardMaxTradesPerDay)
-      return;
-
    int dailyScore = DailyScore(regime);
    int maxTrades = 0;
    double dailyRiskMult = 0.0;
    bool pyramidAllowed = false;
    if(InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
+   {
+      skipMask |= SKIP_DAILY_SCORE;
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0);
       return;
+   }
+
+   int allowedTrades = InpHardMaxTradesPerDay;
+   if(InpUseDailyTradeControl)
+      allowedTrades = MathMin(allowedTrades, maxTrades);
+   if(dayTrades >= allowedTrades)
+   {
+      skipMask |= SKIP_DAILY_MAX;
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0);
+      return;
+   }
 
    TradeDir dir;
    double entry = 0.0, sl = 0.0, tp = 0.0, tp1 = 0.0, riskR = 0.0;
@@ -1241,16 +1505,23 @@ void OnTick()
    if(lots <= 0.0)
       return;
 
+   if(!StopsOk(entry, sl, tp))
+   {
+      skipMask |= SKIP_STOPS;
+      LogCSV("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask);
+      return;
+   }
+
    bool sent = false;
    if(dir == DIR_LONG)
-      sent = trade.Buy(lots, g_symbol, entry, sl, tp, "ENTRY");
+      sent = trade.Buy(lots, g_symbol, 0.0, sl, tp, "ENTRY");
    else if(dir == DIR_SHORT)
-      sent = trade.Sell(lots, g_symbol, entry, sl, tp, "ENTRY");
+      sent = trade.Sell(lots, g_symbol, 0.0, sl, tp, "ENTRY");
 
    if(sent)
    {
       GVSetInt("dayTrades", dayTrades + 1);
-      GVSetInt("lastEntryBar", (int)iBars(g_symbol, PERIOD_M15));
+      GVSetDouble("lastEntryTime", (double)iTime(g_symbol, PERIOD_M15, 0));
       GVSetDouble("origRisk", riskR);
       GVSetInt("tp1done", 0);
       GVSetDouble("tp1price", tp1);

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -8,6 +8,7 @@
 //| - Convert GOLD-tuned distances to profile-aware points.          |
 //| - Fix index key-step units and volume step rounding.             |
 //| - Add tickSize/pipSize to logs and sanity warnings.              |
+//| - Add optional SD/candle/momentum bonus scoring + CSV fields.    |
 //|                                                                  |
 //| CHANGELOG                                                       |
 //| - Added ICT/SMC modules: NY killzones, PD arrays, liquidity      |
@@ -141,6 +142,22 @@ input double InpFP_AbsorpVolRatio = 1.50;
 input double InpFP_AbsorpRangeATR = 0.45;
 input bool   InpFP_RequireAcceptance = true;
 input int    InpFP_ScoreBonus = 10;
+
+input bool   InpUseSupplyDemandBonus = true;
+input ENUM_TIMEFRAMES InpSD_TF = PERIOD_H1;
+input int    InpSD_LookbackBars = 200;
+input double InpSD_MinImpulseATR = 1.2;
+input int    InpSD_MaxBaseBars = 3;
+input double InpSD_ZonePadATR = 0.15;
+input double InpSD_MaxDistATR = 0.8;
+input int    InpSD_BonusPoints = 6;
+input int    InpSD_FreshnessBonus = 3;
+
+input bool   InpUseCandleBonus = true;
+input int    InpCandleBonusPoints = 4;
+
+input bool   InpUseMomentumBonus = true;
+input int    InpMomentumBonusPoints = 4;
 
 input bool   InpUseSpikeGuard = true;
 input double InpSpikeMultATR = 2.5;
@@ -310,6 +327,19 @@ double cfg_InpFP_AbsorpVolRatio;
 double cfg_InpFP_AbsorpRangeATR;
 bool cfg_InpFP_RequireAcceptance;
 int cfg_InpFP_ScoreBonus;
+bool cfg_InpUseSupplyDemandBonus;
+ENUM_TIMEFRAMES cfg_InpSD_TF;
+int cfg_InpSD_LookbackBars;
+double cfg_InpSD_MinImpulseATR;
+int cfg_InpSD_MaxBaseBars;
+double cfg_InpSD_ZonePadATR;
+double cfg_InpSD_MaxDistATR;
+int cfg_InpSD_BonusPoints;
+int cfg_InpSD_FreshnessBonus;
+bool cfg_InpUseCandleBonus;
+int cfg_InpCandleBonusPoints;
+bool cfg_InpUseMomentumBonus;
+int cfg_InpMomentumBonusPoints;
 bool cfg_InpUseSpikeGuard;
 double cfg_InpSpikeMultATR;
 double cfg_InpSL_ATR_Mult;
@@ -431,7 +461,10 @@ enum EntryMask
    ENTRY_OB_RTO = 1 << 18,
    ENTRY_OTE = 1 << 19,
    ENTRY_PDARRAY = 1 << 20,
-   ENTRY_SR = 1 << 21
+   ENTRY_SR = 1 << 21,
+   ENTRY_SD = 1 << 22,
+   ENTRY_CANDLE = 1 << 23,
+   ENTRY_MOM = 1 << 24
 };
 
 string GVName(const string key)
@@ -500,7 +533,7 @@ SymbolProfile DetectSymbolProfile(const string symbol)
       return PROFILE_FX_MAJORS_5DIG;
    string indexTokens[] = {"US30", "DJ30", "WS30", "US30CASH",
                            "NAS100", "USTEC", "US100", "NAS",
-                           "SPX500", "US500", "SP500",
+                           "SPX500", "SPX", "US500", "US_500", "SP500",
                            "GER40", "DE40", "DAX", "DAX40",
                            "FTSEMIB", "FTSE_MIB", "ITA40",
                            "UK100", "FTSE"};
@@ -576,10 +609,7 @@ double AutoPipSize(bool useOverride)
       return cfg_InpPipPrice;
 
    if(g_profile == PROFILE_INDICES)
-   {
-      double tickSize = TickSize();
-      return (tickSize > 0.0) ? tickSize : 1.0;
-   }
+      return 1.0;
 
    if(g_digits == 3 || g_digits == 5)
       return g_point * 10.0;
@@ -1480,6 +1510,212 @@ bool FootprintOk(TradeDir dir, double atrM15, bool &absorption, bool &accepted)
    return !absorption;
 }
 
+bool DetectSupplyDemandBonus(TradeDir dir, int &sdType, double &sdDistATR, int &sdFresh)
+{
+   sdType = 0;
+   sdDistATR = 0.0;
+   sdFresh = 0;
+   if(!cfg_InpUseSupplyDemandBonus)
+      return false;
+
+   int bars = iBars(g_symbol, cfg_InpSD_TF);
+   if(bars <= cfg_InpSD_MaxBaseBars + 2)
+      return false;
+
+   int lookback = MathMin(cfg_InpSD_LookbackBars, bars - cfg_InpSD_MaxBaseBars - 2);
+   if(lookback < cfg_InpSD_MaxBaseBars + 2)
+      return false;
+
+   double atrM15 = ATR(PERIOD_M15, 1);
+   if(atrM15 <= 0.0)
+      return false;
+
+   double bestDist = DBL_MAX;
+   bool zoneFresh = false;
+   int zoneType = 0;
+
+   for(int i = 1; i <= lookback; i++)
+   {
+      double atr = iATR(g_symbol, cfg_InpSD_TF, cfg_InpATRPeriod, i);
+      if(atr <= 0.0)
+         continue;
+      double impOpen = iOpen(g_symbol, cfg_InpSD_TF, i);
+      double impClose = iClose(g_symbol, cfg_InpSD_TF, i);
+      double impHigh = iHigh(g_symbol, cfg_InpSD_TF, i);
+      double impLow = iLow(g_symbol, cfg_InpSD_TF, i);
+      double impRange = impHigh - impLow;
+      double impBody = MathAbs(impClose - impOpen);
+      double bodyRatio = (impRange > 0.0) ? (impBody / impRange) : 0.0;
+      if(impRange < atr * cfg_InpSD_MinImpulseATR || bodyRatio < 0.55)
+         continue;
+
+      int baseBars = 0;
+      double baseMinLow = DBL_MAX;
+      double baseMaxHigh = -DBL_MAX;
+      double baseMinBody = DBL_MAX;
+      double baseMaxBody = -DBL_MAX;
+      for(int b = 1; b <= cfg_InpSD_MaxBaseBars; b++)
+      {
+         int shift = i + b;
+         if(shift >= bars)
+            break;
+         double bHigh = iHigh(g_symbol, cfg_InpSD_TF, shift);
+         double bLow = iLow(g_symbol, cfg_InpSD_TF, shift);
+         double bOpen = iOpen(g_symbol, cfg_InpSD_TF, shift);
+         double bClose = iClose(g_symbol, cfg_InpSD_TF, shift);
+         double bRange = bHigh - bLow;
+         if(bRange >= atr * 0.8)
+            break;
+         baseBars++;
+         baseMinLow = MathMin(baseMinLow, bLow);
+         baseMaxHigh = MathMax(baseMaxHigh, bHigh);
+         baseMinBody = MathMin(baseMinBody, MathMin(bOpen, bClose));
+         baseMaxBody = MathMax(baseMaxBody, MathMax(bOpen, bClose));
+      }
+      if(baseBars <= 0)
+         continue;
+
+      bool impulseUp = impClose > impOpen;
+      int candidateType = impulseUp ? 1 : -1;
+      if(dir == DIR_LONG && candidateType != 1)
+         continue;
+      if(dir == DIR_SHORT && candidateType != -1)
+         continue;
+
+      double pad = atr * cfg_InpSD_ZonePadATR;
+      double candLow = (candidateType == 1) ? baseMinLow : baseMinBody;
+      double candHigh = (candidateType == 1) ? baseMaxBody : baseMaxHigh;
+      candLow -= pad;
+      candHigh += pad;
+
+      bool mitigated = false;
+      for(int j = i - 1; j >= 1; j--)
+      {
+         double jHigh = iHigh(g_symbol, cfg_InpSD_TF, j);
+         double jLow = iLow(g_symbol, cfg_InpSD_TF, j);
+         if(jLow <= candHigh && jHigh >= candLow)
+         {
+            mitigated = true;
+            break;
+         }
+      }
+
+      double price = iClose(g_symbol, PERIOD_M15, 1);
+      double dist = 0.0;
+      if(price < candLow)
+         dist = candLow - price;
+      else if(price > candHigh)
+         dist = price - candHigh;
+      else
+         dist = 0.0;
+
+      double distAtr = dist / atrM15;
+      if(distAtr > cfg_InpSD_MaxDistATR)
+         continue;
+
+      if(distAtr < bestDist)
+      {
+         bestDist = distAtr;
+         zoneFresh = !mitigated;
+         zoneType = candidateType;
+      }
+   }
+
+   if(bestDist == DBL_MAX)
+      return false;
+
+   sdType = zoneType;
+   sdDistATR = bestDist;
+   sdFresh = zoneFresh ? 1 : 0;
+   return true;
+}
+
+bool CandleBonus(TradeDir dir, int &candleType)
+{
+   candleType = 0;
+   if(!cfg_InpUseCandleBonus)
+      return false;
+
+   double o1 = iOpen(g_symbol, PERIOD_M15, 1);
+   double c1 = iClose(g_symbol, PERIOD_M15, 1);
+   double h1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double l1 = iLow(g_symbol, PERIOD_M15, 1);
+   double o2 = iOpen(g_symbol, PERIOD_M15, 2);
+   double c2 = iClose(g_symbol, PERIOD_M15, 2);
+   double range = h1 - l1;
+   if(range <= 0.0)
+      return false;
+
+   double body = MathAbs(c1 - o1);
+   double upperWick = h1 - MathMax(o1, c1);
+   double lowerWick = MathMin(o1, c1) - l1;
+
+   bool bullish = c1 > o1;
+   bool bearish = c1 < o1;
+
+   bool bullEngulf = bullish && c1 >= o2 && o1 <= c2;
+   bool bearEngulf = bearish && c1 <= o2 && o1 >= c2;
+
+   bool bullPin = lowerWick > body * 2.0 && lowerWick > upperWick;
+   bool bearPin = upperWick > body * 2.0 && upperWick > lowerWick;
+
+   bool doji = body <= range * 0.25;
+   bool dojiBull = doji && lowerWick > upperWick * 1.5;
+   bool dojiBear = doji && upperWick > lowerWick * 1.5;
+
+   if(dir == DIR_LONG)
+   {
+      if(bullEngulf)
+      {
+         candleType = 1;
+         return true;
+      }
+      if(bullPin)
+      {
+         candleType = 3;
+         return true;
+      }
+      if(dojiBull)
+      {
+         candleType = 5;
+         return true;
+      }
+   }
+   else if(dir == DIR_SHORT)
+   {
+      if(bearEngulf)
+      {
+         candleType = 2;
+         return true;
+      }
+      if(bearPin)
+      {
+         candleType = 4;
+         return true;
+      }
+      if(dojiBear)
+      {
+         candleType = 6;
+         return true;
+      }
+   }
+
+   return false;
+}
+
+bool MomentumBonus(TradeDir dir, double &rsi1, double &rsi2)
+{
+   rsi1 = RSI(PERIOD_M15, 1);
+   rsi2 = RSI(PERIOD_M15, 2);
+   if(!cfg_InpUseMomentumBonus)
+      return false;
+   if(dir == DIR_LONG)
+      return (rsi1 > rsi2 && rsi1 > 50.0);
+   if(dir == DIR_SHORT)
+      return (rsi1 < rsi2 && rsi1 < 50.0);
+   return false;
+}
+
 bool SpikeGuardOk(double atrM15)
 {
    if(!cfg_InpUseSpikeGuard)
@@ -2026,6 +2262,19 @@ void ApplyPreset()
    cfg_InpFP_AbsorpRangeATR = InpFP_AbsorpRangeATR;
    cfg_InpFP_RequireAcceptance = InpFP_RequireAcceptance;
    cfg_InpFP_ScoreBonus = InpFP_ScoreBonus;
+   cfg_InpUseSupplyDemandBonus = InpUseSupplyDemandBonus;
+   cfg_InpSD_TF = InpSD_TF;
+   cfg_InpSD_LookbackBars = InpSD_LookbackBars;
+   cfg_InpSD_MinImpulseATR = InpSD_MinImpulseATR;
+   cfg_InpSD_MaxBaseBars = InpSD_MaxBaseBars;
+   cfg_InpSD_ZonePadATR = InpSD_ZonePadATR;
+   cfg_InpSD_MaxDistATR = InpSD_MaxDistATR;
+   cfg_InpSD_BonusPoints = InpSD_BonusPoints;
+   cfg_InpSD_FreshnessBonus = InpSD_FreshnessBonus;
+   cfg_InpUseCandleBonus = InpUseCandleBonus;
+   cfg_InpCandleBonusPoints = InpCandleBonusPoints;
+   cfg_InpUseMomentumBonus = InpUseMomentumBonus;
+   cfg_InpMomentumBonusPoints = InpMomentumBonusPoints;
    cfg_InpUseSpikeGuard = InpUseSpikeGuard;
    cfg_InpSpikeMultATR = InpSpikeMultATR;
    cfg_InpSL_ATR_Mult = InpSL_ATR_Mult;
@@ -2176,7 +2425,16 @@ void ApplyPreset()
       }
    }
 
-   g_pip = AutoPipSize(true);
+   double pipSize = AutoPipSize(true);
+   if(cfg_InpPresetMode == PRESET_BALANCED || cfg_InpPresetMode == PRESET_CONSERVATIVE)
+   {
+      if(g_profile == PROFILE_INDICES)
+         cfg_InpMaxSpreadPoints = (int)MathRound(PointsFromPrice(2.5));
+      else
+         cfg_InpMaxSpreadPoints = (int)MathRound((2.0 * pipSize) / g_point);
+   }
+
+   g_pip = pipSize;
 
    ApplyProfileDefaults();
    LogPresetConfig();
@@ -2303,6 +2561,20 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
             int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
             int oteOk)
 {
+   LogCSVEx(event, dir, entry, sl, tp, tp1, lot, dailyScore, setup, timing, total, skipMask, entryMask,
+            retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+            sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+            0, 0, 0.0, 0, 0, 0, 0, 0.0, 0.0);
+}
+
+void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
+              int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
+              int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
+              int killzoneActive, double pdh, double pdl, double psh, double psl, double hod, double lod,
+              int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
+              int oteOk, int sdHit, int sdType, double sdDistATR, int sdFresh,
+              int candleHit, int candleType, int momHit, double rsi1, double rsi2)
+{
    if(!cfg_InpEnableCSV)
       return;
 
@@ -2320,7 +2592,9 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
                 "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
                 "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
                 "killzoneActive", "pdh", "pdl", "psh", "psl", "hod", "lod",
-                "sweepDir", "sweepLevel", "displacementScore", "obHigh", "obLow", "obMT", "oteOk");
+                "sweepDir", "sweepLevel", "displacementScore", "obHigh", "obLow", "obMT", "oteOk",
+                "sdHit", "sdType", "sdDistATR", "sdFresh", "candleHit", "candleType",
+                "momHit", "rsi1", "rsi2");
    }
 
    int lossStreak = GVGetInt("lossStreak", 0);
@@ -2385,7 +2659,16 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
              DoubleToString(obHigh, g_digits),
              DoubleToString(obLow, g_digits),
              DoubleToString(obMT, g_digits),
-             oteOk);
+             oteOk,
+             sdHit,
+             sdType,
+             DoubleToString(sdDistATR, 2),
+             sdFresh,
+             candleHit,
+             candleType,
+             momHit,
+             DoubleToString(rsi1, 2),
+             DoubleToString(rsi2, 2));
 
    FileClose(handle);
 }
@@ -2395,7 +2678,10 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
                     double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
                     double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
                     int &sweepDir, double &sweepLevel, double &displacementScore,
-                    double &obHigh, double &obLow, double &obMT, int &oteOk)
+                    double &obHigh, double &obLow, double &obMT, int &oteOk,
+                    int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                    int &candleHit, int &candleType,
+                    int &momHit, double &rsi1, double &rsi2)
 {
    setupScore = 0;
    timingScore = 0;
@@ -2413,6 +2699,15 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    displacementScore = 0.0;
    obHigh = obLow = obMT = 0.0;
    oteOk = 0;
+   sdHit = 0;
+   sdType = 0;
+   sdDistATR = 0.0;
+   sdFresh = 0;
+   candleHit = 0;
+   candleType = 0;
+   momHit = 0;
+   rsi1 = 0.0;
+   rsi2 = 0.0;
 
    TradeDir bias = BiasH1();
    if(bias == DIR_NONE)
@@ -2549,6 +2844,29 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    if(!RSIAfterLossOk(dir))
       return false;
    entryMask |= ENTRY_RSI_LOSS;
+
+   if(DetectSupplyDemandBonus(dir, sdType, sdDistATR, sdFresh))
+   {
+      sdHit = 1;
+      entryMask |= ENTRY_SD;
+      setupScore += cfg_InpSD_BonusPoints;
+      if(sdFresh == 1)
+         setupScore += cfg_InpSD_FreshnessBonus;
+   }
+
+   if(CandleBonus(dir, candleType))
+   {
+      candleHit = 1;
+      entryMask |= ENTRY_CANDLE;
+      setupScore += cfg_InpCandleBonusPoints;
+   }
+
+   if(MomentumBonus(dir, rsi1, rsi2))
+   {
+      momHit = 1;
+      entryMask |= ENTRY_MOM;
+      timingScore += cfg_InpMomentumBonusPoints;
+   }
 
    int obAgeBars = -1;
    if(!FindOrderBlock(dir, obHigh, obLow, obMT, obAgeBars))
@@ -2906,14 +3224,25 @@ void OnTick()
    double displacementScore = 0.0;
    double obHigh = 0.0, obLow = 0.0, obMT = 0.0;
    int oteOk = 0;
+   int sdHit = 0;
+   int sdType = 0;
+   double sdDistATR = 0.0;
+   int sdFresh = 0;
+   int candleHit = 0;
+   int candleType = 0;
+   int momHit = 0;
+   double rsi1 = 0.0;
+   double rsi2 = 0.0;
 
    if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask,
                       nearestKey, bosLevel, bosAgeBars, killzoneActive, pdh, pdl, psh, psl, hod, lod,
-                      sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk))
+                      sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+                      sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2))
    {
-      LogCSV("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
-             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
+      LogCSVEx("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
       return;
    }
 
@@ -2928,9 +3257,10 @@ void OnTick()
    if(!StopsOk(dir, entry, sl, tp))
    {
       skipMask |= SKIP_STOPS;
-      LogCSV("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
-             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
+      LogCSVEx("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
       return;
    }
 
@@ -2948,15 +3278,17 @@ void OnTick()
       GVSetInt("addCount", 0);
       GVSetDouble("lastAddPrice", entry);
 
-      LogCSV("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
-             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
+      LogCSVEx("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
    }
    else
    {
-      LogCSV("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
-             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
+      LogCSVEx("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
    }
 }
 

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -2,6 +2,13 @@
 //|                                     XAUUSD Killer XM (MT5)       |
 //|   Trend-follow + SMC light - production-safe single file EA      |
 //|                                                                  |
+//| FIXES                                                           |
+//| - Normalize pip/point/tick handling across FX/JPY/indices.       |
+//| - Harden symbol profile detection for XM index variants.         |
+//| - Convert GOLD-tuned distances to profile-aware points.          |
+//| - Fix index key-step units and volume step rounding.             |
+//| - Add tickSize/pipSize to logs and sanity warnings.              |
+//|                                                                  |
 //| CHANGELOG                                                       |
 //| - Added ICT/SMC modules: NY killzones, PD arrays, liquidity      |
 //|   sweeps, displacement, MSS/BOS, order blocks + RTO/MT, and OTE  |
@@ -47,7 +54,7 @@ input PresetMode InpPresetMode = PRESET_CUSTOM;
 
 input string InpSymbolOverride = "";
 input long   InpMagic = 3011;
-input double InpPipPrice = 0.10; // if 0 -> auto Point*10
+input double InpPipPrice = 0.10; // if 0 -> auto pip size (FX/JPY/indices)
 input int    InpMaxSpreadPoints = 35;
 input int    InpMaxSlippagePoints = 35;
 input int    InpMaxRetries = 2;
@@ -215,6 +222,12 @@ input string InpCSVName = "xauusd_killer_v314_xm_gold.csv";
 const int SETUP_MIN = 50;
 const int TIMING_MIN = 15;
 const int TOTAL_MIN = 68;
+
+// XM suggested starting inputs (not optimized; adjust per broker/spread):
+// Profile   | MaxSpreadPts | MaxSlippagePts | SpreadMultiple | SpreadSpikeFactor | Rollover  | Session
+// FX majors | 25-35        | 30-40          | 2.5-3.0        | 1.5-1.8           | 23:55-00:15 | 06-23
+// FX JPY    | 25-40        | 30-50          | 2.5-3.0        | 1.5-1.8           | 23:55-00:15 | 06-23
+// Indices   | 80-150       | 80-150         | 2.0-2.5        | 1.4-1.7           | 23:55-00:15 | 06-23
 
 string g_symbol = "";
 int g_digits = 2;
@@ -485,8 +498,12 @@ SymbolProfile DetectSymbolProfile(const string symbol)
    string symUpper = StringUpper(symbol);
    if(StringFind(symUpper, "XAU") >= 0 || StringFind(symUpper, "GOLD") >= 0)
       return PROFILE_FX_MAJORS_5DIG;
-   string indexTokens[] = {"US30", "DJ30", "US30CASH", "NAS100", "US100", "NAS", "SPX500", "US500", "SP500",
-                           "GER40", "DE40", "DAX", "DAX40", "FTSEMIB", "ITA40", "FTSE", "UK100"};
+   string indexTokens[] = {"US30", "DJ30", "WS30", "US30CASH",
+                           "NAS100", "USTEC", "US100", "NAS",
+                           "SPX500", "US500", "SP500",
+                           "GER40", "DE40", "DAX", "DAX40",
+                           "FTSEMIB", "FTSE_MIB", "ITA40",
+                           "UK100", "FTSE"};
    if(ContainsAny(symUpper, indexTokens))
       return PROFILE_INDICES;
    if(StringFind(symUpper, "JPY") >= 0)
@@ -551,6 +568,23 @@ double PipPrice()
    if(cfg_InpPipPrice > 0.0)
       return cfg_InpPipPrice;
    return g_pip;
+}
+
+double AutoPipSize(bool useOverride)
+{
+   if(useOverride && cfg_InpPipPrice > 0.0)
+      return cfg_InpPipPrice;
+
+   if(g_profile == PROFILE_INDICES)
+   {
+      double tickSize = TickSize();
+      return (tickSize > 0.0) ? tickSize : 1.0;
+   }
+
+   if(g_digits == 3 || g_digits == 5)
+      return g_point * 10.0;
+
+   return g_point;
 }
 
 double SpreadPoints()
@@ -1717,11 +1751,19 @@ double TickValue()
    return tickValue;
 }
 
+double TickSize()
+{
+   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   if(tickSize <= 0.0)
+      tickSize = g_point;
+   return tickSize;
+}
+
 double CalcLots(double slDist, double riskPct)
 {
    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
    double riskMoney = equity * (riskPct / 100.0);
-   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   double tickSize = TickSize();
    double tickValue = TickValue();
    if(tickSize <= 0.0 || tickValue <= 0.0 || slDist <= 0.0)
       return 0.0;
@@ -1749,7 +1791,14 @@ double NormalizeVolumeByStep(double volume)
    double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
    double vol = MathMin(maxLot, MathMax(minLot, volume));
    vol = MathFloor(vol / step) * step;
-   return NormalizeDouble(vol, 2);
+   int decimals = 0;
+   double scaled = step;
+   while(decimals < 8 && MathAbs(scaled - MathRound(scaled)) > 1e-8)
+   {
+      scaled *= 10.0;
+      decimals++;
+   }
+   return NormalizeDouble(vol, decimals);
 }
 
 bool StopsOk(TradeDir dir, double entry, double sl, double tp)
@@ -1834,20 +1883,10 @@ string PresetModeLabel(PresetMode mode);
 void LogPresetConfig();
 void LogSymbolCheck();
 
-double GoldPriceToPips(double price)
-{
-   return price / 0.10;
-}
-
-double GoldPointsToPips(double points)
-{
-   return points / 10.0;
-}
-
 double IndexKeyStepPoints()
 {
    string symUpper = StringUpper(g_symbol);
-   if(StringFind(symUpper, "US30") >= 0 || StringFind(symUpper, "DJ30") >= 0)
+   if(StringFind(symUpper, "US30") >= 0 || StringFind(symUpper, "DJ30") >= 0 || StringFind(symUpper, "WS30") >= 0)
       return 100.0;
    return 50.0;
 }
@@ -1872,7 +1911,7 @@ void ApplyProfileDefaults()
 
    if(g_profile == PROFILE_INDICES)
    {
-      cfg_KeyLevelStepPoints = PointsFromPrice(IndexKeyStepPoints());
+      cfg_KeyLevelStepPoints = IndexKeyStepPoints();
       cfg_KeyNearPoints = PointsFromPrice(5.0);
    }
    else
@@ -1882,36 +1921,36 @@ void ApplyProfileDefaults()
    }
    cfg_KeyChaseMaxDistPoints = cfg_KeyLevelStepPoints * 0.30;
 
-   double slPips = GoldPriceToPips(cfg_InpSL_MinBufferPrice);
-   double bePips = GoldPriceToPips(cfg_InpBE_OffsetPrice);
-   double trailPips = GoldPriceToPips(cfg_InpTrailMinImprovePrice);
-   double fibPips = GoldPriceToPips(cfg_InpFibTolPrice);
-   double pdPips = GoldPriceToPips(cfg_InpMinPDArrayDistance);
-   double mmslExtraPips = GoldPriceToPips(cfg_InpMMSL_ExtraBufferPrice);
-   double eqTolPips = GoldPointsToPips(cfg_InpEqToleranceMinPoints);
-   double pdMinPips = GoldPointsToPips(cfg_InpMinPDArrayMinPoints);
+   double slEquiv = cfg_InpSL_MinBufferPrice / 0.10;
+   double beEquiv = cfg_InpBE_OffsetPrice / 0.10;
+   double trailEquiv = cfg_InpTrailMinImprovePrice / 0.10;
+   double fibEquiv = cfg_InpFibTolPrice / 0.10;
+   double pdEquiv = cfg_InpMinPDArrayDistance / 0.10;
+   double mmslExtraEquiv = cfg_InpMMSL_ExtraBufferPrice / 0.10;
+   double eqTolEquiv = cfg_InpEqToleranceMinPoints / 10.0;
+   double pdMinEquiv = cfg_InpMinPDArrayMinPoints / 10.0;
 
    if(g_profile == PROFILE_INDICES)
    {
-      cfg_SL_MinBufferPoints = PointsFromPrice(slPips);
-      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(mmslExtraPips);
-      cfg_BE_OffsetPoints = PointsFromPrice(bePips);
-      cfg_TrailMinImprovePoints = PointsFromPrice(trailPips);
-      cfg_FibTolPoints = PointsFromPrice(fibPips);
-      cfg_EqToleranceMinPoints = PointsFromPrice(eqTolPips);
-      cfg_MinPDArrayDistancePoints = PointsFromPrice(pdPips);
-      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPrice(pdMinPips));
+      cfg_SL_MinBufferPoints = PointsFromPrice(slEquiv);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(mmslExtraEquiv);
+      cfg_BE_OffsetPoints = PointsFromPrice(beEquiv);
+      cfg_TrailMinImprovePoints = PointsFromPrice(trailEquiv);
+      cfg_FibTolPoints = PointsFromPrice(fibEquiv);
+      cfg_EqToleranceMinPoints = MathRound(PointsFromPrice(eqTolEquiv));
+      cfg_MinPDArrayDistancePoints = PointsFromPrice(pdEquiv);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPrice(pdMinEquiv));
    }
    else
    {
-      cfg_SL_MinBufferPoints = PointsFromPips(slPips);
-      cfg_MMSL_ExtraBufferPoints = PointsFromPips(mmslExtraPips);
-      cfg_BE_OffsetPoints = PointsFromPips(bePips);
-      cfg_TrailMinImprovePoints = PointsFromPips(trailPips);
-      cfg_FibTolPoints = PointsFromPips(fibPips);
-      cfg_EqToleranceMinPoints = PointsFromPips(eqTolPips);
-      cfg_MinPDArrayDistancePoints = PointsFromPips(pdPips);
-      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPips(pdMinPips));
+      cfg_SL_MinBufferPoints = PointsFromPips(slEquiv);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPips(mmslExtraEquiv);
+      cfg_BE_OffsetPoints = PointsFromPips(beEquiv);
+      cfg_TrailMinImprovePoints = PointsFromPips(trailEquiv);
+      cfg_FibTolPoints = PointsFromPips(fibEquiv);
+      cfg_EqToleranceMinPoints = MathRound(PointsFromPips(eqTolEquiv));
+      cfg_MinPDArrayDistancePoints = PointsFromPips(pdEquiv);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPips(pdMinEquiv));
    }
 }
 
@@ -2137,10 +2176,7 @@ void ApplyPreset()
       }
    }
 
-   if(cfg_InpPipPrice > 0.0)
-      g_pip = cfg_InpPipPrice;
-   else
-      g_pip = (g_profile == PROFILE_INDICES) ? 1.0 : g_point * 10.0;
+   g_pip = AutoPipSize(true);
 
    ApplyProfileDefaults();
    LogPresetConfig();
@@ -2163,8 +2199,8 @@ string PresetModeLabel(PresetMode mode)
 void LogPresetConfig()
 {
    Print("Preset applied: ", PresetModeLabel(cfg_InpPresetMode));
-   PrintFormat("Profile: %s Symbol=%s Point=%.5f Pip=%.5f",
-               ProfileName(g_profile), g_symbol, g_point, g_pip);
+   PrintFormat("Profile: %s Symbol=%s Point=%.5f Pip=%.5f TickSize=%.5f",
+               ProfileName(g_profile), g_symbol, g_point, g_pip, TickSize());
    if(cfg_InpUseManualNYOffset)
    {
       string dstNote = cfg_InpAutoNYDST ? "auto DST" : "manual DST";
@@ -2239,9 +2275,12 @@ void LogSymbolCheck()
    string symUpper = StringUpper(g_symbol);
    bool symbolMatch = (StringFind(symUpper, "GOLD") >= 0 || StringFind(symUpper, "XAU") >= 0);
    bool digitsOk = (g_digits == 2 && MathAbs(g_point - 0.01) <= 0.000001);
+   double tickSize = TickSize();
+   double expectedPip = AutoPipSize(false);
 
    Print("Symbol check: symbol=", g_symbol, " profile=", ProfileName(g_profile),
-         " digits=", g_digits, " point=", DoubleToString(g_point, 5), " pip=", DoubleToString(g_pip, 5));
+         " digits=", g_digits, " point=", DoubleToString(g_point, 5),
+         " pip=", DoubleToString(g_pip, 5), " tickSize=", DoubleToString(tickSize, 5));
 
    if(g_isGoldSymbol)
    {
@@ -2250,6 +2289,11 @@ void LogSymbolCheck()
       if(!digitsOk)
          Print("Warning: Unexpected digits/point for GOLD. Expected digits=2 and point=0.01. Verify cfg_InpPipPrice/g_pip.");
    }
+
+   if(tickSize > 0.0 && MathAbs(tickSize - g_point) > 1e-7)
+      Print("Warning: TickSize differs from Point. Using tickSize for risk math where applicable.");
+   if(cfg_InpPipPrice <= 0.0 && MathAbs(g_pip - expectedPip) > 1e-7)
+      Print("Warning: Auto pip size differs from expected calculation. Check symbol digits/override.");
 }
 
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
@@ -2271,7 +2315,7 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
 
    if(FileSize(handle) == 0)
    {
-      FileWrite(handle, "time", "sym", "profile", "point", "pip", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
+      FileWrite(handle, "time", "sym", "profile", "point", "pipSize", "tickSize", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
                 "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
                 "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
                 "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
@@ -2296,6 +2340,7 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
              ProfileName(g_profile),
              DoubleToString(g_point, 5),
              DoubleToString(g_pip, 5),
+             DoubleToString(TickSize(), 5),
              (string)cfg_InpMagic,
              event,
              (int)dir,
@@ -2749,17 +2794,17 @@ int OnInit()
    g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
    g_isGoldSymbol = IsGoldSymbol(g_symbol);
    g_profile = DetectSymbolProfile(g_symbol);
-   g_pip = g_point * 10.0;
 
    ApplyPreset();
 
    trade.SetExpertMagicNumber((uint)cfg_InpMagic);
    trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
 
-   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   double tickSize = TickSize();
    double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
-   Print("Symbol=", g_symbol, " Digits=", g_digits, " Point=", DoubleToString(g_point, 2),
-         " TickSize=", DoubleToString(tickSize, 2), " TickValue=", DoubleToString(tickValue, 2));
+   Print("Symbol=", g_symbol, " Digits=", g_digits, " Point=", DoubleToString(g_point, 5),
+         " Pip=", DoubleToString(g_pip, 5), " TickSize=", DoubleToString(tickSize, 5),
+         " TickValue=", DoubleToString(tickValue, 2));
    LogSymbolCheck();
 
    UpdateDailyReset();

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -19,6 +19,11 @@
 //+------------------------------------------------------------------+
 #property strict
 #include <Trade/Trade.mqh>
+#include <Controls/Dialog.mqh>
+#include <Controls/Label.mqh>
+#include <Controls/Button.mqh>
+#include <Controls/ComboBox.mqh>
+#include <Controls/Edit.mqh>
 
 CTrade trade;
 
@@ -49,6 +54,13 @@ enum SymbolProfile
    PROFILE_FX_MAJORS_5DIG = 0,
    PROFILE_FX_JPY_3DIG = 1,
    PROFILE_INDICES = 2
+};
+
+enum RuntimeMode
+{
+   MODE_SOFT = 0,
+   MODE_NORMAL = 1,
+   MODE_AGGRESSIVE = 2
 };
 
 input PresetMode InpPresetMode = PRESET_CUSTOM;
@@ -255,6 +267,105 @@ bool g_isGoldSymbol = false;
 datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
+bool g_eaEnabled = true;
+bool g_csvEnabledUI = true;
+bool g_panelReady = false;
+RuntimeMode g_runtimeMode = MODE_NORMAL;
+int g_minTotalScoreUI = TOTAL_MIN;
+int g_minDailyScoreUI = 0;
+int g_lastSkipMask = 0;
+int g_lastEntryMask = 0;
+int g_lastSetupScore = 0;
+int g_lastTimingScore = 0;
+int g_lastTotalScore = 0;
+int g_lastDailyScore = 0;
+string g_lastUiEvent = "";
+
+struct RuntimeCfgSnapshot
+{
+   bool initialized;
+   double baseRiskPct;
+   bool usePyramiding;
+   int cooldownBars;
+   double minRRAllowed;
+   double spreadMultiple;
+   double spreadSpikeFactor;
+};
+
+RuntimeCfgSnapshot g_cfgSnapshot;
+
+class CEAPanel : public CAppDialog
+{
+public:
+   CLabel lblTitle, lblStatus, lblScores, lblMarket, lblFilters, lblLast;
+   CButton btnToggleEA, btnToggleCSV;
+   CComboBox cmbMode;
+   CEdit edtMinTotal, edtMinDaily;
+
+   bool CreatePanel(long chart_id)
+   {
+      int x = 10, y = 20, w = 360, h = 185;
+      if(!Create(chart_id, "XK_PANEL", 0, x, y, x + w, y + h))
+         return false;
+
+      lblTitle.Create(m_chart_id, "lblTitle", m_subwin, 10, 5, 340, 20);
+      lblTitle.Text("XAUUSD Killer – Control Panel");
+
+      btnToggleEA.Create(m_chart_id, "btnEA", m_subwin, 10, 28, 110, 22);
+      btnToggleEA.Text("EA: ON");
+
+      btnToggleCSV.Create(m_chart_id, "btnCSV", m_subwin, 125, 28, 110, 22);
+      btnToggleCSV.Text("CSV: ON");
+
+      cmbMode.Create(m_chart_id, "cmbMode", m_subwin, 240, 28, 110, 200);
+      cmbMode.AddItem("Soft", MODE_SOFT);
+      cmbMode.AddItem("Normal", MODE_NORMAL);
+      cmbMode.AddItem("Aggressive", MODE_AGGRESSIVE);
+      cmbMode.SelectByValue(MODE_NORMAL);
+
+      edtMinTotal.Create(m_chart_id, "edtMinTotal", m_subwin, 10, 55, 90, 20);
+      edtMinTotal.Text(IntegerToString(TOTAL_MIN));
+      edtMinDaily.Create(m_chart_id, "edtMinDaily", m_subwin, 125, 55, 90, 20);
+      edtMinDaily.Text("0");
+
+      lblStatus.Create(m_chart_id, "lblStatus", m_subwin, 10, 80, 340, 18);
+      lblScores.Create(m_chart_id, "lblScores", m_subwin, 10, 100, 340, 18);
+      lblMarket.Create(m_chart_id, "lblMarket", m_subwin, 10, 120, 340, 18);
+      lblFilters.Create(m_chart_id, "lblFilters", m_subwin, 10, 140, 340, 18);
+      lblLast.Create(m_chart_id, "lblLast", m_subwin, 10, 160, 340, 18);
+
+      lblStatus.Text("Status: INIT");
+      lblScores.Text("Scores: -");
+      lblMarket.Text("Market: -");
+      lblFilters.Text("Filters: -");
+      lblLast.Text("Last: -");
+
+      Add(lblTitle);
+      Add(btnToggleEA);
+      Add(btnToggleCSV);
+      Add(cmbMode);
+      Add(edtMinTotal);
+      Add(edtMinDaily);
+      Add(lblStatus);
+      Add(lblScores);
+      Add(lblMarket);
+      Add(lblFilters);
+      Add(lblLast);
+
+      return true;
+   }
+
+   void UpdateText(const string status, const string scores, const string market, const string filters, const string last)
+   {
+      lblStatus.Text(status);
+      lblScores.Text(scores);
+      lblMarket.Text(market);
+      lblFilters.Text(filters);
+      lblLast.Text(last);
+   }
+};
+
+CEAPanel g_panel;
 
 // Runtime config (preset-applied)
 PresetMode cfg_InpPresetMode;
@@ -470,6 +581,168 @@ enum EntryMask
 string GVName(const string key)
 {
    return "XK_" + key + "_" + g_symbol + "_" + (string)cfg_InpMagic;
+}
+
+string SkipMaskToText(int mask)
+{
+   if(mask == 0)
+      return "OK";
+   string s = "";
+   if(mask & SKIP_SESSION) s += "SESSION ";
+   if(mask & SKIP_ROLLOVER) s += "ROLLOVER ";
+   if(mask & SKIP_SPREAD) s += "SPREAD ";
+   if(mask & SKIP_SPREAD_MULT) s += "SPREADx ";
+   if(mask & SKIP_SPREAD_INSTAB) s += "SPREAD_SPIKE ";
+   if(mask & SKIP_LOWVOL) s += "LOWVOL ";
+   if(mask & SKIP_DAILY_LOCK) s += "DAILY_LOCK ";
+   if(mask & SKIP_COOLDOWN) s += "COOLDOWN ";
+   if(mask & SKIP_LOSS_BLOCK) s += "LOSS_BLOCK ";
+   if(mask & SKIP_DAILY_MAX) s += "MAX_TRADES ";
+   if(mask & SKIP_DAILY_SCORE) s += "DAILY_SCORE ";
+   if(mask & SKIP_STOPS) s += "STOPS ";
+   if(mask & SKIP_KILLZONE) s += "NO_KZ ";
+   if(mask & SKIP_PDARRAY) s += "PDARRAY ";
+   return s;
+}
+
+string EntryMaskToText(int mask)
+{
+   if(mask == 0)
+      return "NONE";
+   string s = "";
+   if(mask & ENTRY_BIAS) s += "BIAS ";
+   if(mask & ENTRY_PIVOT) s += "PIVOT ";
+   if(mask & ENTRY_HL_LH) s += "HL ";
+   if(mask & ENTRY_BOS_CLOSE) s += "BOS ";
+   if(mask & ENTRY_BOS_RETEST) s += "RETEST ";
+   if(mask & ENTRY_KEYLEVEL) s += "KEY ";
+   if(mask & ENTRY_ANTICHASE) s += "ANTICHASE ";
+   if(mask & ENTRY_FVG) s += "FVG ";
+   if(mask & ENTRY_FIB) s += "FIB ";
+   if(mask & ENTRY_FOOTPRINT) s += "FP ";
+   if(mask & ENTRY_SPIKE) s += "SPIKE ";
+   if(mask & ENTRY_RSI_LOSS) s += "RSI ";
+   if(mask & ENTRY_MMSL) s += "MMSL ";
+   if(mask & ENTRY_RR) s += "RR ";
+   if(mask & ENTRY_KILLZONE) s += "KZ ";
+   if(mask & ENTRY_SWEEP) s += "SWEEP ";
+   if(mask & ENTRY_DISPLACEMENT) s += "DISP ";
+   if(mask & ENTRY_MSS) s += "MSS ";
+   if(mask & ENTRY_OB_RTO) s += "OB ";
+   if(mask & ENTRY_OTE) s += "OTE ";
+   if(mask & ENTRY_PDARRAY) s += "PD ";
+   if(mask & ENTRY_SR) s += "SR ";
+   if(mask & ENTRY_SD) s += "SD ";
+   if(mask & ENTRY_CANDLE) s += "CANDLE ";
+   if(mask & ENTRY_MOM) s += "MOM ";
+   return s;
+}
+
+void CaptureCfgSnapshot()
+{
+   g_cfgSnapshot.initialized = true;
+   g_cfgSnapshot.baseRiskPct = cfg_InpBaseRiskPct;
+   g_cfgSnapshot.usePyramiding = cfg_InpUsePyramiding;
+   g_cfgSnapshot.cooldownBars = cfg_InpCooldownBarsAfterEntry;
+   g_cfgSnapshot.minRRAllowed = cfg_InpMinRRAllowed;
+   g_cfgSnapshot.spreadMultiple = cfg_InpSpreadMultiple;
+   g_cfgSnapshot.spreadSpikeFactor = cfg_InpSpreadSpikeFactor;
+}
+
+void RestoreCfgSnapshot()
+{
+   if(!g_cfgSnapshot.initialized)
+      return;
+   cfg_InpBaseRiskPct = g_cfgSnapshot.baseRiskPct;
+   cfg_InpUsePyramiding = g_cfgSnapshot.usePyramiding;
+   cfg_InpCooldownBarsAfterEntry = g_cfgSnapshot.cooldownBars;
+   cfg_InpMinRRAllowed = g_cfgSnapshot.minRRAllowed;
+   cfg_InpSpreadMultiple = g_cfgSnapshot.spreadMultiple;
+   cfg_InpSpreadSpikeFactor = g_cfgSnapshot.spreadSpikeFactor;
+}
+
+void ApplyRuntimeMode()
+{
+   if(g_panelReady)
+   {
+      g_minTotalScoreUI = MathMax(0, (int)StringToInteger(g_panel.edtMinTotal.Text()));
+      g_minDailyScoreUI = MathMax(0, (int)StringToInteger(g_panel.edtMinDaily.Text()));
+      g_runtimeMode = (RuntimeMode)g_panel.cmbMode.Value();
+   }
+
+   if(g_runtimeMode == MODE_SOFT)
+   {
+      cfg_InpBaseRiskPct = MathMin(cfg_InpBaseRiskPct, 0.7);
+      cfg_InpUsePyramiding = false;
+      cfg_InpCooldownBarsAfterEntry = MathMax(cfg_InpCooldownBarsAfterEntry, 4);
+      cfg_InpMinRRAllowed = MathMax(cfg_InpMinRRAllowed, 1.7);
+   }
+   else if(g_runtimeMode == MODE_AGGRESSIVE)
+   {
+      cfg_InpBaseRiskPct = MathMin(cfg_InpBaseRiskPct, 1.2);
+      cfg_InpUsePyramiding = true;
+      cfg_InpCooldownBarsAfterEntry = MathMin(cfg_InpCooldownBarsAfterEntry, 2);
+      cfg_InpMinRRAllowed = MathMax(cfg_InpMinRRAllowed, 1.5);
+      cfg_InpSpreadMultiple = MathMin(cfg_InpSpreadMultiple, 2.4);
+      cfg_InpSpreadSpikeFactor = MathMin(cfg_InpSpreadSpikeFactor, 1.5);
+   }
+   else
+   {
+      RestoreCfgSnapshot();
+   }
+
+   cfg_InpEnableCSV = g_csvEnabledUI;
+}
+
+void UpdatePanelUI(RegimeState regime, int dailyScore, int setup, int timing, int total)
+{
+   if(!g_panelReady)
+      return;
+
+   TradeDir bias = BiasH1();
+   bool locked = (GVGetInt("dayLocked", 0) == 1);
+   bool lossBlock = LossBlocksActive();
+   string status = "Status: ";
+   if(!g_eaEnabled)
+      status += "PAUSED";
+   else if(locked)
+      status += "LOCKED";
+   else if(lossBlock || g_lastSkipMask != 0)
+      status += "BLOCKED";
+   else
+      status += "RUN";
+
+   string reason = SkipMaskToText(g_lastSkipMask);
+   status += " | " + reason;
+
+   int maxTrades = 0;
+   double riskMult = 0.0;
+   bool pyramidAllowed = false;
+   DailyTradeAllowed(dailyScore, maxTrades, riskMult, pyramidAllowed);
+
+   string scores = StringFormat("Scores: Daily=%d Setup=%d Timing=%d Total=%d | MinTotal=%d MinDaily=%d | MaxTrades=%d RiskMult=%.2f Pyr=%s",
+                                dailyScore, setup, timing, total,
+                                g_minTotalScoreUI, g_minDailyScoreUI,
+                                maxTrades, riskMult, (pyramidAllowed ? "Y" : "N"));
+
+   double adx = ADX(PERIOD_H1, 1);
+   double atr15 = ATR(PERIOD_M15, 1);
+   double spread = SpreadPoints();
+   string market = StringFormat("Market: Regime=%d Bias=%d | ADX=%.1f ATR15=%.2f Spread=%.1f EMA=%.1f",
+                                (int)regime, (int)bias, adx, atr15, spread, g_spreadEma);
+
+   bool kzA = false, kzL = false, kzN = false;
+   bool kzActive = KillzoneActive(kzA, kzL, kzN);
+   datetime nyTime = ToNYTime(TimeCurrent());
+   string filters = StringFormat("Filters: KZ=%s (A:%d L:%d N:%d) NY=%s | CSV=%s | Mode=%d | EntryMask=%s",
+                                 (kzActive ? "ON" : "OFF"), (kzA ? 1 : 0), (kzL ? 1 : 0), (kzN ? 1 : 0),
+                                 TimeToString(nyTime, TIME_MINUTES),
+                                 (cfg_InpEnableCSV ? "ON" : "OFF"), (int)g_runtimeMode,
+                                 EntryMaskToText(g_lastEntryMask));
+
+   string last = "Last: " + g_lastUiEvent;
+
+   g_panel.UpdateText(status, scores, market, filters, last);
 }
 
 double GVGetDouble(const string key, double defval)
@@ -2437,6 +2710,7 @@ void ApplyPreset()
    g_pip = pipSize;
 
    ApplyProfileDefaults();
+   CaptureCfgSnapshot();
    LogPresetConfig();
 }
 
@@ -2575,6 +2849,7 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
               int oteOk, int sdHit, int sdType, double sdDistATR, int sdFresh,
               int candleHit, int candleType, int momHit, double rsi1, double rsi2)
 {
+   g_lastUiEvent = event;
    if(!cfg_InpEnableCSV)
       return;
 
@@ -2936,7 +3211,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
 
 bool ShouldEnterTrade(int setupScore, int timingScore, int totalScore, RegimeState regime)
 {
-   int totalMin = TOTAL_MIN;
+   int totalMin = (g_minTotalScoreUI > 0 ? g_minTotalScoreUI : TOTAL_MIN);
    int lossStreak = GVGetInt("lossStreak", 0);
 
    if(regime == REGIME_TRANSITION)
@@ -3114,6 +3389,7 @@ int OnInit()
    g_profile = DetectSymbolProfile(g_symbol);
 
    ApplyPreset();
+   g_csvEnabledUI = cfg_InpEnableCSV;
 
    trade.SetExpertMagicNumber((uint)cfg_InpMagic);
    trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
@@ -3125,9 +3401,23 @@ int OnInit()
          " TickValue=", DoubleToString(tickValue, 2));
    LogSymbolCheck();
 
+   g_panelReady = g_panel.CreatePanel(ChartID());
+   if(!g_panelReady)
+      Print("Panel create failed");
+   else
+      g_panel.Run();
+   ApplyRuntimeMode();
+   ChartRedraw();
+
    UpdateDailyReset();
 
    return INIT_SUCCEEDED;
+}
+
+void OnDeinit(const int reason)
+{
+   if(g_panelReady)
+      g_panel.Destroy(reason);
 }
 
 void OnTick()
@@ -3156,6 +3446,13 @@ void OnTick()
       double dailyRiskMult = 0.0;
       DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed);
       TryPyramiding(riskR, pyramidAllowed, regime);
+      g_lastSkipMask = SKIP_NONE;
+      g_lastEntryMask = 0;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
+      UpdatePanelUI(regime, dailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
       return;
    }
 
@@ -3163,20 +3460,34 @@ void OnTick()
    if(LossBlocksActive())
    {
       skipMask |= SKIP_LOSS_BLOCK;
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = 0;
+      g_lastDailyScore = DailyScore(regime);
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      UpdatePanelUI(regime, g_lastDailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
       return;
    }
    if(!HardGuardsOk(skipMask))
    {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = 0;
+      g_lastDailyScore = DailyScore(regime);
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      UpdatePanelUI(regime, g_lastDailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
       return;
    }
 
@@ -3185,14 +3496,34 @@ void OnTick()
    int maxTrades = 0;
    double dailyRiskMult = 0.0;
    bool pyramidAllowed = false;
+   if(g_minDailyScoreUI > 0 && dailyScore < g_minDailyScoreUI)
+   {
+      skipMask |= SKIP_DAILY_SCORE;
+      g_lastSkipMask = skipMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
+             0, 0, 0.0, -1, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      UpdatePanelUI(regime, dailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
+      return;
+   }
    if(cfg_InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
    {
       skipMask |= SKIP_DAILY_SCORE;
+      g_lastSkipMask = skipMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      UpdatePanelUI(regime, dailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
       return;
    }
 
@@ -3202,11 +3533,17 @@ void OnTick()
    if(dayTrades >= allowedTrades)
    {
       skipMask |= SKIP_DAILY_MAX;
+      g_lastSkipMask = skipMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = 0;
+      g_lastTimingScore = 0;
+      g_lastTotalScore = 0;
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      UpdatePanelUI(regime, dailyScore, g_lastSetupScore, g_lastTimingScore, g_lastTotalScore);
       return;
    }
 
@@ -3239,28 +3576,72 @@ void OnTick()
                       sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
                       sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2))
    {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
       LogCSVEx("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
                0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
                sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
                sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+      UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
       return;
    }
 
    if(!ShouldEnterTrade(setupScore, timingScore, totalScore, regime))
+   {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
+      UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
       return;
+   }
 
    double riskMult = CurrentRiskMultiplier(dailyRiskMult);
    double lots = CalcLots(riskR, cfg_InpBaseRiskPct * riskMult);
    if(lots <= 0.0)
+   {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
+      UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
       return;
+   }
 
    if(!StopsOk(dir, entry, sl, tp))
    {
       skipMask |= SKIP_STOPS;
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
       LogCSVEx("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
                0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
                sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
                sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+      UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
+      return;
+   }
+
+   if(!g_eaEnabled)
+   {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
+      UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
       return;
    }
 
@@ -3270,6 +3651,12 @@ void OnTick()
 
    if(sent)
    {
+      g_lastSkipMask = SKIP_NONE;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
       GVSetInt("dayTrades", dayTrades + 1);
       GVSetDouble("lastEntryTime", (double)iTime(g_symbol, PERIOD_M15, 0));
       GVSetDouble("origRisk", riskR);
@@ -3285,11 +3672,18 @@ void OnTick()
    }
    else
    {
+      g_lastSkipMask = skipMask;
+      g_lastEntryMask = entryMask;
+      g_lastDailyScore = dailyScore;
+      g_lastSetupScore = setupScore;
+      g_lastTimingScore = timingScore;
+      g_lastTotalScore = totalScore;
       LogCSVEx("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
                retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
                sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
                sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
    }
+   UpdatePanelUI(regime, dailyScore, setupScore, timingScore, totalScore);
 }
 
 void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest &request, const MqlTradeResult &result)
@@ -3319,4 +3713,28 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
    }
+}
+
+void OnChartEvent(const int id, const long &lparam, const double &dparam, const string &sparam)
+{
+   if(g_panelReady)
+      g_panel.ChartEvent(id, lparam, dparam, sparam);
+
+   if(id == CHARTEVENT_OBJECT_CLICK)
+   {
+      if(sparam == "btnEA")
+      {
+         g_eaEnabled = !g_eaEnabled;
+         g_panel.btnToggleEA.Text(g_eaEnabled ? "EA: ON" : "EA: OFF");
+      }
+      else if(sparam == "btnCSV")
+      {
+         g_csvEnabledUI = !g_csvEnabledUI;
+         g_panel.btnToggleCSV.Text(g_csvEnabledUI ? "CSV: ON" : "CSV: OFF");
+      }
+      ApplyRuntimeMode();
+   }
+
+   if(id == CHARTEVENT_OBJECT_ENDEDIT || id == CHARTEVENT_OBJECT_CHANGE)
+      ApplyRuntimeMode();
 }

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -169,6 +169,7 @@ const int TOTAL_MIN = 68;
 string g_symbol = "";
 int g_digits = 2;
 double g_point = 0.01;
+double g_pip = 0.10;
 datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
@@ -262,7 +263,7 @@ double PipPrice()
 {
    if(InpPipPrice > 0.0)
       return InpPipPrice;
-   return g_point * 10.0;
+   return g_pip;
 }
 
 double SpreadPoints()
@@ -504,6 +505,15 @@ bool IsConfirmedPivotLow(int index)
          return false;
    }
    return true;
+}
+
+int BOSAgeBars(double &bosLevel)
+{
+   bosLevel = GVGetDouble("bosLevel", 0.0);
+   datetime bosTime = (datetime)GVGetDouble("bosTime", 0.0);
+   if(bosTime == 0)
+      return -1;
+   return iBarShift(g_symbol, PERIOD_M15, bosTime, true);
 }
 
 bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, double &prevLow)
@@ -805,9 +815,25 @@ bool RSIAfterLossOk(TradeDir dir)
    return false;
 }
 
+bool SelectOurPosition()
+{
+   int total = PositionsTotal();
+   for(int i = 0; i < total; i++)
+   {
+      if(PositionSelectByIndex(i))
+      {
+         string symbol = PositionGetString(POSITION_SYMBOL);
+         long magic = PositionGetInteger(POSITION_MAGIC);
+         if(symbol == g_symbol && magic == InpMagic)
+            return true;
+      }
+   }
+   return false;
+}
+
 bool HasPosition()
 {
-   return PositionSelect(g_symbol);
+   return SelectOurPosition();
 }
 
 bool DailyLossLocked()
@@ -1054,21 +1080,40 @@ double CalcLots(double slDist, double riskPct)
    if(InpMaxLotCap > 0.0)
       maxLot = MathMin(maxLot, InpMaxLotCap);
    lot = MathMin(lot, maxLot);
-   lot = MathFloor(lot / step) * step;
-   return NormalizeDouble(lot, 2);
+   return NormalizeVolumeByStep(lot);
 }
 
-bool StopsOk(double entry, double sl, double tp)
+double NormalizeVolumeByStep(double volume)
+{
+   double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+   double maxLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MAX);
+   double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+   double vol = MathMin(maxLot, MathMax(minLot, volume));
+   vol = MathFloor(vol / step) * step;
+   return NormalizeDouble(vol, 2);
+}
+
+bool StopsOk(TradeDir dir, double entry, double sl, double tp)
 {
    int stopsLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_STOPS_LEVEL);
    if(stopsLevel <= 0)
       return true;
 
    double minDist = stopsLevel * g_point;
-   if(sl > 0.0 && MathAbs(entry - sl) < minDist)
-      return false;
-   if(tp > 0.0 && MathAbs(entry - tp) < minDist)
-      return false;
+   if(dir == DIR_LONG)
+   {
+      if(sl > 0.0 && (sl >= entry || MathAbs(entry - sl) < minDist))
+         return false;
+      if(tp > 0.0 && (tp <= entry || MathAbs(tp - entry) < minDist))
+         return false;
+   }
+   else if(dir == DIR_SHORT)
+   {
+      if(sl > 0.0 && (sl <= entry || MathAbs(entry - sl) < minDist))
+         return false;
+      if(tp > 0.0 && (tp >= entry || MathAbs(tp - entry) < minDist))
+         return false;
+   }
    return true;
 }
 
@@ -1082,8 +1127,52 @@ bool CanModifyStops(double newSl)
    return MathAbs(price - newSl) > freezeLevel * g_point;
 }
 
+bool FreezeOkForClose()
+{
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   if(freezeLevel <= 0)
+      return true;
+   double price = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   return MathAbs(price - entry) > freezeLevel * g_point;
+}
+
+bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+{
+   retcode = 0;
+   lasterr = 0;
+   for(int attempt = 0; attempt <= InpMaxRetries; attempt++)
+   {
+      bool ok = false;
+      ResetLastError();
+      if(dir == DIR_LONG)
+         ok = trade.Buy(lots, g_symbol, 0.0, sl, tp, comment);
+      else if(dir == DIR_SHORT)
+         ok = trade.Sell(lots, g_symbol, 0.0, sl, tp, comment);
+
+      retcode = (int)trade.ResultRetcode();
+      lasterr = (int)GetLastError();
+
+      if(ok)
+         return true;
+
+      if(retcode == TRADE_RETCODE_PRICE_CHANGED ||
+         retcode == TRADE_RETCODE_REQUOTE ||
+         retcode == TRADE_RETCODE_OFF_QUOTES ||
+         retcode == TRADE_RETCODE_TRADE_CONTEXT_BUSY ||
+         retcode == TRADE_RETCODE_SERVER_BUSY)
+      {
+         Sleep(InpRetryDelayMs);
+         continue;
+      }
+      break;
+   }
+   return false;
+}
+
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
-            int dailyScore, int setup, int timing, int total, int skipMask, int entryMask)
+            int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
+            int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey)
 {
    if(!InpEnableCSV)
       return;
@@ -1099,7 +1188,8 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
    {
       FileWrite(handle, "time", "sym", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
                 "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
-                "setup", "timing", "total");
+                "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
+                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price");
    }
 
    int lossStreak = GVGetInt("lossStreak", 0);
@@ -1108,6 +1198,10 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
    double adx = ADX(PERIOD_H1, 1);
    double atrM15 = ATR(PERIOD_M15, 1);
    double atrH1 = ATR(PERIOD_H1, 1);
+
+   double spreadNow = SpreadPoints();
+   int stopsLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_STOPS_LEVEL);
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
 
    FileWrite(handle,
              TimeToString(TimeCurrent(), TIME_DATE|TIME_MINUTES),
@@ -1120,7 +1214,7 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
              DoubleToString(tp, g_digits),
              DoubleToString(tp1, g_digits),
              DoubleToString(lot, 2),
-             DoubleToString(SpreadPoints(), 1),
+             DoubleToString(spreadNow, 1),
              (int)reg,
              (int)bias,
              DoubleToString(adx, 2),
@@ -1132,13 +1226,24 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
              entryMask,
              setup,
              timing,
-             total);
+             total,
+             retcode,
+             lasterr,
+             DoubleToString(g_spreadEma, 2),
+             DoubleToString(spreadNow, 1),
+             stopsLevel,
+             freezeLevel,
+             DoubleToString(bosLevel, g_digits),
+             bosAgeBars,
+             DoubleToString(nearestKey, g_digits),
+             DoubleToString(tp1, g_digits));
 
    FileClose(handle);
 }
 
 bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
-                    int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask)
+                    int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                    double &nearestKey, double &bosLevel, int &bosAgeBars)
 {
    setupScore = 0;
    timingScore = 0;
@@ -1146,6 +1251,9 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    skipMask = 0;
    entryMask = 0;
    dir = DIR_NONE;
+   nearestKey = 0.0;
+   bosLevel = 0.0;
+   bosAgeBars = -1;
 
    TradeDir bias = BiasH1();
    if(bias == DIR_NONE)
@@ -1166,7 +1274,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    setupScore += 10;
    entryMask |= ENTRY_HL_LH;
 
-   double bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
+   bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
    bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
    double atrM15 = ATR(PERIOD_M15, 1);
@@ -1181,16 +1289,18 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    if(brOk)
       entryMask |= ENTRY_BOS_RETEST;
    if(!closeConfirm && !brOk)
+   {
+      bosAgeBars = BOSAgeBars(bosLevel);
       return false;
+   }
    timingScore += 10;
 
    double mid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
-   double nearest = 0.0;
-   if(!KeyLevelNearOk(mid, nearest))
+   if(!KeyLevelNearOk(mid, nearestKey))
       return false;
    entryMask |= ENTRY_KEYLEVEL;
 
-   if(!AntiChaseOk(dir, mid, nearest))
+   if(!AntiChaseOk(dir, mid, nearestKey))
       return false;
    entryMask |= ENTRY_ANTICHASE;
    setupScore += 10;
@@ -1265,6 +1375,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
       }
    }
 
+   bosAgeBars = BOSAgeBars(bosLevel);
    totalScore = setupScore + timingScore;
    return true;
 }
@@ -1289,7 +1400,7 @@ bool ShouldEnterTrade(int setupScore, int timingScore, int totalScore, RegimeSta
 
 void ManagePosition(double riskR)
 {
-   if(!PositionSelect(g_symbol))
+   if(!SelectOurPosition())
       return;
 
    ulong ticket = PositionGetInteger(POSITION_TICKET);
@@ -1307,25 +1418,35 @@ void ManagePosition(double riskR)
    bool tp1done = GVGetInt("tp1done", 0) == 1;
    double tp1price = GVGetDouble("tp1price", 0.0);
 
-   if(InpUseTP1Partial && !tp1done && profitR >= 1.0)
+   bool tp1Hit = false;
+   if(type == POSITION_TYPE_BUY)
+      tp1Hit = (tp1price > 0.0 && SymbolInfoDouble(g_symbol, SYMBOL_BID) >= tp1price);
+   else
+      tp1Hit = (tp1price > 0.0 && SymbolInfoDouble(g_symbol, SYMBOL_ASK) <= tp1price);
+
+   if(InpUseTP1Partial && !tp1done && tp1Hit)
    {
       double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
       double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
       double closeVol = MathFloor((volume * InpTP1_CloseFrac) / step) * step;
-      closeVol = NormalizeDouble(closeVol, 2);
-      if(closeVol >= minLot && (volume - closeVol) >= minLot)
+      closeVol = NormalizeVolumeByStep(closeVol);
+      if(closeVol >= minLot && (volume - closeVol) >= minLot && FreezeOkForClose())
       {
          trade.PositionClosePartial(ticket, closeVol);
          GVSetInt("tp1done", 1);
          GVSetDouble("tp1price", price);
-         LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0);
+         double bosLevel = 0.0;
+         int bosAgeBars = BOSAgeBars(bosLevel);
+         LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0,
+                0, 0, bosLevel, bosAgeBars, 0.0);
       }
    }
 
    if(InpUseSmartBE && profitR >= InpBE_MinProfitR)
    {
       double newSL = (type == POSITION_TYPE_BUY) ? (entry + InpBE_OffsetPrice) : (entry - InpBE_OffsetPrice);
-      if(CanModifyStops(newSL) && StopsOk(entry, newSL, tp) &&
+      TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+      if(CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp) &&
          ((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl)))
          trade.PositionModify(ticket, newSL, tp);
    }
@@ -1336,9 +1457,10 @@ void ManagePosition(double riskR)
       {
          double atr = ATR(PERIOD_M15, 1);
          double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * InpTrailATR_Mult) : (price + atr * InpTrailATR_Mult);
-         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(entry, newSL, tp))
+         TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
-         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(entry, newSL, tp))
+         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
       }
    }
@@ -1348,7 +1470,7 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
 {
    if(!InpUsePyramiding || !pyramidAllowed)
       return;
-   if(!PositionSelect(g_symbol))
+   if(!SelectOurPosition())
       return;
 
    int addCount = GVGetInt("addCount", 0);
@@ -1368,6 +1490,14 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
    double atr = ATR(PERIOD_M15, 1);
    if(MathAbs(price - lastAddPrice) < atr * InpPyramidSpacingATR)
       return;
+
+   if(InpPyramidRequireMainBE)
+   {
+      if(type == POSITION_TYPE_BUY && sl < entry + g_point)
+         return;
+      if(type == POSITION_TYPE_SELL && sl > entry - g_point)
+         return;
+   }
 
    if(InpPyramidOnlyInTrend && regime != REGIME_TREND)
       return;
@@ -1395,20 +1525,23 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
       return;
 
    double addTp = (type == POSITION_TYPE_BUY) ? (price + riskR * InpTP_RR_Main) : (price - riskR * InpTP_RR_Main);
-   if(!StopsOk(price, sl, addTp))
+   TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+   if(!StopsOk(dir, price, sl, addTp))
       return;
 
    bool result = false;
-   if(type == POSITION_TYPE_BUY)
-      result = trade.Buy(addLots, g_symbol, 0.0, sl, addTp, "PYR");
-   else
-      result = trade.Sell(addLots, g_symbol, 0.0, sl, addTp, "PYR");
+   int retcode = 0;
+   int lasterr = 0;
+   result = SendOrderWithRetry(dir, addLots, sl, addTp, "PYR", retcode, lasterr);
 
    if(result)
    {
       GVSetInt("addCount", addCount + 1);
       GVSetDouble("lastAddPrice", price);
-      LogCSV("PYR", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), price, sl, 0.0, 0.0, addLots, 0, 0, 0, 0, 0, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("PYR", dir, price, sl, addTp, 0.0, addLots, 0, 0, 0, 0, 0, 0,
+             retcode, lasterr, bosLevel, bosAgeBars, 0.0);
    }
 }
 
@@ -1417,6 +1550,7 @@ int OnInit()
    g_symbol = ResolveSymbol();
    g_digits = (int)SymbolInfoInteger(g_symbol, SYMBOL_DIGITS);
    g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
+   g_pip = g_point * 10.0;
 
    trade.SetExpertMagicNumber((uint)InpMagic);
    trade.SetDeviationInPoints(InpMaxSlippagePoints);
@@ -1459,12 +1593,18 @@ void OnTick()
    if(LossBlocksActive())
    {
       skipMask |= SKIP_LOSS_BLOCK;
-      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0);
       return;
    }
    if(!HardGuardsOk(skipMask))
    {
-      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0);
       return;
    }
 
@@ -1476,7 +1616,10 @@ void OnTick()
    if(InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
    {
       skipMask |= SKIP_DAILY_SCORE;
-      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0);
       return;
    }
 
@@ -1486,16 +1629,28 @@ void OnTick()
    if(dayTrades >= allowedTrades)
    {
       skipMask |= SKIP_DAILY_MAX;
-      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0);
       return;
    }
 
    TradeDir dir;
    double entry = 0.0, sl = 0.0, tp = 0.0, tp1 = 0.0, riskR = 0.0;
-   int setupScore = 0, timingScore = 0, totalScore = 0, skipMask = 0, entryMask = 0;
+   int setupScore = 0, timingScore = 0, totalScore = 0, entryMask = 0;
+   skipMask = 0;
+   double nearestKey = 0.0;
+   double bosLevel = 0.0;
+   int bosAgeBars = -1;
 
-   if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask))
+   if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask,
+                      nearestKey, bosLevel, bosAgeBars))
+   {
+      LogCSV("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+             0, 0, bosLevel, bosAgeBars, nearestKey);
       return;
+   }
 
    if(!ShouldEnterTrade(setupScore, timingScore, totalScore, regime))
       return;
@@ -1505,18 +1660,17 @@ void OnTick()
    if(lots <= 0.0)
       return;
 
-   if(!StopsOk(entry, sl, tp))
+   if(!StopsOk(dir, entry, sl, tp))
    {
       skipMask |= SKIP_STOPS;
-      LogCSV("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask);
+      LogCSV("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+             0, 0, bosLevel, bosAgeBars, nearestKey);
       return;
    }
 
-   bool sent = false;
-   if(dir == DIR_LONG)
-      sent = trade.Buy(lots, g_symbol, 0.0, sl, tp, "ENTRY");
-   else if(dir == DIR_SHORT)
-      sent = trade.Sell(lots, g_symbol, 0.0, sl, tp, "ENTRY");
+   int retcode = 0;
+   int lasterr = 0;
+   bool sent = SendOrderWithRetry(dir, lots, sl, tp, "ENTRY", retcode, lasterr);
 
    if(sent)
    {
@@ -1528,7 +1682,13 @@ void OnTick()
       GVSetInt("addCount", 0);
       GVSetDouble("lastAddPrice", entry);
 
-      LogCSV("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask);
+      LogCSV("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+             retcode, lasterr, bosLevel, bosAgeBars, nearestKey);
+   }
+   else
+   {
+      LogCSV("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+             retcode, lasterr, bosLevel, bosAgeBars, nearestKey);
    }
 }
 
@@ -1537,6 +1697,8 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
    if(trans.type != TRADE_TRANSACTION_DEAL_ADD)
       return;
    if(trans.symbol != g_symbol)
+      return;
+   if(trans.magic != InpMagic)
       return;
 
    double profit = trans.profit + trans.commission + trans.swap;
@@ -1550,6 +1712,10 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
       GVSetInt("lossStreak", lossStreak);
       UpdateLossBlock(lossStreak);
 
-      LogCSV("EXIT", DIR_NONE, trans.price, 0.0, 0.0, 0.0, trans.volume, DailyScore((RegimeState)GVGetInt("regime", REGIME_RANGE)), 0, 0, 0, 0, 0);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("EXIT", DIR_NONE, trans.price, 0.0, 0.0, 0.0, trans.volume,
+             DailyScore((RegimeState)GVGetInt("regime", REGIME_RANGE)), 0, 0, 0, 0, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0);
    }
 }

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -29,6 +29,15 @@ enum TradeDir
    DIR_SHORT = -1
 };
 
+enum PresetMode
+{
+   PRESET_CUSTOM = 0,
+   PRESET_BALANCED = 1,
+   PRESET_CONSERVATIVE = 2
+};
+
+input PresetMode InpPresetMode = PRESET_CUSTOM;
+
 input string InpSymbolOverride = "";
 input long   InpMagic = 3011;
 input double InpPipPrice = 0.10; // if 0 -> auto Point*10
@@ -52,6 +61,8 @@ input int  InpEndHour = 23;
 input bool InpUseICTTime = true;
 input bool InpUseManualNYOffset = true;
 input int  InpNYOffsetHours = -5;
+input bool InpAutoNYDST = false;
+input int  InpNYOffsetSummerHours = -4;
 input bool InpUseKillzoneAsia = true;
 input bool InpUseKillzoneLondon = true;
 input bool InpUseKillzoneNY = true;
@@ -75,6 +86,7 @@ input int    InpEqClusterMin = 2;
 input int    InpEqScanBars = 40;
 input double InpDisplacementATR = 1.1;
 input double InpDisplacementBodyRatio = 0.55;
+input int    InpDisplacementSearchBars = 4;
 input int    InpOBLookback = 10;
 input int    InpOBMaxAgeBars = 12;
 
@@ -83,6 +95,8 @@ input int    InpOTE_SwingLookback = 48;
 input double InpOTE_Min = 0.62;
 input double InpOTE_Max = 0.79;
 input double InpMinPDArrayDistance = 0.80;
+input double InpMinPDArrayATR = 1.0;
+input int    InpMinPDArrayMinPoints = 80;
 
 input bool   InpUseBreakRetest = true;
 input double InpRetestTolATR = 0.15;
@@ -203,6 +217,267 @@ datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
 
+// Runtime config (preset-applied)
+bool cfg_InpUseSessionFilter;
+int cfg_InpStartHour;
+int cfg_InpEndHour;
+int cfg_InpMaxSpreadPoints;
+int cfg_InpMaxSlippagePoints;
+int cfg_InpMaxRetries;
+int cfg_InpRetryDelayMs;
+bool cfg_InpUseICTTime;
+bool cfg_InpUseManualNYOffset;
+int cfg_InpNYOffsetHours;
+bool cfg_InpAutoNYDST;
+int cfg_InpNYOffsetSummerHours;
+bool cfg_InpUseKillzoneAsia;
+bool cfg_InpUseKillzoneLondon;
+bool cfg_InpUseKillzoneNY;
+int cfg_InpATRPeriod;
+int cfg_InpADXPeriod;
+int cfg_InpRSIPeriod;
+int cfg_InpEMA_Fast;
+int cfg_InpEMA_Slow;
+int cfg_InpRegimeConfirmBarsH1;
+int cfg_InpRegimeLockBarsH1;
+int cfg_InpPivotLen;
+int cfg_InpPivotConfirmBars;
+int cfg_InpMaxBarsAfterBOS;
+double cfg_InpEqToleranceATR;
+double cfg_InpEqToleranceMinPoints;
+int cfg_InpEqClusterMin;
+int cfg_InpEqScanBars;
+double cfg_InpDisplacementATR;
+double cfg_InpDisplacementBodyRatio;
+int cfg_InpDisplacementSearchBars;
+int cfg_InpOBLookback;
+int cfg_InpOBMaxAgeBars;
+ENUM_TIMEFRAMES cfg_InpOTE_HTF;
+int cfg_InpOTE_SwingLookback;
+double cfg_InpOTE_Min;
+double cfg_InpOTE_Max;
+double cfg_InpMinPDArrayDistance;
+double cfg_InpMinPDArrayATR;
+int cfg_InpMinPDArrayMinPoints;
+bool cfg_InpUseBreakRetest;
+double cfg_InpRetestTolATR;
+double cfg_InpKeyLevelStepPrice;
+double cfg_InpKeyNearPrice;
+double cfg_InpKeyChaseMaxDistPrice;
+bool cfg_InpUseFVGFeature;
+int cfg_InpFVGScanBars;
+double cfg_InpFVGMaxDistATR;
+bool cfg_InpUseFibFilter;
+double cfg_InpFibBaseMin;
+double cfg_InpFibBaseMax;
+double cfg_InpFibTolPrice;
+bool cfg_InpUseOTEBonus;
+double cfg_InpOTEMin;
+double cfg_InpOTEMax;
+int cfg_InpOTEBonusPoints;
+bool cfg_InpUseFootprintProxy;
+int cfg_InpFP_VolMAPeriod;
+double cfg_InpFP_VolSpikeRatio;
+double cfg_InpFP_BodyMinRatio;
+double cfg_InpFP_CloseSideMin;
+double cfg_InpFP_AbsorpVolRatio;
+double cfg_InpFP_AbsorpRangeATR;
+bool cfg_InpFP_RequireAcceptance;
+int cfg_InpFP_ScoreBonus;
+bool cfg_InpUseSpikeGuard;
+double cfg_InpSpikeMultATR;
+double cfg_InpSL_ATR_Mult;
+double cfg_InpSL_MinBufferPrice;
+bool cfg_InpUseMMSL;
+int cfg_InpMMSL_Pips;
+double cfg_InpMMSL_ExtraBufferPrice;
+double cfg_InpTP_RR_Main;
+double cfg_InpMinRRAllowed;
+bool cfg_InpUseTP1Partial;
+double cfg_InpTP1_CloseFrac;
+bool cfg_InpTP1_UseKeyLevelFirst;
+bool cfg_InpUseSmartBE;
+double cfg_InpBE_MinProfitR;
+double cfg_InpBE_OffsetPrice;
+bool cfg_InpUseATRTrailAfterTP1;
+double cfg_InpTrailATR_Mult;
+double cfg_InpTrailMinImprovePrice;
+bool cfg_InpTrailOnNewBarOnly;
+double cfg_InpBaseRiskPct;
+double cfg_InpMaxLotCap;
+bool cfg_InpUseLowVolFilter;
+ENUM_TIMEFRAMES cfg_InpVolTF;
+int cfg_InpVolMAPeriod;
+double cfg_InpLowVolFactor;
+bool cfg_InpUseSpreadMultiple;
+double cfg_InpSpreadMultiple;
+int cfg_InpSpreadMultipleBlockMin;
+bool cfg_InpUseSpreadInstability;
+int cfg_InpSpreadAvgBarsH1;
+double cfg_InpSpreadSpikeFactor;
+int cfg_InpSpreadSpikeBlockMin;
+bool cfg_InpUseRolloverBlock;
+string cfg_InpRolloverStart;
+string cfg_InpRolloverEnd;
+bool cfg_InpUseDailyTradeControl;
+int cfg_InpHardMaxTradesPerDay;
+bool cfg_InpUseMaxDailyLossLock;
+double cfg_InpMaxDailyLossPct;
+bool cfg_InpUseSoftEquityLock;
+double cfg_InpSoftEqTrigger1;
+double cfg_InpSoftEqFloor1;
+double cfg_InpSoftEqTrigger2;
+double cfg_InpSoftEqFloor2;
+int cfg_InpCooldownBarsAfterEntry;
+bool cfg_InpUseAntiChop;
+int cfg_InpLossBlock2_Hours;
+int cfg_InpLossBlock3_Hours;
+double cfg_InpRiskMultAfter3Loss;
+int cfg_InpRiskCutAfter3Loss_H;
+bool cfg_InpUseRSIAfterLoss;
+int cfg_InpLossStreakForRSI;
+bool cfg_InpUsePyramiding;
+int cfg_InpMaxAdds;
+double cfg_InpPyramidMinProfitR;
+bool cfg_InpPyramidRequireMainBE;
+double cfg_InpPyramidSpacingATR;
+bool cfg_InpPyramidOnlyInTrend;
+bool cfg_InpPyramidRequireAdxRising;
+bool cfg_InpPyramidUsePeakDDCap;
+double cfg_InpPyramidMaxPeakDDPct;
+double cfg_InpAddRiskMult1;
+double cfg_InpAddRiskMult2;
+
+#define InpUseSessionFilter cfg_InpUseSessionFilter
+#define InpStartHour cfg_InpStartHour
+#define InpEndHour cfg_InpEndHour
+#define InpMaxSpreadPoints cfg_InpMaxSpreadPoints
+#define InpMaxSlippagePoints cfg_InpMaxSlippagePoints
+#define InpMaxRetries cfg_InpMaxRetries
+#define InpRetryDelayMs cfg_InpRetryDelayMs
+#define InpUseICTTime cfg_InpUseICTTime
+#define InpUseManualNYOffset cfg_InpUseManualNYOffset
+#define InpNYOffsetHours cfg_InpNYOffsetHours
+#define InpAutoNYDST cfg_InpAutoNYDST
+#define InpNYOffsetSummerHours cfg_InpNYOffsetSummerHours
+#define InpUseKillzoneAsia cfg_InpUseKillzoneAsia
+#define InpUseKillzoneLondon cfg_InpUseKillzoneLondon
+#define InpUseKillzoneNY cfg_InpUseKillzoneNY
+#define InpATRPeriod cfg_InpATRPeriod
+#define InpADXPeriod cfg_InpADXPeriod
+#define InpRSIPeriod cfg_InpRSIPeriod
+#define InpEMA_Fast cfg_InpEMA_Fast
+#define InpEMA_Slow cfg_InpEMA_Slow
+#define InpRegimeConfirmBarsH1 cfg_InpRegimeConfirmBarsH1
+#define InpRegimeLockBarsH1 cfg_InpRegimeLockBarsH1
+#define InpPivotLen cfg_InpPivotLen
+#define InpPivotConfirmBars cfg_InpPivotConfirmBars
+#define InpMaxBarsAfterBOS cfg_InpMaxBarsAfterBOS
+#define InpEqToleranceATR cfg_InpEqToleranceATR
+#define InpEqToleranceMinPoints cfg_InpEqToleranceMinPoints
+#define InpEqClusterMin cfg_InpEqClusterMin
+#define InpEqScanBars cfg_InpEqScanBars
+#define InpDisplacementATR cfg_InpDisplacementATR
+#define InpDisplacementBodyRatio cfg_InpDisplacementBodyRatio
+#define InpDisplacementSearchBars cfg_InpDisplacementSearchBars
+#define InpOBLookback cfg_InpOBLookback
+#define InpOBMaxAgeBars cfg_InpOBMaxAgeBars
+#define InpOTE_HTF cfg_InpOTE_HTF
+#define InpOTE_SwingLookback cfg_InpOTE_SwingLookback
+#define InpOTE_Min cfg_InpOTE_Min
+#define InpOTE_Max cfg_InpOTE_Max
+#define InpMinPDArrayDistance cfg_InpMinPDArrayDistance
+#define InpMinPDArrayATR cfg_InpMinPDArrayATR
+#define InpMinPDArrayMinPoints cfg_InpMinPDArrayMinPoints
+#define InpUseBreakRetest cfg_InpUseBreakRetest
+#define InpRetestTolATR cfg_InpRetestTolATR
+#define InpKeyLevelStepPrice cfg_InpKeyLevelStepPrice
+#define InpKeyNearPrice cfg_InpKeyNearPrice
+#define InpKeyChaseMaxDistPrice cfg_InpKeyChaseMaxDistPrice
+#define InpUseFVGFeature cfg_InpUseFVGFeature
+#define InpFVGScanBars cfg_InpFVGScanBars
+#define InpFVGMaxDistATR cfg_InpFVGMaxDistATR
+#define InpUseFibFilter cfg_InpUseFibFilter
+#define InpFibBaseMin cfg_InpFibBaseMin
+#define InpFibBaseMax cfg_InpFibBaseMax
+#define InpFibTolPrice cfg_InpFibTolPrice
+#define InpUseOTEBonus cfg_InpUseOTEBonus
+#define InpOTEMin cfg_InpOTEMin
+#define InpOTEMax cfg_InpOTEMax
+#define InpOTEBonusPoints cfg_InpOTEBonusPoints
+#define InpUseFootprintProxy cfg_InpUseFootprintProxy
+#define InpFP_VolMAPeriod cfg_InpFP_VolMAPeriod
+#define InpFP_VolSpikeRatio cfg_InpFP_VolSpikeRatio
+#define InpFP_BodyMinRatio cfg_InpFP_BodyMinRatio
+#define InpFP_CloseSideMin cfg_InpFP_CloseSideMin
+#define InpFP_AbsorpVolRatio cfg_InpFP_AbsorpVolRatio
+#define InpFP_AbsorpRangeATR cfg_InpFP_AbsorpRangeATR
+#define InpFP_RequireAcceptance cfg_InpFP_RequireAcceptance
+#define InpFP_ScoreBonus cfg_InpFP_ScoreBonus
+#define InpUseSpikeGuard cfg_InpUseSpikeGuard
+#define InpSpikeMultATR cfg_InpSpikeMultATR
+#define InpSL_ATR_Mult cfg_InpSL_ATR_Mult
+#define InpSL_MinBufferPrice cfg_InpSL_MinBufferPrice
+#define InpUseMMSL cfg_InpUseMMSL
+#define InpMMSL_Pips cfg_InpMMSL_Pips
+#define InpMMSL_ExtraBufferPrice cfg_InpMMSL_ExtraBufferPrice
+#define InpTP_RR_Main cfg_InpTP_RR_Main
+#define InpMinRRAllowed cfg_InpMinRRAllowed
+#define InpUseTP1Partial cfg_InpUseTP1Partial
+#define InpTP1_CloseFrac cfg_InpTP1_CloseFrac
+#define InpTP1_UseKeyLevelFirst cfg_InpTP1_UseKeyLevelFirst
+#define InpUseSmartBE cfg_InpUseSmartBE
+#define InpBE_MinProfitR cfg_InpBE_MinProfitR
+#define InpBE_OffsetPrice cfg_InpBE_OffsetPrice
+#define InpUseATRTrailAfterTP1 cfg_InpUseATRTrailAfterTP1
+#define InpTrailATR_Mult cfg_InpTrailATR_Mult
+#define InpTrailMinImprovePrice cfg_InpTrailMinImprovePrice
+#define InpTrailOnNewBarOnly cfg_InpTrailOnNewBarOnly
+#define InpBaseRiskPct cfg_InpBaseRiskPct
+#define InpMaxLotCap cfg_InpMaxLotCap
+#define InpUseLowVolFilter cfg_InpUseLowVolFilter
+#define InpVolTF cfg_InpVolTF
+#define InpVolMAPeriod cfg_InpVolMAPeriod
+#define InpLowVolFactor cfg_InpLowVolFactor
+#define InpUseSpreadMultiple cfg_InpUseSpreadMultiple
+#define InpSpreadMultiple cfg_InpSpreadMultiple
+#define InpSpreadMultipleBlockMin cfg_InpSpreadMultipleBlockMin
+#define InpUseSpreadInstability cfg_InpUseSpreadInstability
+#define InpSpreadAvgBarsH1 cfg_InpSpreadAvgBarsH1
+#define InpSpreadSpikeFactor cfg_InpSpreadSpikeFactor
+#define InpSpreadSpikeBlockMin cfg_InpSpreadSpikeBlockMin
+#define InpUseRolloverBlock cfg_InpUseRolloverBlock
+#define InpRolloverStart cfg_InpRolloverStart
+#define InpRolloverEnd cfg_InpRolloverEnd
+#define InpUseDailyTradeControl cfg_InpUseDailyTradeControl
+#define InpHardMaxTradesPerDay cfg_InpHardMaxTradesPerDay
+#define InpUseMaxDailyLossLock cfg_InpUseMaxDailyLossLock
+#define InpMaxDailyLossPct cfg_InpMaxDailyLossPct
+#define InpUseSoftEquityLock cfg_InpUseSoftEquityLock
+#define InpSoftEqTrigger1 cfg_InpSoftEqTrigger1
+#define InpSoftEqFloor1 cfg_InpSoftEqFloor1
+#define InpSoftEqTrigger2 cfg_InpSoftEqTrigger2
+#define InpSoftEqFloor2 cfg_InpSoftEqFloor2
+#define InpCooldownBarsAfterEntry cfg_InpCooldownBarsAfterEntry
+#define InpUseAntiChop cfg_InpUseAntiChop
+#define InpLossBlock2_Hours cfg_InpLossBlock2_Hours
+#define InpLossBlock3_Hours cfg_InpLossBlock3_Hours
+#define InpRiskMultAfter3Loss cfg_InpRiskMultAfter3Loss
+#define InpRiskCutAfter3Loss_H cfg_InpRiskCutAfter3Loss_H
+#define InpUseRSIAfterLoss cfg_InpUseRSIAfterLoss
+#define InpLossStreakForRSI cfg_InpLossStreakForRSI
+#define InpUsePyramiding cfg_InpUsePyramiding
+#define InpMaxAdds cfg_InpMaxAdds
+#define InpPyramidMinProfitR cfg_InpPyramidMinProfitR
+#define InpPyramidRequireMainBE cfg_InpPyramidRequireMainBE
+#define InpPyramidSpacingATR cfg_InpPyramidSpacingATR
+#define InpPyramidOnlyInTrend cfg_InpPyramidOnlyInTrend
+#define InpPyramidRequireAdxRising cfg_InpPyramidRequireAdxRising
+#define InpPyramidUsePeakDDCap cfg_InpPyramidUsePeakDDCap
+#define InpPyramidMaxPeakDDPct cfg_InpPyramidMaxPeakDDPct
+#define InpAddRiskMult1 cfg_InpAddRiskMult1
+#define InpAddRiskMult2 cfg_InpAddRiskMult2
+
 enum SkipMask
 {
    SKIP_NONE = 0,
@@ -319,6 +594,17 @@ int MinutesOfDay(datetime t)
    return dt.hour * 60 + dt.min;
 }
 
+int EffectiveNYOffsetHours()
+{
+   if(!InpAutoNYDST)
+      return InpNYOffsetHours;
+   MqlDateTime dt;
+   TimeToStruct(TimeGMT(), dt);
+   if(dt.mon >= 3 && dt.mon <= 11)
+      return InpNYOffsetSummerHours;
+   return InpNYOffsetHours;
+}
+
 int GetServerUtcOffsetSeconds()
 {
    return (int)(TimeTradeServer() - TimeGMT());
@@ -327,7 +613,7 @@ int GetServerUtcOffsetSeconds()
 datetime ToNYTime(datetime serverTime)
 {
    int serverOffset = GetServerUtcOffsetSeconds();
-   int nyOffset = InpUseManualNYOffset ? (InpNYOffsetHours * 3600) : (-5 * 3600);
+   int nyOffset = InpUseManualNYOffset ? (EffectiveNYOffsetHours() * 3600) : (-5 * 3600);
    return serverTime - serverOffset + nyOffset;
 }
 
@@ -1478,6 +1764,589 @@ bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const s
    return false;
 }
 
+#undef InpUseSessionFilter
+#undef InpStartHour
+#undef InpEndHour
+#undef InpMaxSpreadPoints
+#undef InpMaxSlippagePoints
+#undef InpMaxRetries
+#undef InpRetryDelayMs
+#undef InpUseICTTime
+#undef InpUseManualNYOffset
+#undef InpNYOffsetHours
+#undef InpAutoNYDST
+#undef InpNYOffsetSummerHours
+#undef InpUseKillzoneAsia
+#undef InpUseKillzoneLondon
+#undef InpUseKillzoneNY
+#undef InpATRPeriod
+#undef InpADXPeriod
+#undef InpRSIPeriod
+#undef InpEMA_Fast
+#undef InpEMA_Slow
+#undef InpRegimeConfirmBarsH1
+#undef InpRegimeLockBarsH1
+#undef InpPivotLen
+#undef InpPivotConfirmBars
+#undef InpMaxBarsAfterBOS
+#undef InpEqToleranceATR
+#undef InpEqToleranceMinPoints
+#undef InpEqClusterMin
+#undef InpEqScanBars
+#undef InpDisplacementATR
+#undef InpDisplacementBodyRatio
+#undef InpDisplacementSearchBars
+#undef InpOBLookback
+#undef InpOBMaxAgeBars
+#undef InpOTE_HTF
+#undef InpOTE_SwingLookback
+#undef InpOTE_Min
+#undef InpOTE_Max
+#undef InpMinPDArrayDistance
+#undef InpMinPDArrayATR
+#undef InpMinPDArrayMinPoints
+#undef InpUseBreakRetest
+#undef InpRetestTolATR
+#undef InpKeyLevelStepPrice
+#undef InpKeyNearPrice
+#undef InpKeyChaseMaxDistPrice
+#undef InpUseFVGFeature
+#undef InpFVGScanBars
+#undef InpFVGMaxDistATR
+#undef InpUseFibFilter
+#undef InpFibBaseMin
+#undef InpFibBaseMax
+#undef InpFibTolPrice
+#undef InpUseOTEBonus
+#undef InpOTEMin
+#undef InpOTEMax
+#undef InpOTEBonusPoints
+#undef InpUseFootprintProxy
+#undef InpFP_VolMAPeriod
+#undef InpFP_VolSpikeRatio
+#undef InpFP_BodyMinRatio
+#undef InpFP_CloseSideMin
+#undef InpFP_AbsorpVolRatio
+#undef InpFP_AbsorpRangeATR
+#undef InpFP_RequireAcceptance
+#undef InpFP_ScoreBonus
+#undef InpUseSpikeGuard
+#undef InpSpikeMultATR
+#undef InpSL_ATR_Mult
+#undef InpSL_MinBufferPrice
+#undef InpUseMMSL
+#undef InpMMSL_Pips
+#undef InpMMSL_ExtraBufferPrice
+#undef InpTP_RR_Main
+#undef InpMinRRAllowed
+#undef InpUseTP1Partial
+#undef InpTP1_CloseFrac
+#undef InpTP1_UseKeyLevelFirst
+#undef InpUseSmartBE
+#undef InpBE_MinProfitR
+#undef InpBE_OffsetPrice
+#undef InpUseATRTrailAfterTP1
+#undef InpTrailATR_Mult
+#undef InpTrailMinImprovePrice
+#undef InpTrailOnNewBarOnly
+#undef InpBaseRiskPct
+#undef InpMaxLotCap
+#undef InpUseLowVolFilter
+#undef InpVolTF
+#undef InpVolMAPeriod
+#undef InpLowVolFactor
+#undef InpUseSpreadMultiple
+#undef InpSpreadMultiple
+#undef InpSpreadMultipleBlockMin
+#undef InpUseSpreadInstability
+#undef InpSpreadAvgBarsH1
+#undef InpSpreadSpikeFactor
+#undef InpSpreadSpikeBlockMin
+#undef InpUseRolloverBlock
+#undef InpRolloverStart
+#undef InpRolloverEnd
+#undef InpUseDailyTradeControl
+#undef InpHardMaxTradesPerDay
+#undef InpUseMaxDailyLossLock
+#undef InpMaxDailyLossPct
+#undef InpUseSoftEquityLock
+#undef InpSoftEqTrigger1
+#undef InpSoftEqFloor1
+#undef InpSoftEqTrigger2
+#undef InpSoftEqFloor2
+#undef InpCooldownBarsAfterEntry
+#undef InpUseAntiChop
+#undef InpLossBlock2_Hours
+#undef InpLossBlock3_Hours
+#undef InpRiskMultAfter3Loss
+#undef InpRiskCutAfter3Loss_H
+#undef InpUseRSIAfterLoss
+#undef InpLossStreakForRSI
+#undef InpUsePyramiding
+#undef InpMaxAdds
+#undef InpPyramidMinProfitR
+#undef InpPyramidRequireMainBE
+#undef InpPyramidSpacingATR
+#undef InpPyramidOnlyInTrend
+#undef InpPyramidRequireAdxRising
+#undef InpPyramidUsePeakDDCap
+#undef InpPyramidMaxPeakDDPct
+#undef InpAddRiskMult1
+#undef InpAddRiskMult2
+
+string PresetModeLabel(PresetMode mode);
+void LogPresetConfig();
+void LogSymbolCheck();
+
+void ApplyPreset()
+{
+   cfg_InpUseSessionFilter = InpUseSessionFilter;
+   cfg_InpStartHour = InpStartHour;
+   cfg_InpEndHour = InpEndHour;
+   cfg_InpMaxSpreadPoints = InpMaxSpreadPoints;
+   cfg_InpMaxSlippagePoints = InpMaxSlippagePoints;
+   cfg_InpMaxRetries = InpMaxRetries;
+   cfg_InpRetryDelayMs = InpRetryDelayMs;
+   cfg_InpUseICTTime = InpUseICTTime;
+   cfg_InpUseManualNYOffset = InpUseManualNYOffset;
+   cfg_InpNYOffsetHours = InpNYOffsetHours;
+   cfg_InpAutoNYDST = InpAutoNYDST;
+   cfg_InpNYOffsetSummerHours = InpNYOffsetSummerHours;
+   cfg_InpUseKillzoneAsia = InpUseKillzoneAsia;
+   cfg_InpUseKillzoneLondon = InpUseKillzoneLondon;
+   cfg_InpUseKillzoneNY = InpUseKillzoneNY;
+   cfg_InpATRPeriod = InpATRPeriod;
+   cfg_InpADXPeriod = InpADXPeriod;
+   cfg_InpRSIPeriod = InpRSIPeriod;
+   cfg_InpEMA_Fast = InpEMA_Fast;
+   cfg_InpEMA_Slow = InpEMA_Slow;
+   cfg_InpRegimeConfirmBarsH1 = InpRegimeConfirmBarsH1;
+   cfg_InpRegimeLockBarsH1 = InpRegimeLockBarsH1;
+   cfg_InpPivotLen = InpPivotLen;
+   cfg_InpPivotConfirmBars = InpPivotConfirmBars;
+   cfg_InpMaxBarsAfterBOS = InpMaxBarsAfterBOS;
+   cfg_InpEqToleranceATR = InpEqToleranceATR;
+   cfg_InpEqToleranceMinPoints = InpEqToleranceMinPoints;
+   cfg_InpEqClusterMin = InpEqClusterMin;
+   cfg_InpEqScanBars = InpEqScanBars;
+   cfg_InpDisplacementATR = InpDisplacementATR;
+   cfg_InpDisplacementBodyRatio = InpDisplacementBodyRatio;
+   cfg_InpDisplacementSearchBars = InpDisplacementSearchBars;
+   cfg_InpOBLookback = InpOBLookback;
+   cfg_InpOBMaxAgeBars = InpOBMaxAgeBars;
+   cfg_InpOTE_HTF = InpOTE_HTF;
+   cfg_InpOTE_SwingLookback = InpOTE_SwingLookback;
+   cfg_InpOTE_Min = InpOTE_Min;
+   cfg_InpOTE_Max = InpOTE_Max;
+   cfg_InpMinPDArrayDistance = InpMinPDArrayDistance;
+   cfg_InpMinPDArrayATR = InpMinPDArrayATR;
+   cfg_InpMinPDArrayMinPoints = InpMinPDArrayMinPoints;
+   cfg_InpUseBreakRetest = InpUseBreakRetest;
+   cfg_InpRetestTolATR = InpRetestTolATR;
+   cfg_InpKeyLevelStepPrice = InpKeyLevelStepPrice;
+   cfg_InpKeyNearPrice = InpKeyNearPrice;
+   cfg_InpKeyChaseMaxDistPrice = InpKeyChaseMaxDistPrice;
+   cfg_InpUseFVGFeature = InpUseFVGFeature;
+   cfg_InpFVGScanBars = InpFVGScanBars;
+   cfg_InpFVGMaxDistATR = InpFVGMaxDistATR;
+   cfg_InpUseFibFilter = InpUseFibFilter;
+   cfg_InpFibBaseMin = InpFibBaseMin;
+   cfg_InpFibBaseMax = InpFibBaseMax;
+   cfg_InpFibTolPrice = InpFibTolPrice;
+   cfg_InpUseOTEBonus = InpUseOTEBonus;
+   cfg_InpOTEMin = InpOTEMin;
+   cfg_InpOTEMax = InpOTEMax;
+   cfg_InpOTEBonusPoints = InpOTEBonusPoints;
+   cfg_InpUseFootprintProxy = InpUseFootprintProxy;
+   cfg_InpFP_VolMAPeriod = InpFP_VolMAPeriod;
+   cfg_InpFP_VolSpikeRatio = InpFP_VolSpikeRatio;
+   cfg_InpFP_BodyMinRatio = InpFP_BodyMinRatio;
+   cfg_InpFP_CloseSideMin = InpFP_CloseSideMin;
+   cfg_InpFP_AbsorpVolRatio = InpFP_AbsorpVolRatio;
+   cfg_InpFP_AbsorpRangeATR = InpFP_AbsorpRangeATR;
+   cfg_InpFP_RequireAcceptance = InpFP_RequireAcceptance;
+   cfg_InpFP_ScoreBonus = InpFP_ScoreBonus;
+   cfg_InpUseSpikeGuard = InpUseSpikeGuard;
+   cfg_InpSpikeMultATR = InpSpikeMultATR;
+   cfg_InpSL_ATR_Mult = InpSL_ATR_Mult;
+   cfg_InpSL_MinBufferPrice = InpSL_MinBufferPrice;
+   cfg_InpUseMMSL = InpUseMMSL;
+   cfg_InpMMSL_Pips = InpMMSL_Pips;
+   cfg_InpMMSL_ExtraBufferPrice = InpMMSL_ExtraBufferPrice;
+   cfg_InpTP_RR_Main = InpTP_RR_Main;
+   cfg_InpMinRRAllowed = InpMinRRAllowed;
+   cfg_InpUseTP1Partial = InpUseTP1Partial;
+   cfg_InpTP1_CloseFrac = InpTP1_CloseFrac;
+   cfg_InpTP1_UseKeyLevelFirst = InpTP1_UseKeyLevelFirst;
+   cfg_InpUseSmartBE = InpUseSmartBE;
+   cfg_InpBE_MinProfitR = InpBE_MinProfitR;
+   cfg_InpBE_OffsetPrice = InpBE_OffsetPrice;
+   cfg_InpUseATRTrailAfterTP1 = InpUseATRTrailAfterTP1;
+   cfg_InpTrailATR_Mult = InpTrailATR_Mult;
+   cfg_InpTrailMinImprovePrice = InpTrailMinImprovePrice;
+   cfg_InpTrailOnNewBarOnly = InpTrailOnNewBarOnly;
+   cfg_InpBaseRiskPct = InpBaseRiskPct;
+   cfg_InpMaxLotCap = InpMaxLotCap;
+   cfg_InpUseLowVolFilter = InpUseLowVolFilter;
+   cfg_InpVolTF = InpVolTF;
+   cfg_InpVolMAPeriod = InpVolMAPeriod;
+   cfg_InpLowVolFactor = InpLowVolFactor;
+   cfg_InpUseSpreadMultiple = InpUseSpreadMultiple;
+   cfg_InpSpreadMultiple = InpSpreadMultiple;
+   cfg_InpSpreadMultipleBlockMin = InpSpreadMultipleBlockMin;
+   cfg_InpUseSpreadInstability = InpUseSpreadInstability;
+   cfg_InpSpreadAvgBarsH1 = InpSpreadAvgBarsH1;
+   cfg_InpSpreadSpikeFactor = InpSpreadSpikeFactor;
+   cfg_InpSpreadSpikeBlockMin = InpSpreadSpikeBlockMin;
+   cfg_InpUseRolloverBlock = InpUseRolloverBlock;
+   cfg_InpRolloverStart = InpRolloverStart;
+   cfg_InpRolloverEnd = InpRolloverEnd;
+   cfg_InpUseDailyTradeControl = InpUseDailyTradeControl;
+   cfg_InpHardMaxTradesPerDay = InpHardMaxTradesPerDay;
+   cfg_InpUseMaxDailyLossLock = InpUseMaxDailyLossLock;
+   cfg_InpMaxDailyLossPct = InpMaxDailyLossPct;
+   cfg_InpUseSoftEquityLock = InpUseSoftEquityLock;
+   cfg_InpSoftEqTrigger1 = InpSoftEqTrigger1;
+   cfg_InpSoftEqFloor1 = InpSoftEqFloor1;
+   cfg_InpSoftEqTrigger2 = InpSoftEqTrigger2;
+   cfg_InpSoftEqFloor2 = InpSoftEqFloor2;
+   cfg_InpCooldownBarsAfterEntry = InpCooldownBarsAfterEntry;
+   cfg_InpUseAntiChop = InpUseAntiChop;
+   cfg_InpLossBlock2_Hours = InpLossBlock2_Hours;
+   cfg_InpLossBlock3_Hours = InpLossBlock3_Hours;
+   cfg_InpRiskMultAfter3Loss = InpRiskMultAfter3Loss;
+   cfg_InpRiskCutAfter3Loss_H = InpRiskCutAfter3Loss_H;
+   cfg_InpUseRSIAfterLoss = InpUseRSIAfterLoss;
+   cfg_InpLossStreakForRSI = InpLossStreakForRSI;
+   cfg_InpUsePyramiding = InpUsePyramiding;
+   cfg_InpMaxAdds = InpMaxAdds;
+   cfg_InpPyramidMinProfitR = InpPyramidMinProfitR;
+   cfg_InpPyramidRequireMainBE = InpPyramidRequireMainBE;
+   cfg_InpPyramidSpacingATR = InpPyramidSpacingATR;
+   cfg_InpPyramidOnlyInTrend = InpPyramidOnlyInTrend;
+   cfg_InpPyramidRequireAdxRising = InpPyramidRequireAdxRising;
+   cfg_InpPyramidUsePeakDDCap = InpPyramidUsePeakDDCap;
+   cfg_InpPyramidMaxPeakDDPct = InpPyramidMaxPeakDDPct;
+   cfg_InpAddRiskMult1 = InpAddRiskMult1;
+   cfg_InpAddRiskMult2 = InpAddRiskMult2;
+
+   if(InpPresetMode == PRESET_BALANCED || InpPresetMode == PRESET_CONSERVATIVE)
+   {
+      cfg_InpUseICTTime = true;
+      cfg_InpUseManualNYOffset = true;
+      cfg_InpNYOffsetHours = -5;
+      cfg_InpUseKillzoneAsia = false;
+      cfg_InpUseKillzoneLondon = true;
+      cfg_InpUseKillzoneNY = true;
+      cfg_InpUseSessionFilter = true;
+      cfg_InpStartHour = 6;
+      cfg_InpEndHour = 23;
+      cfg_InpMaxSpreadPoints = 35;
+      cfg_InpUseSpreadMultiple = true;
+      cfg_InpSpreadMultiple = 2.7;
+      cfg_InpSpreadMultipleBlockMin = 45;
+      cfg_InpUseSpreadInstability = true;
+      cfg_InpSpreadSpikeFactor = 1.6;
+      cfg_InpSpreadSpikeBlockMin = 60;
+      cfg_InpUseRolloverBlock = true;
+      cfg_InpRolloverStart = "23:55";
+      cfg_InpRolloverEnd = "00:15";
+      cfg_InpEqScanBars = 60;
+      cfg_InpEqClusterMin = 2;
+      cfg_InpEqToleranceATR = 0.20;
+      cfg_InpEqToleranceMinPoints = 12;
+      cfg_InpDisplacementATR = 1.25;
+      cfg_InpDisplacementBodyRatio = 0.60;
+      cfg_InpOBLookback = 14;
+      cfg_InpOBMaxAgeBars = 10;
+      cfg_InpOTE_HTF = PERIOD_H1;
+      cfg_InpOTE_SwingLookback = 72;
+      cfg_InpOTE_Min = 0.62;
+      cfg_InpOTE_Max = 0.79;
+      cfg_InpMinPDArrayDistance = 1.20;
+      cfg_InpKeyLevelStepPrice = 5.0;
+      cfg_InpKeyNearPrice = 0.45;
+      cfg_InpKeyChaseMaxDistPrice = 1.20;
+      cfg_InpUseFVGFeature = true;
+      cfg_InpFVGScanBars = 24;
+      cfg_InpFVGMaxDistATR = 1.0;
+      cfg_InpSL_ATR_Mult = 0.30;
+      cfg_InpSL_MinBufferPrice = 0.20;
+      cfg_InpUseMMSL = true;
+      cfg_InpMMSL_Pips = 35;
+      cfg_InpTP_RR_Main = 2.0;
+      cfg_InpMinRRAllowed = 1.6;
+      cfg_InpUseTP1Partial = true;
+      cfg_InpTP1_CloseFrac = 0.50;
+      cfg_InpUseSmartBE = true;
+      cfg_InpBE_MinProfitR = 1.0;
+      cfg_InpBE_OffsetPrice = 0.06;
+      cfg_InpUseATRTrailAfterTP1 = true;
+      cfg_InpTrailATR_Mult = 1.15;
+      cfg_InpTrailMinImprovePrice = 0.12;
+      cfg_InpTrailOnNewBarOnly = true;
+      cfg_InpBaseRiskPct = 1.0;
+      cfg_InpHardMaxTradesPerDay = 2;
+      cfg_InpUseMaxDailyLossLock = true;
+      cfg_InpMaxDailyLossPct = 3.0;
+      cfg_InpUseSoftEquityLock = true;
+      cfg_InpSoftEqTrigger1 = 2.0;
+      cfg_InpSoftEqFloor1 = 0.8;
+      cfg_InpSoftEqTrigger2 = 4.0;
+      cfg_InpSoftEqFloor2 = 2.0;
+      cfg_InpCooldownBarsAfterEntry = 3;
+      cfg_InpUseAntiChop = true;
+      cfg_InpLossBlock2_Hours = 6;
+      cfg_InpLossBlock3_Hours = 18;
+      cfg_InpRiskMultAfter3Loss = 0.60;
+      cfg_InpRiskCutAfter3Loss_H = 24;
+      cfg_InpUsePyramiding = false;
+
+      if(InpPresetMode == PRESET_CONSERVATIVE)
+      {
+         cfg_InpUseKillzoneAsia = false;
+         cfg_InpUseKillzoneLondon = false;
+         cfg_InpUseKillzoneNY = true;
+         cfg_InpDisplacementATR = 1.35;
+         cfg_InpEqToleranceATR = 0.18;
+         cfg_InpHardMaxTradesPerDay = 1;
+         cfg_InpBaseRiskPct = 0.7;
+      }
+   }
+
+   LogPresetConfig();
+}
+
+string PresetModeLabel(PresetMode mode)
+{
+   switch(mode)
+   {
+      case PRESET_CUSTOM:
+         return "CUSTOM";
+      case PRESET_BALANCED:
+         return "BALANCED";
+      case PRESET_CONSERVATIVE:
+         return "CONSERVATIVE";
+   }
+   return "UNKNOWN";
+}
+
+void LogPresetConfig()
+{
+   Print("Preset applied: ", PresetModeLabel(InpPresetMode));
+   if(cfg_InpUseManualNYOffset)
+   {
+      string dstNote = cfg_InpAutoNYDST ? "auto DST" : "manual DST";
+      Print("NY offset: ", cfg_InpNYOffsetHours, " (", dstNote, ", summer=", cfg_InpNYOffsetSummerHours, ")");
+   }
+
+   PrintFormat("Session: use=%s hours=%02d-%02d ICT=%s KZ(Asia/London/NY)=%s/%s/%s",
+               (cfg_InpUseSessionFilter ? "true" : "false"), cfg_InpStartHour, cfg_InpEndHour,
+               (cfg_InpUseICTTime ? "true" : "false"),
+               (cfg_InpUseKillzoneAsia ? "true" : "false"),
+               (cfg_InpUseKillzoneLondon ? "true" : "false"),
+               (cfg_InpUseKillzoneNY ? "true" : "false"));
+   PrintFormat("Execution: spreadMaxPts=%d spreadMult=%s x%.2f blockMin=%d spreadInstab=%s spikeFactor=%.2f spikeBlockMin=%d slippagePts=%d retries=%d retryDelayMs=%d",
+               cfg_InpMaxSpreadPoints, (cfg_InpUseSpreadMultiple ? "true" : "false"), cfg_InpSpreadMultiple,
+               cfg_InpSpreadMultipleBlockMin, (cfg_InpUseSpreadInstability ? "true" : "false"),
+               cfg_InpSpreadSpikeFactor, cfg_InpSpreadSpikeBlockMin, cfg_InpMaxSlippagePoints,
+               cfg_InpMaxRetries, cfg_InpRetryDelayMs);
+   PrintFormat("Indicators: ATR=%d ADX=%d RSI=%d EMA=%d/%d RegimeConfirmH1=%d RegimeLockH1=%d",
+               cfg_InpATRPeriod, cfg_InpADXPeriod, cfg_InpRSIPeriod, cfg_InpEMA_Fast, cfg_InpEMA_Slow,
+               cfg_InpRegimeConfirmBarsH1, cfg_InpRegimeLockBarsH1);
+   PrintFormat("SMC: PivotLen=%d PivotConfirm=%d MaxBarsAfterBOS=%d EqScanBars=%d EqClusterMin=%d EqTolATR=%.2f EqTolMinPts=%.2f",
+               cfg_InpPivotLen, cfg_InpPivotConfirmBars, cfg_InpMaxBarsAfterBOS,
+               cfg_InpEqScanBars, cfg_InpEqClusterMin, cfg_InpEqToleranceATR, cfg_InpEqToleranceMinPoints);
+   PrintFormat("SMC: DisplacementATR=%.2f BodyRatio=%.2f SearchBars=%d OBLookback=%d OBMaxAgeBars=%d",
+               cfg_InpDisplacementATR, cfg_InpDisplacementBodyRatio, cfg_InpDisplacementSearchBars,
+               cfg_InpOBLookback, cfg_InpOBMaxAgeBars);
+   PrintFormat("SMC: OTE_HTF=%d SwingLookback=%d OTE_Min=%.2f OTE_Max=%.2f PDArrayDist=%.2f PDArrayATR=%.2f PDArrayMinPts=%d",
+               cfg_InpOTE_HTF, cfg_InpOTE_SwingLookback, cfg_InpOTE_Min, cfg_InpOTE_Max,
+               cfg_InpMinPDArrayDistance, cfg_InpMinPDArrayATR, cfg_InpMinPDArrayMinPoints);
+   PrintFormat("Filters: BreakRetest=%s RetestTolATR=%.2f KeyStep=%.2f KeyNear=%.2f KeyChaseMax=%.2f",
+               (cfg_InpUseBreakRetest ? "true" : "false"), cfg_InpRetestTolATR,
+               cfg_InpKeyLevelStepPrice, cfg_InpKeyNearPrice, cfg_InpKeyChaseMaxDistPrice);
+   PrintFormat("FVG/Fib: FVG=%s ScanBars=%d MaxDistATR=%.2f Fib=%s BaseMin=%.2f BaseMax=%.3f FibTol=%.2f OTEBonus=%s OTE_Min=%.2f OTE_Max=%.2f BonusPts=%d",
+               (cfg_InpUseFVGFeature ? "true" : "false"), cfg_InpFVGScanBars, cfg_InpFVGMaxDistATR,
+               (cfg_InpUseFibFilter ? "true" : "false"), cfg_InpFibBaseMin, cfg_InpFibBaseMax,
+               cfg_InpFibTolPrice, (cfg_InpUseOTEBonus ? "true" : "false"),
+               cfg_InpOTEMin, cfg_InpOTEMax, cfg_InpOTEBonusPoints);
+   PrintFormat("Footprint/Spike: FP=%s VolMAPeriod=%d VolSpike=%.2f BodyMin=%.2f CloseSideMin=%.2f AbsorpVol=%.2f AbsorpRangeATR=%.2f RequireAccept=%s ScoreBonus=%d SpikeGuard=%s SpikeATR=%.2f",
+               (cfg_InpUseFootprintProxy ? "true" : "false"), cfg_InpFP_VolMAPeriod, cfg_InpFP_VolSpikeRatio,
+               cfg_InpFP_BodyMinRatio, cfg_InpFP_CloseSideMin, cfg_InpFP_AbsorpVolRatio, cfg_InpFP_AbsorpRangeATR,
+               (cfg_InpFP_RequireAcceptance ? "true" : "false"), cfg_InpFP_ScoreBonus,
+               (cfg_InpUseSpikeGuard ? "true" : "false"), cfg_InpSpikeMultATR);
+   PrintFormat("Stops/Targets: SL_ATR=%.2f SL_MinBuffer=%.2f MMSL=%s MMSL_Pips=%d MMSL_Extra=%.2f RR=%.2f MinRR=%.2f TP1=%s TP1_Close=%.2f KeyFirst=%s",
+               cfg_InpSL_ATR_Mult, cfg_InpSL_MinBufferPrice, (cfg_InpUseMMSL ? "true" : "false"),
+               cfg_InpMMSL_Pips, cfg_InpMMSL_ExtraBufferPrice, cfg_InpTP_RR_Main, cfg_InpMinRRAllowed,
+               (cfg_InpUseTP1Partial ? "true" : "false"), cfg_InpTP1_CloseFrac,
+               (cfg_InpTP1_UseKeyLevelFirst ? "true" : "false"));
+   PrintFormat("BE/Trail: SmartBE=%s MinProfitR=%.2f BE_Offset=%.2f TrailAfterTP1=%s ATR_Mult=%.2f MinImprove=%.2f NewBarOnly=%s",
+               (cfg_InpUseSmartBE ? "true" : "false"), cfg_InpBE_MinProfitR, cfg_InpBE_OffsetPrice,
+               (cfg_InpUseATRTrailAfterTP1 ? "true" : "false"), cfg_InpTrailATR_Mult,
+               cfg_InpTrailMinImprovePrice, (cfg_InpTrailOnNewBarOnly ? "true" : "false"));
+   PrintFormat("Risk/Daily: BaseRiskPct=%.2f MaxLot=%.2f DailyControl=%s MaxTrades=%d MaxDailyLoss=%s %.2f%% SoftEqLock=%s Triggers=%.2f/%.2f Floors=%.2f/%.2f CooldownBars=%d",
+               cfg_InpBaseRiskPct, cfg_InpMaxLotCap, (cfg_InpUseDailyTradeControl ? "true" : "false"),
+               cfg_InpHardMaxTradesPerDay, (cfg_InpUseMaxDailyLossLock ? "true" : "false"),
+               cfg_InpMaxDailyLossPct, (cfg_InpUseSoftEquityLock ? "true" : "false"),
+               cfg_InpSoftEqTrigger1, cfg_InpSoftEqTrigger2, cfg_InpSoftEqFloor1, cfg_InpSoftEqFloor2,
+               cfg_InpCooldownBarsAfterEntry);
+   PrintFormat("AntiChop/RSI: AntiChop=%s LossBlock2H=%d LossBlock3H=%d RiskMultAfter3=%.2f RiskCutAfter3H=%d RSIAfterLoss=%s LossStreakRSI=%d",
+               (cfg_InpUseAntiChop ? "true" : "false"), cfg_InpLossBlock2_Hours, cfg_InpLossBlock3_Hours,
+               cfg_InpRiskMultAfter3Loss, cfg_InpRiskCutAfter3Loss_H,
+               (cfg_InpUseRSIAfterLoss ? "true" : "false"), cfg_InpLossStreakForRSI);
+   PrintFormat("Pyramiding: Enable=%s MaxAdds=%d MinProfitR=%.2f RequireMainBE=%s SpacingATR=%.2f OnlyTrend=%s RequireAdxRising=%s PeakDDCap=%s MaxPeakDD=%.2f AddRiskMult=%.2f/%.2f",
+               (cfg_InpUsePyramiding ? "true" : "false"), cfg_InpMaxAdds, cfg_InpPyramidMinProfitR,
+               (cfg_InpPyramidRequireMainBE ? "true" : "false"), cfg_InpPyramidSpacingATR,
+               (cfg_InpPyramidOnlyInTrend ? "true" : "false"), (cfg_InpPyramidRequireAdxRising ? "true" : "false"),
+               (cfg_InpPyramidUsePeakDDCap ? "true" : "false"), cfg_InpPyramidMaxPeakDDPct,
+               cfg_InpAddRiskMult1, cfg_InpAddRiskMult2);
+}
+
+void LogSymbolCheck()
+{
+   string symUpper = StringUpper(g_symbol);
+   bool symbolMatch = (StringFind(symUpper, "GOLD") >= 0 || StringFind(symUpper, "XAUUSD") >= 0);
+   bool digitsOk = (g_digits == 2 && MathAbs(g_point - 0.01) <= 0.000001);
+
+   Print("Symbol check: symbol=", g_symbol, " match=", (symbolMatch ? "true" : "false"),
+         " digits=", g_digits, " point=", DoubleToString(g_point, 5));
+
+   if(!symbolMatch)
+      Print("Warning: Symbol is not GOLD/XAUUSD. Verify XM GOLD settings.");
+   if(!digitsOk)
+      Print("Warning: Unexpected digits/point. Expected digits=2 and point=0.01. Verify InpPipPrice/g_pip for XM GOLD.");
+}
+
+#define InpUseSessionFilter cfg_InpUseSessionFilter
+#define InpStartHour cfg_InpStartHour
+#define InpEndHour cfg_InpEndHour
+#define InpMaxSpreadPoints cfg_InpMaxSpreadPoints
+#define InpMaxSlippagePoints cfg_InpMaxSlippagePoints
+#define InpMaxRetries cfg_InpMaxRetries
+#define InpRetryDelayMs cfg_InpRetryDelayMs
+#define InpUseICTTime cfg_InpUseICTTime
+#define InpUseManualNYOffset cfg_InpUseManualNYOffset
+#define InpNYOffsetHours cfg_InpNYOffsetHours
+#define InpAutoNYDST cfg_InpAutoNYDST
+#define InpNYOffsetSummerHours cfg_InpNYOffsetSummerHours
+#define InpUseKillzoneAsia cfg_InpUseKillzoneAsia
+#define InpUseKillzoneLondon cfg_InpUseKillzoneLondon
+#define InpUseKillzoneNY cfg_InpUseKillzoneNY
+#define InpATRPeriod cfg_InpATRPeriod
+#define InpADXPeriod cfg_InpADXPeriod
+#define InpRSIPeriod cfg_InpRSIPeriod
+#define InpEMA_Fast cfg_InpEMA_Fast
+#define InpEMA_Slow cfg_InpEMA_Slow
+#define InpRegimeConfirmBarsH1 cfg_InpRegimeConfirmBarsH1
+#define InpRegimeLockBarsH1 cfg_InpRegimeLockBarsH1
+#define InpPivotLen cfg_InpPivotLen
+#define InpPivotConfirmBars cfg_InpPivotConfirmBars
+#define InpMaxBarsAfterBOS cfg_InpMaxBarsAfterBOS
+#define InpEqToleranceATR cfg_InpEqToleranceATR
+#define InpEqToleranceMinPoints cfg_InpEqToleranceMinPoints
+#define InpEqClusterMin cfg_InpEqClusterMin
+#define InpEqScanBars cfg_InpEqScanBars
+#define InpDisplacementATR cfg_InpDisplacementATR
+#define InpDisplacementBodyRatio cfg_InpDisplacementBodyRatio
+#define InpDisplacementSearchBars cfg_InpDisplacementSearchBars
+#define InpOBLookback cfg_InpOBLookback
+#define InpOBMaxAgeBars cfg_InpOBMaxAgeBars
+#define InpOTE_HTF cfg_InpOTE_HTF
+#define InpOTE_SwingLookback cfg_InpOTE_SwingLookback
+#define InpOTE_Min cfg_InpOTE_Min
+#define InpOTE_Max cfg_InpOTE_Max
+#define InpMinPDArrayDistance cfg_InpMinPDArrayDistance
+#define InpMinPDArrayATR cfg_InpMinPDArrayATR
+#define InpMinPDArrayMinPoints cfg_InpMinPDArrayMinPoints
+#define InpUseBreakRetest cfg_InpUseBreakRetest
+#define InpRetestTolATR cfg_InpRetestTolATR
+#define InpKeyLevelStepPrice cfg_InpKeyLevelStepPrice
+#define InpKeyNearPrice cfg_InpKeyNearPrice
+#define InpKeyChaseMaxDistPrice cfg_InpKeyChaseMaxDistPrice
+#define InpUseFVGFeature cfg_InpUseFVGFeature
+#define InpFVGScanBars cfg_InpFVGScanBars
+#define InpFVGMaxDistATR cfg_InpFVGMaxDistATR
+#define InpUseFibFilter cfg_InpUseFibFilter
+#define InpFibBaseMin cfg_InpFibBaseMin
+#define InpFibBaseMax cfg_InpFibBaseMax
+#define InpFibTolPrice cfg_InpFibTolPrice
+#define InpUseOTEBonus cfg_InpUseOTEBonus
+#define InpOTEMin cfg_InpOTEMin
+#define InpOTEMax cfg_InpOTEMax
+#define InpOTEBonusPoints cfg_InpOTEBonusPoints
+#define InpUseFootprintProxy cfg_InpUseFootprintProxy
+#define InpFP_VolMAPeriod cfg_InpFP_VolMAPeriod
+#define InpFP_VolSpikeRatio cfg_InpFP_VolSpikeRatio
+#define InpFP_BodyMinRatio cfg_InpFP_BodyMinRatio
+#define InpFP_CloseSideMin cfg_InpFP_CloseSideMin
+#define InpFP_AbsorpVolRatio cfg_InpFP_AbsorpVolRatio
+#define InpFP_AbsorpRangeATR cfg_InpFP_AbsorpRangeATR
+#define InpFP_RequireAcceptance cfg_InpFP_RequireAcceptance
+#define InpFP_ScoreBonus cfg_InpFP_ScoreBonus
+#define InpUseSpikeGuard cfg_InpUseSpikeGuard
+#define InpSpikeMultATR cfg_InpSpikeMultATR
+#define InpSL_ATR_Mult cfg_InpSL_ATR_Mult
+#define InpSL_MinBufferPrice cfg_InpSL_MinBufferPrice
+#define InpUseMMSL cfg_InpUseMMSL
+#define InpMMSL_Pips cfg_InpMMSL_Pips
+#define InpMMSL_ExtraBufferPrice cfg_InpMMSL_ExtraBufferPrice
+#define InpTP_RR_Main cfg_InpTP_RR_Main
+#define InpMinRRAllowed cfg_InpMinRRAllowed
+#define InpUseTP1Partial cfg_InpUseTP1Partial
+#define InpTP1_CloseFrac cfg_InpTP1_CloseFrac
+#define InpTP1_UseKeyLevelFirst cfg_InpTP1_UseKeyLevelFirst
+#define InpUseSmartBE cfg_InpUseSmartBE
+#define InpBE_MinProfitR cfg_InpBE_MinProfitR
+#define InpBE_OffsetPrice cfg_InpBE_OffsetPrice
+#define InpUseATRTrailAfterTP1 cfg_InpUseATRTrailAfterTP1
+#define InpTrailATR_Mult cfg_InpTrailATR_Mult
+#define InpTrailMinImprovePrice cfg_InpTrailMinImprovePrice
+#define InpTrailOnNewBarOnly cfg_InpTrailOnNewBarOnly
+#define InpBaseRiskPct cfg_InpBaseRiskPct
+#define InpMaxLotCap cfg_InpMaxLotCap
+#define InpUseLowVolFilter cfg_InpUseLowVolFilter
+#define InpVolTF cfg_InpVolTF
+#define InpVolMAPeriod cfg_InpVolMAPeriod
+#define InpLowVolFactor cfg_InpLowVolFactor
+#define InpUseSpreadMultiple cfg_InpUseSpreadMultiple
+#define InpSpreadMultiple cfg_InpSpreadMultiple
+#define InpSpreadMultipleBlockMin cfg_InpSpreadMultipleBlockMin
+#define InpUseSpreadInstability cfg_InpUseSpreadInstability
+#define InpSpreadAvgBarsH1 cfg_InpSpreadAvgBarsH1
+#define InpSpreadSpikeFactor cfg_InpSpreadSpikeFactor
+#define InpSpreadSpikeBlockMin cfg_InpSpreadSpikeBlockMin
+#define InpUseRolloverBlock cfg_InpUseRolloverBlock
+#define InpRolloverStart cfg_InpRolloverStart
+#define InpRolloverEnd cfg_InpRolloverEnd
+#define InpUseDailyTradeControl cfg_InpUseDailyTradeControl
+#define InpHardMaxTradesPerDay cfg_InpHardMaxTradesPerDay
+#define InpUseMaxDailyLossLock cfg_InpUseMaxDailyLossLock
+#define InpMaxDailyLossPct cfg_InpMaxDailyLossPct
+#define InpUseSoftEquityLock cfg_InpUseSoftEquityLock
+#define InpSoftEqTrigger1 cfg_InpSoftEqTrigger1
+#define InpSoftEqFloor1 cfg_InpSoftEqFloor1
+#define InpSoftEqTrigger2 cfg_InpSoftEqTrigger2
+#define InpSoftEqFloor2 cfg_InpSoftEqFloor2
+#define InpCooldownBarsAfterEntry cfg_InpCooldownBarsAfterEntry
+#define InpUseAntiChop cfg_InpUseAntiChop
+#define InpLossBlock2_Hours cfg_InpLossBlock2_Hours
+#define InpLossBlock3_Hours cfg_InpLossBlock3_Hours
+#define InpRiskMultAfter3Loss cfg_InpRiskMultAfter3Loss
+#define InpRiskCutAfter3Loss_H cfg_InpRiskCutAfter3Loss_H
+#define InpUseRSIAfterLoss cfg_InpUseRSIAfterLoss
+#define InpLossStreakForRSI cfg_InpLossStreakForRSI
+#define InpUsePyramiding cfg_InpUsePyramiding
+#define InpMaxAdds cfg_InpMaxAdds
+#define InpPyramidMinProfitR cfg_InpPyramidMinProfitR
+#define InpPyramidRequireMainBE cfg_InpPyramidRequireMainBE
+#define InpPyramidSpacingATR cfg_InpPyramidSpacingATR
+#define InpPyramidOnlyInTrend cfg_InpPyramidOnlyInTrend
+#define InpPyramidRequireAdxRising cfg_InpPyramidRequireAdxRising
+#define InpPyramidUsePeakDDCap cfg_InpPyramidUsePeakDDCap
+#define InpPyramidMaxPeakDDPct cfg_InpPyramidMaxPeakDDPct
+#define InpAddRiskMult1 cfg_InpAddRiskMult1
+#define InpAddRiskMult2 cfg_InpAddRiskMult2
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
             int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
             int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
@@ -1878,6 +2747,7 @@ void ManagePosition(double riskR)
             trade.PositionModify(ticket, newSL, tp);
       }
    }
+
 }
 
 void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
@@ -1967,8 +2837,16 @@ int OnInit()
    g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
    g_pip = g_point * 10.0;
 
+   ApplyPreset();
+
    trade.SetExpertMagicNumber((uint)InpMagic);
    trade.SetDeviationInPoints(InpMaxSlippagePoints);
+
+   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   Print("Symbol=", g_symbol, " Digits=", g_digits, " Point=", DoubleToString(g_point, 2),
+         " TickSize=", DoubleToString(tickSize, 2), " TickValue=", DoubleToString(tickValue, 2));
+   LogSymbolCheck();
 
    UpdateDailyReset();
 

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -36,6 +36,13 @@ enum PresetMode
    PRESET_CONSERVATIVE = 2
 };
 
+enum SymbolProfile
+{
+   PROFILE_FX_MAJORS_5DIG = 0,
+   PROFILE_FX_JPY_3DIG = 1,
+   PROFILE_INDICES = 2
+};
+
 input PresetMode InpPresetMode = PRESET_CUSTOM;
 
 input string InpSymbolOverride = "";
@@ -213,11 +220,17 @@ string g_symbol = "";
 int g_digits = 2;
 double g_point = 0.01;
 double g_pip = 0.10;
+SymbolProfile g_profile = PROFILE_FX_MAJORS_5DIG;
+bool g_isGoldSymbol = false;
 datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
 
 // Runtime config (preset-applied)
+PresetMode cfg_InpPresetMode;
+string cfg_InpSymbolOverride;
+long cfg_InpMagic;
+double cfg_InpPipPrice;
 bool cfg_InpUseSessionFilter;
 int cfg_InpStartHour;
 int cfg_InpEndHour;
@@ -347,136 +360,20 @@ bool cfg_InpPyramidUsePeakDDCap;
 double cfg_InpPyramidMaxPeakDDPct;
 double cfg_InpAddRiskMult1;
 double cfg_InpAddRiskMult2;
+bool cfg_InpEnableCSV;
+string cfg_InpCSVName;
 
-#define InpUseSessionFilter cfg_InpUseSessionFilter
-#define InpStartHour cfg_InpStartHour
-#define InpEndHour cfg_InpEndHour
-#define InpMaxSpreadPoints cfg_InpMaxSpreadPoints
-#define InpMaxSlippagePoints cfg_InpMaxSlippagePoints
-#define InpMaxRetries cfg_InpMaxRetries
-#define InpRetryDelayMs cfg_InpRetryDelayMs
-#define InpUseICTTime cfg_InpUseICTTime
-#define InpUseManualNYOffset cfg_InpUseManualNYOffset
-#define InpNYOffsetHours cfg_InpNYOffsetHours
-#define InpAutoNYDST cfg_InpAutoNYDST
-#define InpNYOffsetSummerHours cfg_InpNYOffsetSummerHours
-#define InpUseKillzoneAsia cfg_InpUseKillzoneAsia
-#define InpUseKillzoneLondon cfg_InpUseKillzoneLondon
-#define InpUseKillzoneNY cfg_InpUseKillzoneNY
-#define InpATRPeriod cfg_InpATRPeriod
-#define InpADXPeriod cfg_InpADXPeriod
-#define InpRSIPeriod cfg_InpRSIPeriod
-#define InpEMA_Fast cfg_InpEMA_Fast
-#define InpEMA_Slow cfg_InpEMA_Slow
-#define InpRegimeConfirmBarsH1 cfg_InpRegimeConfirmBarsH1
-#define InpRegimeLockBarsH1 cfg_InpRegimeLockBarsH1
-#define InpPivotLen cfg_InpPivotLen
-#define InpPivotConfirmBars cfg_InpPivotConfirmBars
-#define InpMaxBarsAfterBOS cfg_InpMaxBarsAfterBOS
-#define InpEqToleranceATR cfg_InpEqToleranceATR
-#define InpEqToleranceMinPoints cfg_InpEqToleranceMinPoints
-#define InpEqClusterMin cfg_InpEqClusterMin
-#define InpEqScanBars cfg_InpEqScanBars
-#define InpDisplacementATR cfg_InpDisplacementATR
-#define InpDisplacementBodyRatio cfg_InpDisplacementBodyRatio
-#define InpDisplacementSearchBars cfg_InpDisplacementSearchBars
-#define InpOBLookback cfg_InpOBLookback
-#define InpOBMaxAgeBars cfg_InpOBMaxAgeBars
-#define InpOTE_HTF cfg_InpOTE_HTF
-#define InpOTE_SwingLookback cfg_InpOTE_SwingLookback
-#define InpOTE_Min cfg_InpOTE_Min
-#define InpOTE_Max cfg_InpOTE_Max
-#define InpMinPDArrayDistance cfg_InpMinPDArrayDistance
-#define InpMinPDArrayATR cfg_InpMinPDArrayATR
-#define InpMinPDArrayMinPoints cfg_InpMinPDArrayMinPoints
-#define InpUseBreakRetest cfg_InpUseBreakRetest
-#define InpRetestTolATR cfg_InpRetestTolATR
-#define InpKeyLevelStepPrice cfg_InpKeyLevelStepPrice
-#define InpKeyNearPrice cfg_InpKeyNearPrice
-#define InpKeyChaseMaxDistPrice cfg_InpKeyChaseMaxDistPrice
-#define InpUseFVGFeature cfg_InpUseFVGFeature
-#define InpFVGScanBars cfg_InpFVGScanBars
-#define InpFVGMaxDistATR cfg_InpFVGMaxDistATR
-#define InpUseFibFilter cfg_InpUseFibFilter
-#define InpFibBaseMin cfg_InpFibBaseMin
-#define InpFibBaseMax cfg_InpFibBaseMax
-#define InpFibTolPrice cfg_InpFibTolPrice
-#define InpUseOTEBonus cfg_InpUseOTEBonus
-#define InpOTEMin cfg_InpOTEMin
-#define InpOTEMax cfg_InpOTEMax
-#define InpOTEBonusPoints cfg_InpOTEBonusPoints
-#define InpUseFootprintProxy cfg_InpUseFootprintProxy
-#define InpFP_VolMAPeriod cfg_InpFP_VolMAPeriod
-#define InpFP_VolSpikeRatio cfg_InpFP_VolSpikeRatio
-#define InpFP_BodyMinRatio cfg_InpFP_BodyMinRatio
-#define InpFP_CloseSideMin cfg_InpFP_CloseSideMin
-#define InpFP_AbsorpVolRatio cfg_InpFP_AbsorpVolRatio
-#define InpFP_AbsorpRangeATR cfg_InpFP_AbsorpRangeATR
-#define InpFP_RequireAcceptance cfg_InpFP_RequireAcceptance
-#define InpFP_ScoreBonus cfg_InpFP_ScoreBonus
-#define InpUseSpikeGuard cfg_InpUseSpikeGuard
-#define InpSpikeMultATR cfg_InpSpikeMultATR
-#define InpSL_ATR_Mult cfg_InpSL_ATR_Mult
-#define InpSL_MinBufferPrice cfg_InpSL_MinBufferPrice
-#define InpUseMMSL cfg_InpUseMMSL
-#define InpMMSL_Pips cfg_InpMMSL_Pips
-#define InpMMSL_ExtraBufferPrice cfg_InpMMSL_ExtraBufferPrice
-#define InpTP_RR_Main cfg_InpTP_RR_Main
-#define InpMinRRAllowed cfg_InpMinRRAllowed
-#define InpUseTP1Partial cfg_InpUseTP1Partial
-#define InpTP1_CloseFrac cfg_InpTP1_CloseFrac
-#define InpTP1_UseKeyLevelFirst cfg_InpTP1_UseKeyLevelFirst
-#define InpUseSmartBE cfg_InpUseSmartBE
-#define InpBE_MinProfitR cfg_InpBE_MinProfitR
-#define InpBE_OffsetPrice cfg_InpBE_OffsetPrice
-#define InpUseATRTrailAfterTP1 cfg_InpUseATRTrailAfterTP1
-#define InpTrailATR_Mult cfg_InpTrailATR_Mult
-#define InpTrailMinImprovePrice cfg_InpTrailMinImprovePrice
-#define InpTrailOnNewBarOnly cfg_InpTrailOnNewBarOnly
-#define InpBaseRiskPct cfg_InpBaseRiskPct
-#define InpMaxLotCap cfg_InpMaxLotCap
-#define InpUseLowVolFilter cfg_InpUseLowVolFilter
-#define InpVolTF cfg_InpVolTF
-#define InpVolMAPeriod cfg_InpVolMAPeriod
-#define InpLowVolFactor cfg_InpLowVolFactor
-#define InpUseSpreadMultiple cfg_InpUseSpreadMultiple
-#define InpSpreadMultiple cfg_InpSpreadMultiple
-#define InpSpreadMultipleBlockMin cfg_InpSpreadMultipleBlockMin
-#define InpUseSpreadInstability cfg_InpUseSpreadInstability
-#define InpSpreadAvgBarsH1 cfg_InpSpreadAvgBarsH1
-#define InpSpreadSpikeFactor cfg_InpSpreadSpikeFactor
-#define InpSpreadSpikeBlockMin cfg_InpSpreadSpikeBlockMin
-#define InpUseRolloverBlock cfg_InpUseRolloverBlock
-#define InpRolloverStart cfg_InpRolloverStart
-#define InpRolloverEnd cfg_InpRolloverEnd
-#define InpUseDailyTradeControl cfg_InpUseDailyTradeControl
-#define InpHardMaxTradesPerDay cfg_InpHardMaxTradesPerDay
-#define InpUseMaxDailyLossLock cfg_InpUseMaxDailyLossLock
-#define InpMaxDailyLossPct cfg_InpMaxDailyLossPct
-#define InpUseSoftEquityLock cfg_InpUseSoftEquityLock
-#define InpSoftEqTrigger1 cfg_InpSoftEqTrigger1
-#define InpSoftEqFloor1 cfg_InpSoftEqFloor1
-#define InpSoftEqTrigger2 cfg_InpSoftEqTrigger2
-#define InpSoftEqFloor2 cfg_InpSoftEqFloor2
-#define InpCooldownBarsAfterEntry cfg_InpCooldownBarsAfterEntry
-#define InpUseAntiChop cfg_InpUseAntiChop
-#define InpLossBlock2_Hours cfg_InpLossBlock2_Hours
-#define InpLossBlock3_Hours cfg_InpLossBlock3_Hours
-#define InpRiskMultAfter3Loss cfg_InpRiskMultAfter3Loss
-#define InpRiskCutAfter3Loss_H cfg_InpRiskCutAfter3Loss_H
-#define InpUseRSIAfterLoss cfg_InpUseRSIAfterLoss
-#define InpLossStreakForRSI cfg_InpLossStreakForRSI
-#define InpUsePyramiding cfg_InpUsePyramiding
-#define InpMaxAdds cfg_InpMaxAdds
-#define InpPyramidMinProfitR cfg_InpPyramidMinProfitR
-#define InpPyramidRequireMainBE cfg_InpPyramidRequireMainBE
-#define InpPyramidSpacingATR cfg_InpPyramidSpacingATR
-#define InpPyramidOnlyInTrend cfg_InpPyramidOnlyInTrend
-#define InpPyramidRequireAdxRising cfg_InpPyramidRequireAdxRising
-#define InpPyramidUsePeakDDCap cfg_InpPyramidUsePeakDDCap
-#define InpPyramidMaxPeakDDPct cfg_InpPyramidMaxPeakDDPct
-#define InpAddRiskMult1 cfg_InpAddRiskMult1
-#define InpAddRiskMult2 cfg_InpAddRiskMult2
+double cfg_KeyLevelStepPoints;
+double cfg_KeyNearPoints;
+double cfg_KeyChaseMaxDistPoints;
+double cfg_EqToleranceMinPoints;
+double cfg_SL_MinBufferPoints;
+double cfg_MMSL_ExtraBufferPoints;
+double cfg_BE_OffsetPoints;
+double cfg_TrailMinImprovePoints;
+double cfg_FibTolPoints;
+double cfg_MinPDArrayDistancePoints;
+int cfg_MinPDArrayMinPoints;
 
 enum SkipMask
 {
@@ -526,7 +423,7 @@ enum EntryMask
 
 string GVName(const string key)
 {
-   return "XK_" + key + "_" + g_symbol + "_" + (string)InpMagic;
+   return "XK_" + key + "_" + g_symbol + "_" + (string)cfg_InpMagic;
 }
 
 double GVGetDouble(const string key, double defval)
@@ -568,15 +465,91 @@ bool IsNewBar(ENUM_TIMEFRAMES tf, datetime &lastBarTime)
 
 string ResolveSymbol()
 {
-   if(StringLen(InpSymbolOverride) > 0)
-      return InpSymbolOverride;
+   if(StringLen(cfg_InpSymbolOverride) > 0)
+      return cfg_InpSymbolOverride;
    return _Symbol;
+}
+
+bool ContainsAny(const string text, const string &tokens[])
+{
+   for(int i = 0; i < ArraySize(tokens); i++)
+   {
+      if(StringFind(text, tokens[i]) >= 0)
+         return true;
+   }
+   return false;
+}
+
+SymbolProfile DetectSymbolProfile(const string symbol)
+{
+   string symUpper = StringUpper(symbol);
+   if(StringFind(symUpper, "XAU") >= 0 || StringFind(symUpper, "GOLD") >= 0)
+      return PROFILE_FX_MAJORS_5DIG;
+   string indexTokens[] = {"US30", "DJ30", "US30CASH", "NAS100", "US100", "NAS", "SPX500", "US500", "SP500",
+                           "GER40", "DE40", "DAX", "DAX40", "FTSEMIB", "ITA40", "FTSE", "UK100"};
+   if(ContainsAny(symUpper, indexTokens))
+      return PROFILE_INDICES;
+   if(StringFind(symUpper, "JPY") >= 0)
+      return PROFILE_FX_JPY_3DIG;
+   return PROFILE_FX_MAJORS_5DIG;
+}
+
+bool IsGoldSymbol(const string symbol)
+{
+   string symUpper = StringUpper(symbol);
+   return (StringFind(symUpper, "XAU") >= 0 || StringFind(symUpper, "GOLD") >= 0);
+}
+
+string ProfileName(SymbolProfile profile)
+{
+   switch(profile)
+   {
+      case PROFILE_FX_MAJORS_5DIG:
+         return "FX_MAJORS_5DIG";
+      case PROFILE_FX_JPY_3DIG:
+         return "FX_JPY_3DIG";
+      case PROFILE_INDICES:
+         return "INDICES";
+   }
+   return "UNKNOWN";
+}
+
+double PriceFromPoints(double points)
+{
+   return points * g_point;
+}
+
+double PointsFromPrice(double price)
+{
+   return (g_point > 0.0) ? price / g_point : 0.0;
+}
+
+double PriceFromPips(double pips)
+{
+   return pips * g_pip;
+}
+
+double PipsFromPrice(double price)
+{
+   return (g_pip > 0.0) ? price / g_pip : 0.0;
+}
+
+double PointsFromPips(double pips)
+{
+   double price = PriceFromPips(pips);
+   return PointsFromPrice(price);
+}
+
+double PipsFromPoints(double points)
+{
+   double price = PriceFromPoints(points);
+   return PipsFromPrice(price);
 }
 
 double PipPrice()
 {
-   if(InpPipPrice > 0.0)
-      return InpPipPrice;
+   if(cfg_InpPipPrice > 0.0)
+      return cfg_InpPipPrice;
    return g_pip;
 }
 
@@ -594,15 +567,50 @@ int MinutesOfDay(datetime t)
    return dt.hour * 60 + dt.min;
 }
 
+datetime MakeDateTime(int year, int mon, int day, int hour, int min, int sec)
+{
+   MqlDateTime dt;
+   dt.year = year;
+   dt.mon = mon;
+   dt.day = day;
+   dt.hour = hour;
+   dt.min = min;
+   dt.sec = sec;
+   return StructToTime(dt);
+}
+
+datetime FirstSundayUTC(int year, int mon, int hour, int min)
+{
+   MqlDateTime dt;
+   TimeToStruct(MakeDateTime(year, mon, 1, 0, 0, 0), dt);
+   int firstSunday = 1 + ((7 - dt.day_of_week) % 7);
+   return MakeDateTime(year, mon, firstSunday, hour, min, 0);
+}
+
+datetime SecondSundayUTC(int year, int mon, int hour, int min)
+{
+   datetime firstSunday = FirstSundayUTC(year, mon, 0, 0);
+   MqlDateTime dt;
+   TimeToStruct(firstSunday, dt);
+   int secondSunday = dt.day + 7;
+   return MakeDateTime(year, mon, secondSunday, hour, min, 0);
+}
+
+bool IsUSDST(datetime utcTime)
+{
+   MqlDateTime dt;
+   TimeToStruct(utcTime, dt);
+   datetime dstStart = SecondSundayUTC(dt.year, 3, 7, 0);
+   datetime dstEnd = FirstSundayUTC(dt.year, 11, 6, 0);
+   return (utcTime >= dstStart && utcTime < dstEnd);
+}
+
 int EffectiveNYOffsetHours()
 {
-   if(!InpAutoNYDST)
-      return InpNYOffsetHours;
-   MqlDateTime dt;
-   TimeToStruct(TimeGMT(), dt);
-   if(dt.mon >= 3 && dt.mon <= 11)
-      return InpNYOffsetSummerHours;
-   return InpNYOffsetHours;
+   if(!cfg_InpAutoNYDST)
+      return cfg_InpNYOffsetHours;
+   datetime nowUtc = TimeGMT();
+   return IsUSDST(nowUtc) ? cfg_InpNYOffsetSummerHours : cfg_InpNYOffsetHours;
 }
 
 int GetServerUtcOffsetSeconds()
@@ -613,7 +621,7 @@ int GetServerUtcOffsetSeconds()
 datetime ToNYTime(datetime serverTime)
 {
    int serverOffset = GetServerUtcOffsetSeconds();
-   int nyOffset = InpUseManualNYOffset ? (EffectiveNYOffsetHours() * 3600) : (-5 * 3600);
+   int nyOffset = cfg_InpUseManualNYOffset ? (EffectiveNYOffsetHours() * 3600) : (-5 * 3600);
    return serverTime - serverOffset + nyOffset;
 }
 
@@ -628,14 +636,14 @@ bool KillzoneActive(bool &isAsia, bool &isLondon, bool &isNY)
    isAsia = false;
    isLondon = false;
    isNY = false;
-   if(!InpUseICTTime)
+   if(!cfg_InpUseICTTime)
       return false;
    int minNY = MinutesOfDayNY(TimeCurrent());
-   if(InpUseKillzoneAsia && minNY >= 20 * 60 && minNY < 22 * 60)
+   if(cfg_InpUseKillzoneAsia && minNY >= 20 * 60 && minNY < 22 * 60)
       isAsia = true;
-   if(InpUseKillzoneLondon && minNY >= 2 * 60 && minNY < 5 * 60)
+   if(cfg_InpUseKillzoneLondon && minNY >= 2 * 60 && minNY < 5 * 60)
       isLondon = true;
-   if(InpUseKillzoneNY && minNY >= 7 * 60 && minNY < 9 * 60)
+   if(cfg_InpUseKillzoneNY && minNY >= 7 * 60 && minNY < 9 * 60)
       isNY = true;
    return (isAsia || isLondon || isNY);
 }
@@ -659,7 +667,7 @@ bool TimeInRange(const string start, const string end)
 void UpdateSpreadEMA()
 {
    double spread = SpreadPoints();
-   double alpha = 2.0 / (InpSpreadAvgBarsH1 + 1.0);
+   double alpha = 2.0 / (cfg_InpSpreadAvgBarsH1 + 1.0);
    if(g_spreadEma <= 0.0)
       g_spreadEma = spread;
    else
@@ -668,16 +676,16 @@ void UpdateSpreadEMA()
 
 bool SpreadMultipleBlocked()
 {
-   if(!InpUseSpreadMultiple)
+   if(!cfg_InpUseSpreadMultiple)
       return false;
 
    double spread = SpreadPoints();
    if(g_spreadEma <= 0.0)
       return false;
 
-   if(spread > g_spreadEma * InpSpreadMultiple)
+   if(spread > g_spreadEma * cfg_InpSpreadMultiple)
    {
-      datetime until = TimeCurrent() + InpSpreadMultipleBlockMin * 60;
+      datetime until = TimeCurrent() + cfg_InpSpreadMultipleBlockMin * 60;
       GVSetDouble("spreadBlockUntil", (double)until);
    }
 
@@ -687,13 +695,13 @@ bool SpreadMultipleBlocked()
 
 bool SpreadInstabilityBlocked()
 {
-   if(!InpUseSpreadInstability || g_spreadEma <= 0.0)
+   if(!cfg_InpUseSpreadInstability || g_spreadEma <= 0.0)
       return false;
 
    double spread = SpreadPoints();
-   if(spread > g_spreadEma * InpSpreadSpikeFactor)
+   if(spread > g_spreadEma * cfg_InpSpreadSpikeFactor)
    {
-      datetime until = TimeCurrent() + InpSpreadSpikeBlockMin * 60;
+      datetime until = TimeCurrent() + cfg_InpSpreadSpikeBlockMin * 60;
       GVSetDouble("spreadSpikeUntil", (double)until);
    }
 
@@ -703,34 +711,34 @@ bool SpreadInstabilityBlocked()
 
 bool SessionAllowed()
 {
-   if(!InpUseSessionFilter)
+   if(!cfg_InpUseSessionFilter)
       return true;
    int hour = TimeHour(TimeCurrent());
-   if(InpStartHour <= InpEndHour)
-      return (hour >= InpStartHour && hour <= InpEndHour);
-   return (hour >= InpStartHour || hour <= InpEndHour);
+   if(cfg_InpStartHour <= cfg_InpEndHour)
+      return (hour >= cfg_InpStartHour && hour <= cfg_InpEndHour);
+   return (hour >= cfg_InpStartHour || hour <= cfg_InpEndHour);
 }
 
 bool RolloverBlocked()
 {
-   if(!InpUseRolloverBlock)
+   if(!cfg_InpUseRolloverBlock)
       return false;
-   return TimeInRange(InpRolloverStart, InpRolloverEnd);
+   return TimeInRange(cfg_InpRolloverStart, cfg_InpRolloverEnd);
 }
 
 double ATR(ENUM_TIMEFRAMES tf, int shift)
 {
-   return iATR(g_symbol, tf, InpATRPeriod, shift);
+   return iATR(g_symbol, tf, cfg_InpATRPeriod, shift);
 }
 
 double ADX(ENUM_TIMEFRAMES tf, int shift)
 {
-   return iADX(g_symbol, tf, InpADXPeriod, PRICE_CLOSE, MODE_MAIN, shift);
+   return iADX(g_symbol, tf, cfg_InpADXPeriod, PRICE_CLOSE, MODE_MAIN, shift);
 }
 
 double RSI(ENUM_TIMEFRAMES tf, int shift)
 {
-   return iRSI(g_symbol, tf, InpRSIPeriod, PRICE_CLOSE, shift);
+   return iRSI(g_symbol, tf, cfg_InpRSIPeriod, PRICE_CLOSE, shift);
 }
 
 double EMA(ENUM_TIMEFRAMES tf, int period, int shift)
@@ -748,20 +756,20 @@ double VolumeMA(ENUM_TIMEFRAMES tf, int period, int shift)
 
 bool LowVolumeBlocked()
 {
-   if(!InpUseLowVolFilter)
+   if(!cfg_InpUseLowVolFilter)
       return false;
 
-   double vol = (double)iVolume(g_symbol, InpVolTF, 0);
-   double avg = VolumeMA(InpVolTF, InpVolMAPeriod, 1);
+   double vol = (double)iVolume(g_symbol, cfg_InpVolTF, 0);
+   double avg = VolumeMA(cfg_InpVolTF, cfg_InpVolMAPeriod, 1);
    if(avg <= 0.0)
       return false;
-   return vol < avg * InpLowVolFactor;
+   return vol < avg * cfg_InpLowVolFactor;
 }
 
 TradeDir BiasH1()
 {
-   double emaFast = EMA(PERIOD_H1, InpEMA_Fast, 1);
-   double emaSlow = EMA(PERIOD_H1, InpEMA_Slow, 1);
+   double emaFast = EMA(PERIOD_H1, cfg_InpEMA_Fast, 1);
+   double emaSlow = EMA(PERIOD_H1, cfg_InpEMA_Slow, 1);
    double close = iClose(g_symbol, PERIOD_H1, 1);
    if(emaFast > emaSlow && close > emaFast)
       return DIR_LONG;
@@ -805,12 +813,12 @@ RegimeState UpdateRegime()
    if(next != current)
    {
       confirmBars++;
-      if(confirmBars >= InpRegimeConfirmBarsH1)
+      if(confirmBars >= cfg_InpRegimeConfirmBarsH1)
       {
          current = next;
          GVSetInt("regime", (int)current);
          GVSetInt("regimeConfirm", 0);
-         GVSetInt("regimeLock", InpRegimeLockBarsH1);
+         GVSetInt("regimeLock", cfg_InpRegimeLockBarsH1);
          return current;
       }
       GVSetInt("regimeConfirm", confirmBars);
@@ -823,8 +831,13 @@ RegimeState UpdateRegime()
 
 bool IsPivotHigh(int index)
 {
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotLen < 0 || index + cfg_InpPivotLen >= bars)
+      return false;
    double high = iHigh(g_symbol, PERIOD_M15, index);
-   for(int j = 1; j <= InpPivotLen; j++)
+   for(int j = 1; j <= cfg_InpPivotLen; j++)
    {
       if(high <= iHigh(g_symbol, PERIOD_M15, index - j) || high <= iHigh(g_symbol, PERIOD_M15, index + j))
          return false;
@@ -834,8 +847,13 @@ bool IsPivotHigh(int index)
 
 bool IsPivotLow(int index)
 {
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotLen < 0 || index + cfg_InpPivotLen >= bars)
+      return false;
    double low = iLow(g_symbol, PERIOD_M15, index);
-   for(int j = 1; j <= InpPivotLen; j++)
+   for(int j = 1; j <= cfg_InpPivotLen; j++)
    {
       if(low >= iLow(g_symbol, PERIOD_M15, index - j) || low >= iLow(g_symbol, PERIOD_M15, index + j))
          return false;
@@ -845,9 +863,14 @@ bool IsPivotLow(int index)
 
 bool IsConfirmedPivotHigh(int index)
 {
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotConfirmBars < 0)
+      return false;
    if(!IsPivotHigh(index))
       return false;
-   for(int j = 1; j <= InpPivotConfirmBars; j++)
+   for(int j = 1; j <= cfg_InpPivotConfirmBars; j++)
    {
       if(iHigh(g_symbol, PERIOD_M15, index - j) >= iHigh(g_symbol, PERIOD_M15, index))
          return false;
@@ -857,9 +880,14 @@ bool IsConfirmedPivotHigh(int index)
 
 bool IsConfirmedPivotLow(int index)
 {
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotConfirmBars < 0)
+      return false;
    if(!IsPivotLow(index))
       return false;
-   for(int j = 1; j <= InpPivotConfirmBars; j++)
+   for(int j = 1; j <= cfg_InpPivotConfirmBars; j++)
    {
       if(iLow(g_symbol, PERIOD_M15, index - j) <= iLow(g_symbol, PERIOD_M15, index))
          return false;
@@ -894,6 +922,12 @@ void GetHODLOD(double &hod, double &lod)
    hod = -DBL_MAX;
    lod = DBL_MAX;
    int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0)
+   {
+      hod = iHigh(g_symbol, PERIOD_D1, 0);
+      lod = iLow(g_symbol, PERIOD_D1, 0);
+      return;
+   }
    int todayId = NYDayId(TimeCurrent());
    for(int i = 0; i < bars; i++)
    {
@@ -916,6 +950,8 @@ bool GetSessionHighLowNY(int startMin, int endMin, int dayOffset, double &high, 
    high = -DBL_MAX;
    low = DBL_MAX;
    int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0)
+      return false;
    int targetDay = NYDayId(TimeCurrent() + dayOffset * 86400);
    for(int i = 0; i < bars; i++)
    {
@@ -967,10 +1003,14 @@ void GetPSHPSL(double &psh, double &psl)
 bool FindEqualHighCluster(double &level)
 {
    double atr = ATR(PERIOD_M15, 1);
-   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
    int count = 0;
    level = 0.0;
-   for(int i = 2; i < InpEqScanBars; i++)
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int scanBars = MathMin(cfg_InpEqScanBars, bars - 1);
+   if(scanBars <= 2)
+      return false;
+   for(int i = 2; i < scanBars; i++)
    {
       if(!IsConfirmedPivotHigh(i))
          continue;
@@ -984,7 +1024,7 @@ bool FindEqualHighCluster(double &level)
       {
          count++;
       }
-      if(count >= InpEqClusterMin)
+      if(count >= cfg_InpEqClusterMin)
          return true;
    }
    return false;
@@ -993,10 +1033,14 @@ bool FindEqualHighCluster(double &level)
 bool FindEqualLowCluster(double &level)
 {
    double atr = ATR(PERIOD_M15, 1);
-   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
    int count = 0;
    level = 0.0;
-   for(int i = 2; i < InpEqScanBars; i++)
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int scanBars = MathMin(cfg_InpEqScanBars, bars - 1);
+   if(scanBars <= 2)
+      return false;
+   for(int i = 2; i < scanBars; i++)
    {
       if(!IsConfirmedPivotLow(i))
          continue;
@@ -1010,7 +1054,7 @@ bool FindEqualLowCluster(double &level)
       {
          count++;
       }
-      if(count >= InpEqClusterMin)
+      if(count >= cfg_InpEqClusterMin)
          return true;
    }
    return false;
@@ -1020,6 +1064,8 @@ bool DetectLiquiditySweep(TradeDir &sweepDir, double &sweepLevel)
 {
    sweepDir = DIR_NONE;
    sweepLevel = 0.0;
+   if(iBars(g_symbol, PERIOD_M15) <= 1)
+      return false;
    double eqHigh = 0.0;
    double eqLow = 0.0;
    bool hasHigh = FindEqualHighCluster(eqHigh);
@@ -1028,7 +1074,7 @@ bool DetectLiquiditySweep(TradeDir &sweepDir, double &sweepLevel)
    double low1 = iLow(g_symbol, PERIOD_M15, 1);
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
    double atr = ATR(PERIOD_M15, 1);
-   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
    if(hasHigh && high1 > eqHigh + tol && close1 < eqHigh)
    {
       sweepDir = DIR_SHORT;
@@ -1047,6 +1093,8 @@ bool DetectLiquiditySweep(TradeDir &sweepDir, double &sweepLevel)
 bool DisplacementOk(TradeDir dir, double &score)
 {
    score = 0.0;
+   if(iBars(g_symbol, PERIOD_M15) <= 1)
+      return false;
    double high1 = iHigh(g_symbol, PERIOD_M15, 1);
    double low1 = iLow(g_symbol, PERIOD_M15, 1);
    double open1 = iOpen(g_symbol, PERIOD_M15, 1);
@@ -1056,7 +1104,7 @@ bool DisplacementOk(TradeDir dir, double &score)
    double atr = ATR(PERIOD_M15, 1);
    double bodyRatio = (range > 0.0) ? body / range : 0.0;
    bool dirOk = (dir == DIR_LONG) ? (close1 > open1) : (close1 < open1);
-   bool sizeOk = range >= atr * InpDisplacementATR && bodyRatio >= InpDisplacementBodyRatio;
+   bool sizeOk = range >= atr * cfg_InpDisplacementATR && bodyRatio >= cfg_InpDisplacementBodyRatio;
    if(dirOk && sizeOk)
       score = range / (atr > 0.0 ? atr : 1.0);
    return dirOk && sizeOk;
@@ -1068,7 +1116,11 @@ bool FindOrderBlock(TradeDir dir, double &obHigh, double &obLow, double &obMT, i
    obLow = 0.0;
    obMT = 0.0;
    obAgeBars = -1;
-   for(int i = 2; i <= InpOBLookback; i++)
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int lookback = MathMin(cfg_InpOBLookback, bars - 1);
+   if(lookback < 2)
+      return false;
+   for(int i = 2; i <= lookback; i++)
    {
       double open = iOpen(g_symbol, PERIOD_M15, i);
       double close = iClose(g_symbol, PERIOD_M15, i);
@@ -1089,24 +1141,28 @@ bool OTEOk(TradeDir dir, double price, double &oteMin, double &oteMax, double &s
 {
    swingHigh = -DBL_MAX;
    swingLow = DBL_MAX;
-   int bars = iBars(g_symbol, InpOTE_HTF);
-   int lookback = MathMin(InpOTE_SwingLookback, bars - 1);
+   int bars = iBars(g_symbol, cfg_InpOTE_HTF);
+   if(bars <= 1)
+      return false;
+   int lookback = MathMin(cfg_InpOTE_SwingLookback, bars - 1);
+   if(lookback < 1)
+      return false;
    for(int i = 1; i <= lookback; i++)
    {
-      swingHigh = MathMax(swingHigh, iHigh(g_symbol, InpOTE_HTF, i));
-      swingLow = MathMin(swingLow, iLow(g_symbol, InpOTE_HTF, i));
+      swingHigh = MathMax(swingHigh, iHigh(g_symbol, cfg_InpOTE_HTF, i));
+      swingLow = MathMin(swingLow, iLow(g_symbol, cfg_InpOTE_HTF, i));
    }
    if(swingHigh <= swingLow)
       return false;
    double range = swingHigh - swingLow;
    if(dir == DIR_LONG)
    {
-      oteMin = swingHigh - range * InpOTE_Max;
-      oteMax = swingHigh - range * InpOTE_Min;
+      oteMin = swingHigh - range * cfg_InpOTE_Max;
+      oteMax = swingHigh - range * cfg_InpOTE_Min;
       return (price >= oteMin && price <= oteMax && price <= (swingHigh - range * 0.5));
    }
-   oteMin = swingLow + range * InpOTE_Min;
-   oteMax = swingLow + range * InpOTE_Max;
+   oteMin = swingLow + range * cfg_InpOTE_Min;
+   oteMax = swingLow + range * cfg_InpOTE_Max;
    return (price >= oteMin && price <= oteMax && price >= (swingLow + range * 0.5));
 }
 
@@ -1118,11 +1174,15 @@ bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, doubl
    lastLow = prevLow = 0.0;
 
    int bars = iBars(g_symbol, PERIOD_M15);
-   int start = InpPivotLen + InpPivotConfirmBars;
-   int end = MathMin(bars - InpPivotLen - 1, 200);
+   if(bars <= 0)
+      return false;
+   int start = cfg_InpPivotLen + cfg_InpPivotConfirmBars;
+   int end = MathMin(bars - cfg_InpPivotLen - 1, 200);
+   if(end <= start)
+      return false;
    for(int i = start; i < end; i++)
    {
-      if(i - InpPivotConfirmBars < 0)
+      if(i - cfg_InpPivotConfirmBars < 0)
          continue;
 
       if(IsConfirmedPivotHigh(i))
@@ -1168,19 +1228,19 @@ bool BOSStateValid(TradeDir dir, double &bosLevel)
    int shift = iBarShift(g_symbol, PERIOD_M15, bosTime, true);
    if(shift < 0)
       return false;
-   return shift <= InpMaxBarsAfterBOS;
+   return shift <= cfg_InpMaxBarsAfterBOS;
 }
 
 bool BreakRetestOk(TradeDir dir, double atrM15)
 {
-   if(!InpUseBreakRetest)
+   if(!cfg_InpUseBreakRetest)
       return true;
 
    double storedBosLevel = 0.0;
    if(!BOSStateValid(dir, storedBosLevel))
       return false;
 
-   double tol = MathMax(atrM15 * InpRetestTolATR, 5 * g_point);
+   double tol = MathMax(atrM15 * cfg_InpRetestTolATR, 5 * g_point);
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
    double low1 = iLow(g_symbol, PERIOD_M15, 1);
    double high1 = iHigh(g_symbol, PERIOD_M15, 1);
@@ -1194,7 +1254,7 @@ bool BreakRetestOk(TradeDir dir, double atrM15)
 
 double NearestKeyLevel(double price)
 {
-   double step = InpKeyLevelStepPrice;
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
    if(step <= 0.0)
       return price;
    return MathRound(price / step) * step;
@@ -1202,25 +1262,25 @@ double NearestKeyLevel(double price)
 
 double KeyBelow(double price)
 {
-   double step = InpKeyLevelStepPrice;
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
    return MathFloor(price / step) * step;
 }
 
 double KeyAbove(double price)
 {
-   double step = InpKeyLevelStepPrice;
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
    return MathCeil(price / step) * step;
 }
 
 bool KeyLevelNearOk(double mid, double &nearest)
 {
    nearest = NearestKeyLevel(mid);
-   return MathAbs(mid - nearest) <= InpKeyNearPrice;
+   return MathAbs(mid - nearest) <= PriceFromPoints(cfg_KeyNearPoints);
 }
 
 bool AntiChaseOk(TradeDir dir, double mid, double nearest)
 {
-   double step = InpKeyLevelStepPrice;
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
    if(step <= 0.0)
       return true;
    double chaseKey = nearest;
@@ -1229,24 +1289,28 @@ bool AntiChaseOk(TradeDir dir, double mid, double nearest)
    else if(dir == DIR_SHORT && nearest < mid)
       chaseKey = nearest + step;
 
+   double chaseMax = PriceFromPoints(cfg_KeyChaseMaxDistPoints);
    if(dir == DIR_LONG)
-      return (mid - chaseKey <= InpKeyChaseMaxDistPrice);
+      return (mid - chaseKey <= chaseMax);
    if(dir == DIR_SHORT)
-      return (chaseKey - mid <= InpKeyChaseMaxDistPrice);
+      return (chaseKey - mid <= chaseMax);
    return false;
 }
 
 int FVGDirection(double &zoneMid, double priceMid)
 {
-   if(!InpUseFVGFeature)
+   if(!cfg_InpUseFVGFeature)
       return 0;
 
    int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 3)
+      return 0;
    double bestDist = DBL_MAX;
    int bestDir = 0;
    double bestMid = 0.0;
 
-   for(int i = 1; i <= InpFVGScanBars; i++)
+   int scanBars = MathMin(cfg_InpFVGScanBars, bars - 3);
+   for(int i = 1; i <= scanBars; i++)
    {
       if(i + 2 >= bars)
          break;
@@ -1284,7 +1348,7 @@ int FVGDirection(double &zoneMid, double priceMid)
 
 bool FVGOk(TradeDir dir, double mid, double atrM15)
 {
-   if(!InpUseFVGFeature)
+   if(!cfg_InpUseFVGFeature)
       return true;
 
    double zoneMid = 0.0;
@@ -1292,13 +1356,13 @@ bool FVGOk(TradeDir dir, double mid, double atrM15)
    if(fvgDir == 0 || fvgDir != dir)
       return false;
 
-   return MathAbs(mid - zoneMid) <= atrM15 * InpFVGMaxDistATR;
+   return MathAbs(mid - zoneMid) <= atrM15 * cfg_InpFVGMaxDistATR;
 }
 
 bool FibFilterOk(TradeDir dir, double mid, double lastLow, double lastHigh, bool &oteBonus)
 {
    oteBonus = false;
-   if(!InpUseFibFilter)
+   if(!cfg_InpUseFibFilter)
       return true;
 
    double range = MathAbs(lastHigh - lastLow);
@@ -1309,32 +1373,33 @@ bool FibFilterOk(TradeDir dir, double mid, double lastLow, double lastHigh, bool
    double lvl618 = 0.0;
    if(dir == DIR_LONG)
    {
-      lvl50 = lastHigh - range * InpFibBaseMin;
-      lvl618 = lastHigh - range * InpFibBaseMax;
+      lvl50 = lastHigh - range * cfg_InpFibBaseMin;
+      lvl618 = lastHigh - range * cfg_InpFibBaseMax;
    }
    else
    {
-      lvl50 = lastLow + range * InpFibBaseMin;
-      lvl618 = lastLow + range * InpFibBaseMax;
+      lvl50 = lastLow + range * cfg_InpFibBaseMin;
+      lvl618 = lastLow + range * cfg_InpFibBaseMax;
    }
 
-   double minLvl = MathMin(lvl50, lvl618) - InpFibTolPrice;
-   double maxLvl = MathMax(lvl50, lvl618) + InpFibTolPrice;
+   double tol = PriceFromPoints(cfg_FibTolPoints);
+   double minLvl = MathMin(lvl50, lvl618) - tol;
+   double maxLvl = MathMax(lvl50, lvl618) + tol;
    bool inBase = (mid >= minLvl && mid <= maxLvl);
 
-   if(InpUseOTEBonus)
+   if(cfg_InpUseOTEBonus)
    {
       double otemin = 0.0;
       double otemax = 0.0;
       if(dir == DIR_LONG)
       {
-         otemin = lastHigh - range * InpOTEMax;
-         otemax = lastHigh - range * InpOTEMin;
+         otemin = lastHigh - range * cfg_InpOTEMax;
+         otemax = lastHigh - range * cfg_InpOTEMin;
       }
       else
       {
-         otemin = lastLow + range * InpOTEMin;
-         otemax = lastLow + range * InpOTEMax;
+         otemin = lastLow + range * cfg_InpOTEMin;
+         otemax = lastLow + range * cfg_InpOTEMax;
       }
       double omin = MathMin(otemin, otemax);
       double omax = MathMax(otemin, otemax);
@@ -1349,11 +1414,11 @@ bool FootprintOk(TradeDir dir, double atrM15, bool &absorption, bool &accepted)
 {
    absorption = false;
    accepted = true;
-   if(!InpUseFootprintProxy)
+   if(!cfg_InpUseFootprintProxy)
       return true;
 
    double vol = (double)iVolume(g_symbol, PERIOD_M15, 1);
-   double volMA = VolumeMA(PERIOD_M15, InpFP_VolMAPeriod, 2);
+   double volMA = VolumeMA(PERIOD_M15, cfg_InpFP_VolMAPeriod, 2);
    double volRatio = (volMA > 0.0) ? vol / volMA : 0.0;
    double high = iHigh(g_symbol, PERIOD_M15, 1);
    double low = iLow(g_symbol, PERIOD_M15, 1);
@@ -1371,33 +1436,33 @@ bool FootprintOk(TradeDir dir, double atrM15, bool &absorption, bool &accepted)
          closeSide = 1.0 - (close - low) / range;
    }
 
-   accepted = (volRatio >= InpFP_VolSpikeRatio && bodyRatio >= InpFP_BodyMinRatio && closeSide >= InpFP_CloseSideMin);
+   accepted = (volRatio >= cfg_InpFP_VolSpikeRatio && bodyRatio >= cfg_InpFP_BodyMinRatio && closeSide >= cfg_InpFP_CloseSideMin);
 
-   if(volRatio >= InpFP_AbsorpVolRatio && range <= atrM15 * InpFP_AbsorpRangeATR && closeSide < 0.55)
+   if(volRatio >= cfg_InpFP_AbsorpVolRatio && range <= atrM15 * cfg_InpFP_AbsorpRangeATR && closeSide < 0.55)
       absorption = true;
 
-   if(InpFP_RequireAcceptance)
+   if(cfg_InpFP_RequireAcceptance)
       return accepted && !absorption;
    return !absorption;
 }
 
 bool SpikeGuardOk(double atrM15)
 {
-   if(!InpUseSpikeGuard)
+   if(!cfg_InpUseSpikeGuard)
       return true;
 
    double high = iHigh(g_symbol, PERIOD_M15, 1);
    double low = iLow(g_symbol, PERIOD_M15, 1);
-   return (high - low) <= atrM15 * InpSpikeMultATR;
+   return (high - low) <= atrM15 * cfg_InpSpikeMultATR;
 }
 
 bool RSIAfterLossOk(TradeDir dir)
 {
-   if(!InpUseRSIAfterLoss)
+   if(!cfg_InpUseRSIAfterLoss)
       return true;
 
    int lossStreak = GVGetInt("lossStreak", 0);
-   if(lossStreak < InpLossStreakForRSI)
+   if(lossStreak < cfg_InpLossStreakForRSI)
       return true;
 
    double rsi1 = RSI(PERIOD_M15, 1);
@@ -1418,7 +1483,7 @@ bool SelectOurPosition()
       {
          string symbol = PositionGetString(POSITION_SYMBOL);
          long magic = PositionGetInteger(POSITION_MAGIC);
-         if(symbol == g_symbol && magic == InpMagic)
+         if(symbol == g_symbol && magic == cfg_InpMagic)
             return true;
       }
    }
@@ -1432,13 +1497,13 @@ bool HasPosition()
 
 bool DailyLossLocked()
 {
-   if(!InpUseMaxDailyLossLock)
+   if(!cfg_InpUseMaxDailyLossLock)
       return false;
 
    double startEquity = GVGetDouble("dayEquityStart", AccountInfoDouble(ACCOUNT_EQUITY));
    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
    double pct = (startEquity > 0.0) ? (equity - startEquity) / startEquity * 100.0 : 0.0;
-   if(pct <= -InpMaxDailyLossPct)
+   if(pct <= -cfg_InpMaxDailyLossPct)
    {
       GVSetInt("dayLocked", 1);
       return true;
@@ -1448,7 +1513,7 @@ bool DailyLossLocked()
 
 bool SoftEquityLocked()
 {
-   if(!InpUseSoftEquityLock)
+   if(!cfg_InpUseSoftEquityLock)
       return false;
 
    double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
@@ -1462,8 +1527,8 @@ bool SoftEquityLocked()
    double start = GVGetDouble("dayEquityStart", equity);
    double gainPct = (peak - start) / start * 100.0;
    double curPct = (equity - start) / start * 100.0;
-   if((gainPct >= InpSoftEqTrigger2 && curPct <= InpSoftEqFloor2) ||
-      (gainPct >= InpSoftEqTrigger1 && curPct <= InpSoftEqFloor1))
+   if((gainPct >= cfg_InpSoftEqTrigger2 && curPct <= cfg_InpSoftEqFloor2) ||
+      (gainPct >= cfg_InpSoftEqTrigger1 && curPct <= cfg_InpSoftEqFloor1))
    {
       GVSetInt("dayLocked", 1);
       return true;
@@ -1475,7 +1540,7 @@ int DailyScore(RegimeState regime)
 {
    double adx = ADX(PERIOD_H1, 1);
    double vol = (double)iVolume(g_symbol, PERIOD_H1, 1);
-   double volAvg = VolumeMA(PERIOD_H1, InpVolMAPeriod, 2);
+   double volAvg = VolumeMA(PERIOD_H1, cfg_InpVolMAPeriod, 2);
    double volScore = (volAvg > 0.0) ? MathMin(30.0, (vol / volAvg) * 15.0) : 0.0;
    double adxScore = MathMin(30.0, adx);
 
@@ -1483,7 +1548,7 @@ int DailyScore(RegimeState regime)
    if(g_spreadEma > 0.0)
    {
       double spread = SpreadPoints();
-      spreadScore = 20.0 * MathMax(0.0, 1.0 - (spread / (g_spreadEma * InpSpreadSpikeFactor)));
+      spreadScore = 20.0 * MathMax(0.0, 1.0 - (spread / (g_spreadEma * cfg_InpSpreadSpikeFactor)));
    }
 
    double regimeScore = 0.0;
@@ -1539,7 +1604,7 @@ bool CooldownActive()
    int shift = iBarShift(g_symbol, PERIOD_M15, lastEntryTime, true);
    if(shift < 0)
       return false;
-   return shift <= InpCooldownBarsAfterEntry;
+   return shift <= cfg_InpCooldownBarsAfterEntry;
 }
 
 void UpdateDailyReset()
@@ -1570,7 +1635,7 @@ bool HardGuardsOk(int &skipMask)
       skipMask |= SKIP_ROLLOVER;
       return false;
    }
-   if(SpreadPoints() > InpMaxSpreadPoints)
+   if(SpreadPoints() > cfg_InpMaxSpreadPoints)
    {
       skipMask |= SKIP_SPREAD;
       return false;
@@ -1610,7 +1675,7 @@ bool HardGuardsOk(int &skipMask)
 
 bool LossBlocksActive()
 {
-   if(!InpUseAntiChop)
+   if(!cfg_InpUseAntiChop)
       return false;
 
    datetime blockUntil = (datetime)GVGetDouble("blockUntil", 0.0);
@@ -1619,17 +1684,17 @@ bool LossBlocksActive()
 
 void UpdateLossBlock(int lossStreak)
 {
-   if(!InpUseAntiChop)
+   if(!cfg_InpUseAntiChop)
       return;
 
    if(lossStreak >= 3)
    {
-      GVSetDouble("blockUntil", TimeCurrent() + InpLossBlock3_Hours * 3600.0);
-      GVSetDouble("riskCutUntil", TimeCurrent() + InpRiskCutAfter3Loss_H * 3600.0);
+      GVSetDouble("blockUntil", TimeCurrent() + cfg_InpLossBlock3_Hours * 3600.0);
+      GVSetDouble("riskCutUntil", TimeCurrent() + cfg_InpRiskCutAfter3Loss_H * 3600.0);
    }
    else if(lossStreak == 2)
    {
-      GVSetDouble("blockUntil", TimeCurrent() + InpLossBlock2_Hours * 3600.0);
+      GVSetDouble("blockUntil", TimeCurrent() + cfg_InpLossBlock2_Hours * 3600.0);
    }
 }
 
@@ -1638,7 +1703,7 @@ double CurrentRiskMultiplier(double dailyRiskMult)
    double mult = dailyRiskMult;
    datetime riskCutUntil = (datetime)GVGetDouble("riskCutUntil", 0.0);
    if(riskCutUntil > TimeCurrent())
-      mult *= InpRiskMultAfter3Loss;
+      mult *= cfg_InpRiskMultAfter3Loss;
    return mult;
 }
 
@@ -1671,8 +1736,8 @@ double CalcLots(double slDist, double riskPct)
    double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
 
    lot = MathMax(minLot, lot);
-   if(InpMaxLotCap > 0.0)
-      maxLot = MathMin(maxLot, InpMaxLotCap);
+   if(cfg_InpMaxLotCap > 0.0)
+      maxLot = MathMin(maxLot, cfg_InpMaxLotCap);
    lot = MathMin(lot, maxLot);
    return NormalizeVolumeByStep(lot);
 }
@@ -1735,7 +1800,7 @@ bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const s
 {
    retcode = 0;
    lasterr = 0;
-   for(int attempt = 0; attempt <= InpMaxRetries; attempt++)
+   for(int attempt = 0; attempt <= cfg_InpMaxRetries; attempt++)
    {
       bool ok = false;
       ResetLastError();
@@ -1756,7 +1821,7 @@ bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const s
          retcode == TRADE_RETCODE_TRADE_CONTEXT_BUSY ||
          retcode == TRADE_RETCODE_SERVER_BUSY)
       {
-         Sleep(InpRetryDelayMs);
+         Sleep(cfg_InpRetryDelayMs);
          continue;
       }
       break;
@@ -1764,142 +1829,98 @@ bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const s
    return false;
 }
 
-#undef InpUseSessionFilter
-#undef InpStartHour
-#undef InpEndHour
-#undef InpMaxSpreadPoints
-#undef InpMaxSlippagePoints
-#undef InpMaxRetries
-#undef InpRetryDelayMs
-#undef InpUseICTTime
-#undef InpUseManualNYOffset
-#undef InpNYOffsetHours
-#undef InpAutoNYDST
-#undef InpNYOffsetSummerHours
-#undef InpUseKillzoneAsia
-#undef InpUseKillzoneLondon
-#undef InpUseKillzoneNY
-#undef InpATRPeriod
-#undef InpADXPeriod
-#undef InpRSIPeriod
-#undef InpEMA_Fast
-#undef InpEMA_Slow
-#undef InpRegimeConfirmBarsH1
-#undef InpRegimeLockBarsH1
-#undef InpPivotLen
-#undef InpPivotConfirmBars
-#undef InpMaxBarsAfterBOS
-#undef InpEqToleranceATR
-#undef InpEqToleranceMinPoints
-#undef InpEqClusterMin
-#undef InpEqScanBars
-#undef InpDisplacementATR
-#undef InpDisplacementBodyRatio
-#undef InpDisplacementSearchBars
-#undef InpOBLookback
-#undef InpOBMaxAgeBars
-#undef InpOTE_HTF
-#undef InpOTE_SwingLookback
-#undef InpOTE_Min
-#undef InpOTE_Max
-#undef InpMinPDArrayDistance
-#undef InpMinPDArrayATR
-#undef InpMinPDArrayMinPoints
-#undef InpUseBreakRetest
-#undef InpRetestTolATR
-#undef InpKeyLevelStepPrice
-#undef InpKeyNearPrice
-#undef InpKeyChaseMaxDistPrice
-#undef InpUseFVGFeature
-#undef InpFVGScanBars
-#undef InpFVGMaxDistATR
-#undef InpUseFibFilter
-#undef InpFibBaseMin
-#undef InpFibBaseMax
-#undef InpFibTolPrice
-#undef InpUseOTEBonus
-#undef InpOTEMin
-#undef InpOTEMax
-#undef InpOTEBonusPoints
-#undef InpUseFootprintProxy
-#undef InpFP_VolMAPeriod
-#undef InpFP_VolSpikeRatio
-#undef InpFP_BodyMinRatio
-#undef InpFP_CloseSideMin
-#undef InpFP_AbsorpVolRatio
-#undef InpFP_AbsorpRangeATR
-#undef InpFP_RequireAcceptance
-#undef InpFP_ScoreBonus
-#undef InpUseSpikeGuard
-#undef InpSpikeMultATR
-#undef InpSL_ATR_Mult
-#undef InpSL_MinBufferPrice
-#undef InpUseMMSL
-#undef InpMMSL_Pips
-#undef InpMMSL_ExtraBufferPrice
-#undef InpTP_RR_Main
-#undef InpMinRRAllowed
-#undef InpUseTP1Partial
-#undef InpTP1_CloseFrac
-#undef InpTP1_UseKeyLevelFirst
-#undef InpUseSmartBE
-#undef InpBE_MinProfitR
-#undef InpBE_OffsetPrice
-#undef InpUseATRTrailAfterTP1
-#undef InpTrailATR_Mult
-#undef InpTrailMinImprovePrice
-#undef InpTrailOnNewBarOnly
-#undef InpBaseRiskPct
-#undef InpMaxLotCap
-#undef InpUseLowVolFilter
-#undef InpVolTF
-#undef InpVolMAPeriod
-#undef InpLowVolFactor
-#undef InpUseSpreadMultiple
-#undef InpSpreadMultiple
-#undef InpSpreadMultipleBlockMin
-#undef InpUseSpreadInstability
-#undef InpSpreadAvgBarsH1
-#undef InpSpreadSpikeFactor
-#undef InpSpreadSpikeBlockMin
-#undef InpUseRolloverBlock
-#undef InpRolloverStart
-#undef InpRolloverEnd
-#undef InpUseDailyTradeControl
-#undef InpHardMaxTradesPerDay
-#undef InpUseMaxDailyLossLock
-#undef InpMaxDailyLossPct
-#undef InpUseSoftEquityLock
-#undef InpSoftEqTrigger1
-#undef InpSoftEqFloor1
-#undef InpSoftEqTrigger2
-#undef InpSoftEqFloor2
-#undef InpCooldownBarsAfterEntry
-#undef InpUseAntiChop
-#undef InpLossBlock2_Hours
-#undef InpLossBlock3_Hours
-#undef InpRiskMultAfter3Loss
-#undef InpRiskCutAfter3Loss_H
-#undef InpUseRSIAfterLoss
-#undef InpLossStreakForRSI
-#undef InpUsePyramiding
-#undef InpMaxAdds
-#undef InpPyramidMinProfitR
-#undef InpPyramidRequireMainBE
-#undef InpPyramidSpacingATR
-#undef InpPyramidOnlyInTrend
-#undef InpPyramidRequireAdxRising
-#undef InpPyramidUsePeakDDCap
-#undef InpPyramidMaxPeakDDPct
-#undef InpAddRiskMult1
-#undef InpAddRiskMult2
 
 string PresetModeLabel(PresetMode mode);
 void LogPresetConfig();
 void LogSymbolCheck();
 
+double GoldPriceToPips(double price)
+{
+   return price / 0.10;
+}
+
+double GoldPointsToPips(double points)
+{
+   return points / 10.0;
+}
+
+double IndexKeyStepPoints()
+{
+   string symUpper = StringUpper(g_symbol);
+   if(StringFind(symUpper, "US30") >= 0 || StringFind(symUpper, "DJ30") >= 0)
+      return 100.0;
+   return 50.0;
+}
+
+void ApplyProfileDefaults()
+{
+   if(g_isGoldSymbol)
+   {
+      cfg_KeyLevelStepPoints = PointsFromPrice(cfg_InpKeyLevelStepPrice);
+      cfg_KeyNearPoints = PointsFromPrice(cfg_InpKeyNearPrice);
+      cfg_KeyChaseMaxDistPoints = PointsFromPrice(cfg_InpKeyChaseMaxDistPrice);
+      cfg_EqToleranceMinPoints = cfg_InpEqToleranceMinPoints;
+      cfg_SL_MinBufferPoints = PointsFromPrice(cfg_InpSL_MinBufferPrice);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(cfg_InpMMSL_ExtraBufferPrice);
+      cfg_BE_OffsetPoints = PointsFromPrice(cfg_InpBE_OffsetPrice);
+      cfg_TrailMinImprovePoints = PointsFromPrice(cfg_InpTrailMinImprovePrice);
+      cfg_FibTolPoints = PointsFromPrice(cfg_InpFibTolPrice);
+      cfg_MinPDArrayDistancePoints = PointsFromPrice(cfg_InpMinPDArrayDistance);
+      cfg_MinPDArrayMinPoints = cfg_InpMinPDArrayMinPoints;
+      return;
+   }
+
+   if(g_profile == PROFILE_INDICES)
+   {
+      cfg_KeyLevelStepPoints = PointsFromPrice(IndexKeyStepPoints());
+      cfg_KeyNearPoints = PointsFromPrice(5.0);
+   }
+   else
+   {
+      cfg_KeyLevelStepPoints = PointsFromPips(50.0);
+      cfg_KeyNearPoints = PointsFromPips(5.0);
+   }
+   cfg_KeyChaseMaxDistPoints = cfg_KeyLevelStepPoints * 0.30;
+
+   double slPips = GoldPriceToPips(cfg_InpSL_MinBufferPrice);
+   double bePips = GoldPriceToPips(cfg_InpBE_OffsetPrice);
+   double trailPips = GoldPriceToPips(cfg_InpTrailMinImprovePrice);
+   double fibPips = GoldPriceToPips(cfg_InpFibTolPrice);
+   double pdPips = GoldPriceToPips(cfg_InpMinPDArrayDistance);
+   double mmslExtraPips = GoldPriceToPips(cfg_InpMMSL_ExtraBufferPrice);
+   double eqTolPips = GoldPointsToPips(cfg_InpEqToleranceMinPoints);
+   double pdMinPips = GoldPointsToPips(cfg_InpMinPDArrayMinPoints);
+
+   if(g_profile == PROFILE_INDICES)
+   {
+      cfg_SL_MinBufferPoints = PointsFromPrice(slPips);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(mmslExtraPips);
+      cfg_BE_OffsetPoints = PointsFromPrice(bePips);
+      cfg_TrailMinImprovePoints = PointsFromPrice(trailPips);
+      cfg_FibTolPoints = PointsFromPrice(fibPips);
+      cfg_EqToleranceMinPoints = PointsFromPrice(eqTolPips);
+      cfg_MinPDArrayDistancePoints = PointsFromPrice(pdPips);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPrice(pdMinPips));
+   }
+   else
+   {
+      cfg_SL_MinBufferPoints = PointsFromPips(slPips);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPips(mmslExtraPips);
+      cfg_BE_OffsetPoints = PointsFromPips(bePips);
+      cfg_TrailMinImprovePoints = PointsFromPips(trailPips);
+      cfg_FibTolPoints = PointsFromPips(fibPips);
+      cfg_EqToleranceMinPoints = PointsFromPips(eqTolPips);
+      cfg_MinPDArrayDistancePoints = PointsFromPips(pdPips);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPips(pdMinPips));
+   }
+}
+
 void ApplyPreset()
 {
+   cfg_InpPresetMode = InpPresetMode;
+   cfg_InpSymbolOverride = InpSymbolOverride;
+   cfg_InpMagic = InpMagic;
+   cfg_InpPipPrice = InpPipPrice;
    cfg_InpUseSessionFilter = InpUseSessionFilter;
    cfg_InpStartHour = InpStartHour;
    cfg_InpEndHour = InpEndHour;
@@ -2029,8 +2050,10 @@ void ApplyPreset()
    cfg_InpPyramidMaxPeakDDPct = InpPyramidMaxPeakDDPct;
    cfg_InpAddRiskMult1 = InpAddRiskMult1;
    cfg_InpAddRiskMult2 = InpAddRiskMult2;
+   cfg_InpEnableCSV = InpEnableCSV;
+   cfg_InpCSVName = InpCSVName;
 
-   if(InpPresetMode == PRESET_BALANCED || InpPresetMode == PRESET_CONSERVATIVE)
+   if(cfg_InpPresetMode == PRESET_BALANCED || cfg_InpPresetMode == PRESET_CONSERVATIVE)
    {
       cfg_InpUseICTTime = true;
       cfg_InpUseManualNYOffset = true;
@@ -2102,7 +2125,7 @@ void ApplyPreset()
       cfg_InpRiskCutAfter3Loss_H = 24;
       cfg_InpUsePyramiding = false;
 
-      if(InpPresetMode == PRESET_CONSERVATIVE)
+      if(cfg_InpPresetMode == PRESET_CONSERVATIVE)
       {
          cfg_InpUseKillzoneAsia = false;
          cfg_InpUseKillzoneLondon = false;
@@ -2114,6 +2137,12 @@ void ApplyPreset()
       }
    }
 
+   if(cfg_InpPipPrice > 0.0)
+      g_pip = cfg_InpPipPrice;
+   else
+      g_pip = (g_profile == PROFILE_INDICES) ? 1.0 : g_point * 10.0;
+
+   ApplyProfileDefaults();
    LogPresetConfig();
 }
 
@@ -2133,7 +2162,9 @@ string PresetModeLabel(PresetMode mode)
 
 void LogPresetConfig()
 {
-   Print("Preset applied: ", PresetModeLabel(InpPresetMode));
+   Print("Preset applied: ", PresetModeLabel(cfg_InpPresetMode));
+   PrintFormat("Profile: %s Symbol=%s Point=%.5f Pip=%.5f",
+               ProfileName(g_profile), g_symbol, g_point, g_pip);
    if(cfg_InpUseManualNYOffset)
    {
       string dstNote = cfg_InpAutoNYDST ? "auto DST" : "manual DST";
@@ -2156,35 +2187,35 @@ void LogPresetConfig()
                cfg_InpRegimeConfirmBarsH1, cfg_InpRegimeLockBarsH1);
    PrintFormat("SMC: PivotLen=%d PivotConfirm=%d MaxBarsAfterBOS=%d EqScanBars=%d EqClusterMin=%d EqTolATR=%.2f EqTolMinPts=%.2f",
                cfg_InpPivotLen, cfg_InpPivotConfirmBars, cfg_InpMaxBarsAfterBOS,
-               cfg_InpEqScanBars, cfg_InpEqClusterMin, cfg_InpEqToleranceATR, cfg_InpEqToleranceMinPoints);
+               cfg_InpEqScanBars, cfg_InpEqClusterMin, cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints);
    PrintFormat("SMC: DisplacementATR=%.2f BodyRatio=%.2f SearchBars=%d OBLookback=%d OBMaxAgeBars=%d",
                cfg_InpDisplacementATR, cfg_InpDisplacementBodyRatio, cfg_InpDisplacementSearchBars,
                cfg_InpOBLookback, cfg_InpOBMaxAgeBars);
-   PrintFormat("SMC: OTE_HTF=%d SwingLookback=%d OTE_Min=%.2f OTE_Max=%.2f PDArrayDist=%.2f PDArrayATR=%.2f PDArrayMinPts=%d",
+   PrintFormat("SMC: OTE_HTF=%d SwingLookback=%d OTE_Min=%.2f OTE_Max=%.2f PDArrayDistPts=%.1f PDArrayATR=%.2f PDArrayMinPts=%d",
                cfg_InpOTE_HTF, cfg_InpOTE_SwingLookback, cfg_InpOTE_Min, cfg_InpOTE_Max,
-               cfg_InpMinPDArrayDistance, cfg_InpMinPDArrayATR, cfg_InpMinPDArrayMinPoints);
-   PrintFormat("Filters: BreakRetest=%s RetestTolATR=%.2f KeyStep=%.2f KeyNear=%.2f KeyChaseMax=%.2f",
+               cfg_MinPDArrayDistancePoints, cfg_InpMinPDArrayATR, cfg_MinPDArrayMinPoints);
+   PrintFormat("Filters: BreakRetest=%s RetestTolATR=%.2f KeyStepPts=%.1f KeyNearPts=%.1f KeyChaseMaxPts=%.1f",
                (cfg_InpUseBreakRetest ? "true" : "false"), cfg_InpRetestTolATR,
-               cfg_InpKeyLevelStepPrice, cfg_InpKeyNearPrice, cfg_InpKeyChaseMaxDistPrice);
-   PrintFormat("FVG/Fib: FVG=%s ScanBars=%d MaxDistATR=%.2f Fib=%s BaseMin=%.2f BaseMax=%.3f FibTol=%.2f OTEBonus=%s OTE_Min=%.2f OTE_Max=%.2f BonusPts=%d",
+               cfg_KeyLevelStepPoints, cfg_KeyNearPoints, cfg_KeyChaseMaxDistPoints);
+   PrintFormat("FVG/Fib: FVG=%s ScanBars=%d MaxDistATR=%.2f Fib=%s BaseMin=%.2f BaseMax=%.3f FibTolPts=%.1f OTEBonus=%s OTE_Min=%.2f OTE_Max=%.2f BonusPts=%d",
                (cfg_InpUseFVGFeature ? "true" : "false"), cfg_InpFVGScanBars, cfg_InpFVGMaxDistATR,
                (cfg_InpUseFibFilter ? "true" : "false"), cfg_InpFibBaseMin, cfg_InpFibBaseMax,
-               cfg_InpFibTolPrice, (cfg_InpUseOTEBonus ? "true" : "false"),
+               cfg_FibTolPoints, (cfg_InpUseOTEBonus ? "true" : "false"),
                cfg_InpOTEMin, cfg_InpOTEMax, cfg_InpOTEBonusPoints);
    PrintFormat("Footprint/Spike: FP=%s VolMAPeriod=%d VolSpike=%.2f BodyMin=%.2f CloseSideMin=%.2f AbsorpVol=%.2f AbsorpRangeATR=%.2f RequireAccept=%s ScoreBonus=%d SpikeGuard=%s SpikeATR=%.2f",
                (cfg_InpUseFootprintProxy ? "true" : "false"), cfg_InpFP_VolMAPeriod, cfg_InpFP_VolSpikeRatio,
                cfg_InpFP_BodyMinRatio, cfg_InpFP_CloseSideMin, cfg_InpFP_AbsorpVolRatio, cfg_InpFP_AbsorpRangeATR,
                (cfg_InpFP_RequireAcceptance ? "true" : "false"), cfg_InpFP_ScoreBonus,
                (cfg_InpUseSpikeGuard ? "true" : "false"), cfg_InpSpikeMultATR);
-   PrintFormat("Stops/Targets: SL_ATR=%.2f SL_MinBuffer=%.2f MMSL=%s MMSL_Pips=%d MMSL_Extra=%.2f RR=%.2f MinRR=%.2f TP1=%s TP1_Close=%.2f KeyFirst=%s",
-               cfg_InpSL_ATR_Mult, cfg_InpSL_MinBufferPrice, (cfg_InpUseMMSL ? "true" : "false"),
-               cfg_InpMMSL_Pips, cfg_InpMMSL_ExtraBufferPrice, cfg_InpTP_RR_Main, cfg_InpMinRRAllowed,
+   PrintFormat("Stops/Targets: SL_ATR=%.2f SL_MinBufferPts=%.1f MMSL=%s MMSL_Pips=%d MMSL_ExtraPts=%.1f RR=%.2f MinRR=%.2f TP1=%s TP1_Close=%.2f KeyFirst=%s",
+               cfg_InpSL_ATR_Mult, cfg_SL_MinBufferPoints, (cfg_InpUseMMSL ? "true" : "false"),
+               cfg_InpMMSL_Pips, cfg_MMSL_ExtraBufferPoints, cfg_InpTP_RR_Main, cfg_InpMinRRAllowed,
                (cfg_InpUseTP1Partial ? "true" : "false"), cfg_InpTP1_CloseFrac,
                (cfg_InpTP1_UseKeyLevelFirst ? "true" : "false"));
-   PrintFormat("BE/Trail: SmartBE=%s MinProfitR=%.2f BE_Offset=%.2f TrailAfterTP1=%s ATR_Mult=%.2f MinImprove=%.2f NewBarOnly=%s",
-               (cfg_InpUseSmartBE ? "true" : "false"), cfg_InpBE_MinProfitR, cfg_InpBE_OffsetPrice,
+   PrintFormat("BE/Trail: SmartBE=%s MinProfitR=%.2f BE_OffsetPts=%.1f TrailAfterTP1=%s ATR_Mult=%.2f MinImprovePts=%.1f NewBarOnly=%s",
+               (cfg_InpUseSmartBE ? "true" : "false"), cfg_InpBE_MinProfitR, cfg_BE_OffsetPoints,
                (cfg_InpUseATRTrailAfterTP1 ? "true" : "false"), cfg_InpTrailATR_Mult,
-               cfg_InpTrailMinImprovePrice, (cfg_InpTrailOnNewBarOnly ? "true" : "false"));
+               cfg_TrailMinImprovePoints, (cfg_InpTrailOnNewBarOnly ? "true" : "false"));
    PrintFormat("Risk/Daily: BaseRiskPct=%.2f MaxLot=%.2f DailyControl=%s MaxTrades=%d MaxDailyLoss=%s %.2f%% SoftEqLock=%s Triggers=%.2f/%.2f Floors=%.2f/%.2f CooldownBars=%d",
                cfg_InpBaseRiskPct, cfg_InpMaxLotCap, (cfg_InpUseDailyTradeControl ? "true" : "false"),
                cfg_InpHardMaxTradesPerDay, (cfg_InpUseMaxDailyLossLock ? "true" : "false"),
@@ -2206,147 +2237,21 @@ void LogPresetConfig()
 void LogSymbolCheck()
 {
    string symUpper = StringUpper(g_symbol);
-   bool symbolMatch = (StringFind(symUpper, "GOLD") >= 0 || StringFind(symUpper, "XAUUSD") >= 0);
+   bool symbolMatch = (StringFind(symUpper, "GOLD") >= 0 || StringFind(symUpper, "XAU") >= 0);
    bool digitsOk = (g_digits == 2 && MathAbs(g_point - 0.01) <= 0.000001);
 
-   Print("Symbol check: symbol=", g_symbol, " match=", (symbolMatch ? "true" : "false"),
-         " digits=", g_digits, " point=", DoubleToString(g_point, 5));
+   Print("Symbol check: symbol=", g_symbol, " profile=", ProfileName(g_profile),
+         " digits=", g_digits, " point=", DoubleToString(g_point, 5), " pip=", DoubleToString(g_pip, 5));
 
-   if(!symbolMatch)
-      Print("Warning: Symbol is not GOLD/XAUUSD. Verify XM GOLD settings.");
-   if(!digitsOk)
-      Print("Warning: Unexpected digits/point. Expected digits=2 and point=0.01. Verify InpPipPrice/g_pip for XM GOLD.");
+   if(g_isGoldSymbol)
+   {
+      if(!symbolMatch)
+         Print("Warning: Symbol is not GOLD/XAUUSD. Verify XM GOLD settings.");
+      if(!digitsOk)
+         Print("Warning: Unexpected digits/point for GOLD. Expected digits=2 and point=0.01. Verify cfg_InpPipPrice/g_pip.");
+   }
 }
 
-#define InpUseSessionFilter cfg_InpUseSessionFilter
-#define InpStartHour cfg_InpStartHour
-#define InpEndHour cfg_InpEndHour
-#define InpMaxSpreadPoints cfg_InpMaxSpreadPoints
-#define InpMaxSlippagePoints cfg_InpMaxSlippagePoints
-#define InpMaxRetries cfg_InpMaxRetries
-#define InpRetryDelayMs cfg_InpRetryDelayMs
-#define InpUseICTTime cfg_InpUseICTTime
-#define InpUseManualNYOffset cfg_InpUseManualNYOffset
-#define InpNYOffsetHours cfg_InpNYOffsetHours
-#define InpAutoNYDST cfg_InpAutoNYDST
-#define InpNYOffsetSummerHours cfg_InpNYOffsetSummerHours
-#define InpUseKillzoneAsia cfg_InpUseKillzoneAsia
-#define InpUseKillzoneLondon cfg_InpUseKillzoneLondon
-#define InpUseKillzoneNY cfg_InpUseKillzoneNY
-#define InpATRPeriod cfg_InpATRPeriod
-#define InpADXPeriod cfg_InpADXPeriod
-#define InpRSIPeriod cfg_InpRSIPeriod
-#define InpEMA_Fast cfg_InpEMA_Fast
-#define InpEMA_Slow cfg_InpEMA_Slow
-#define InpRegimeConfirmBarsH1 cfg_InpRegimeConfirmBarsH1
-#define InpRegimeLockBarsH1 cfg_InpRegimeLockBarsH1
-#define InpPivotLen cfg_InpPivotLen
-#define InpPivotConfirmBars cfg_InpPivotConfirmBars
-#define InpMaxBarsAfterBOS cfg_InpMaxBarsAfterBOS
-#define InpEqToleranceATR cfg_InpEqToleranceATR
-#define InpEqToleranceMinPoints cfg_InpEqToleranceMinPoints
-#define InpEqClusterMin cfg_InpEqClusterMin
-#define InpEqScanBars cfg_InpEqScanBars
-#define InpDisplacementATR cfg_InpDisplacementATR
-#define InpDisplacementBodyRatio cfg_InpDisplacementBodyRatio
-#define InpDisplacementSearchBars cfg_InpDisplacementSearchBars
-#define InpOBLookback cfg_InpOBLookback
-#define InpOBMaxAgeBars cfg_InpOBMaxAgeBars
-#define InpOTE_HTF cfg_InpOTE_HTF
-#define InpOTE_SwingLookback cfg_InpOTE_SwingLookback
-#define InpOTE_Min cfg_InpOTE_Min
-#define InpOTE_Max cfg_InpOTE_Max
-#define InpMinPDArrayDistance cfg_InpMinPDArrayDistance
-#define InpMinPDArrayATR cfg_InpMinPDArrayATR
-#define InpMinPDArrayMinPoints cfg_InpMinPDArrayMinPoints
-#define InpUseBreakRetest cfg_InpUseBreakRetest
-#define InpRetestTolATR cfg_InpRetestTolATR
-#define InpKeyLevelStepPrice cfg_InpKeyLevelStepPrice
-#define InpKeyNearPrice cfg_InpKeyNearPrice
-#define InpKeyChaseMaxDistPrice cfg_InpKeyChaseMaxDistPrice
-#define InpUseFVGFeature cfg_InpUseFVGFeature
-#define InpFVGScanBars cfg_InpFVGScanBars
-#define InpFVGMaxDistATR cfg_InpFVGMaxDistATR
-#define InpUseFibFilter cfg_InpUseFibFilter
-#define InpFibBaseMin cfg_InpFibBaseMin
-#define InpFibBaseMax cfg_InpFibBaseMax
-#define InpFibTolPrice cfg_InpFibTolPrice
-#define InpUseOTEBonus cfg_InpUseOTEBonus
-#define InpOTEMin cfg_InpOTEMin
-#define InpOTEMax cfg_InpOTEMax
-#define InpOTEBonusPoints cfg_InpOTEBonusPoints
-#define InpUseFootprintProxy cfg_InpUseFootprintProxy
-#define InpFP_VolMAPeriod cfg_InpFP_VolMAPeriod
-#define InpFP_VolSpikeRatio cfg_InpFP_VolSpikeRatio
-#define InpFP_BodyMinRatio cfg_InpFP_BodyMinRatio
-#define InpFP_CloseSideMin cfg_InpFP_CloseSideMin
-#define InpFP_AbsorpVolRatio cfg_InpFP_AbsorpVolRatio
-#define InpFP_AbsorpRangeATR cfg_InpFP_AbsorpRangeATR
-#define InpFP_RequireAcceptance cfg_InpFP_RequireAcceptance
-#define InpFP_ScoreBonus cfg_InpFP_ScoreBonus
-#define InpUseSpikeGuard cfg_InpUseSpikeGuard
-#define InpSpikeMultATR cfg_InpSpikeMultATR
-#define InpSL_ATR_Mult cfg_InpSL_ATR_Mult
-#define InpSL_MinBufferPrice cfg_InpSL_MinBufferPrice
-#define InpUseMMSL cfg_InpUseMMSL
-#define InpMMSL_Pips cfg_InpMMSL_Pips
-#define InpMMSL_ExtraBufferPrice cfg_InpMMSL_ExtraBufferPrice
-#define InpTP_RR_Main cfg_InpTP_RR_Main
-#define InpMinRRAllowed cfg_InpMinRRAllowed
-#define InpUseTP1Partial cfg_InpUseTP1Partial
-#define InpTP1_CloseFrac cfg_InpTP1_CloseFrac
-#define InpTP1_UseKeyLevelFirst cfg_InpTP1_UseKeyLevelFirst
-#define InpUseSmartBE cfg_InpUseSmartBE
-#define InpBE_MinProfitR cfg_InpBE_MinProfitR
-#define InpBE_OffsetPrice cfg_InpBE_OffsetPrice
-#define InpUseATRTrailAfterTP1 cfg_InpUseATRTrailAfterTP1
-#define InpTrailATR_Mult cfg_InpTrailATR_Mult
-#define InpTrailMinImprovePrice cfg_InpTrailMinImprovePrice
-#define InpTrailOnNewBarOnly cfg_InpTrailOnNewBarOnly
-#define InpBaseRiskPct cfg_InpBaseRiskPct
-#define InpMaxLotCap cfg_InpMaxLotCap
-#define InpUseLowVolFilter cfg_InpUseLowVolFilter
-#define InpVolTF cfg_InpVolTF
-#define InpVolMAPeriod cfg_InpVolMAPeriod
-#define InpLowVolFactor cfg_InpLowVolFactor
-#define InpUseSpreadMultiple cfg_InpUseSpreadMultiple
-#define InpSpreadMultiple cfg_InpSpreadMultiple
-#define InpSpreadMultipleBlockMin cfg_InpSpreadMultipleBlockMin
-#define InpUseSpreadInstability cfg_InpUseSpreadInstability
-#define InpSpreadAvgBarsH1 cfg_InpSpreadAvgBarsH1
-#define InpSpreadSpikeFactor cfg_InpSpreadSpikeFactor
-#define InpSpreadSpikeBlockMin cfg_InpSpreadSpikeBlockMin
-#define InpUseRolloverBlock cfg_InpUseRolloverBlock
-#define InpRolloverStart cfg_InpRolloverStart
-#define InpRolloverEnd cfg_InpRolloverEnd
-#define InpUseDailyTradeControl cfg_InpUseDailyTradeControl
-#define InpHardMaxTradesPerDay cfg_InpHardMaxTradesPerDay
-#define InpUseMaxDailyLossLock cfg_InpUseMaxDailyLossLock
-#define InpMaxDailyLossPct cfg_InpMaxDailyLossPct
-#define InpUseSoftEquityLock cfg_InpUseSoftEquityLock
-#define InpSoftEqTrigger1 cfg_InpSoftEqTrigger1
-#define InpSoftEqFloor1 cfg_InpSoftEqFloor1
-#define InpSoftEqTrigger2 cfg_InpSoftEqTrigger2
-#define InpSoftEqFloor2 cfg_InpSoftEqFloor2
-#define InpCooldownBarsAfterEntry cfg_InpCooldownBarsAfterEntry
-#define InpUseAntiChop cfg_InpUseAntiChop
-#define InpLossBlock2_Hours cfg_InpLossBlock2_Hours
-#define InpLossBlock3_Hours cfg_InpLossBlock3_Hours
-#define InpRiskMultAfter3Loss cfg_InpRiskMultAfter3Loss
-#define InpRiskCutAfter3Loss_H cfg_InpRiskCutAfter3Loss_H
-#define InpUseRSIAfterLoss cfg_InpUseRSIAfterLoss
-#define InpLossStreakForRSI cfg_InpLossStreakForRSI
-#define InpUsePyramiding cfg_InpUsePyramiding
-#define InpMaxAdds cfg_InpMaxAdds
-#define InpPyramidMinProfitR cfg_InpPyramidMinProfitR
-#define InpPyramidRequireMainBE cfg_InpPyramidRequireMainBE
-#define InpPyramidSpacingATR cfg_InpPyramidSpacingATR
-#define InpPyramidOnlyInTrend cfg_InpPyramidOnlyInTrend
-#define InpPyramidRequireAdxRising cfg_InpPyramidRequireAdxRising
-#define InpPyramidUsePeakDDCap cfg_InpPyramidUsePeakDDCap
-#define InpPyramidMaxPeakDDPct cfg_InpPyramidMaxPeakDDPct
-#define InpAddRiskMult1 cfg_InpAddRiskMult1
-#define InpAddRiskMult2 cfg_InpAddRiskMult2
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
             int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
             int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
@@ -2354,19 +2259,19 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
             int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
             int oteOk)
 {
-   if(!InpEnableCSV)
+   if(!cfg_InpEnableCSV)
       return;
 
-   int handle = FileOpen(InpCSVName, FILE_READ | FILE_WRITE | FILE_CSV | FILE_ANSI);
+   int handle = FileOpen(cfg_InpCSVName, FILE_READ | FILE_WRITE | FILE_CSV | FILE_ANSI);
    if(handle == INVALID_HANDLE)
-      handle = FileOpen(InpCSVName, FILE_WRITE | FILE_CSV | FILE_ANSI);
+      handle = FileOpen(cfg_InpCSVName, FILE_WRITE | FILE_CSV | FILE_ANSI);
 
    if(handle == INVALID_HANDLE)
       return;
 
    if(FileSize(handle) == 0)
    {
-      FileWrite(handle, "time", "sym", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
+      FileWrite(handle, "time", "sym", "profile", "point", "pip", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
                 "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
                 "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
                 "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
@@ -2388,7 +2293,10 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
    FileWrite(handle,
              TimeToString(TimeCurrent(), TIME_DATE|TIME_MINUTES),
              g_symbol,
-             (string)InpMagic,
+             ProfileName(g_profile),
+             DoubleToString(g_point, 5),
+             DoubleToString(g_pip, 5),
+             (string)cfg_InpMagic,
              event,
              (int)dir,
              DoubleToString(entry, g_digits),
@@ -2471,7 +2379,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    bool kzAsia = false;
    bool kzLondon = false;
    bool kzNY = false;
-   if(InpUseICTTime)
+   if(cfg_InpUseICTTime)
    {
       bool kzActive = KillzoneActive(kzAsia, kzLondon, kzNY);
       killzoneActive = kzActive ? 1 : 0;
@@ -2552,7 +2460,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    entryMask |= ENTRY_ANTICHASE;
    setupScore += 5;
 
-   if(InpUseFVGFeature)
+   if(cfg_InpUseFVGFeature)
    {
       if(!FVGOk(dir, mid, atrM15))
          return false;
@@ -2566,7 +2474,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    entryMask |= ENTRY_FIB;
    setupScore += 10;
    if(oteBonus)
-      setupScore += InpOTEBonusPoints;
+      setupScore += cfg_InpOTEBonusPoints;
 
    double oteMin = 0.0;
    double oteMax = 0.0;
@@ -2577,7 +2485,8 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    oteOk = 1;
    entryMask |= ENTRY_OTE;
    setupScore += 10;
-   if(MathAbs(mid - swingHigh) <= InpKeyNearPrice || MathAbs(mid - swingLow) <= InpKeyNearPrice)
+   if(MathAbs(mid - swingHigh) <= PriceFromPoints(cfg_KeyNearPoints) ||
+      MathAbs(mid - swingLow) <= PriceFromPoints(cfg_KeyNearPoints))
       entryMask |= ENTRY_SR;
 
    bool absorption = false;
@@ -2586,7 +2495,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
       return false;
    entryMask |= ENTRY_FOOTPRINT;
    if(acceptance)
-      timingScore += InpFP_ScoreBonus;
+      timingScore += cfg_InpFP_ScoreBonus;
 
    if(!SpikeGuardOk(atrM15))
       return false;
@@ -2599,7 +2508,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    int obAgeBars = -1;
    if(!FindOrderBlock(dir, obHigh, obLow, obMT, obAgeBars))
       return false;
-   if(obAgeBars > InpOBMaxAgeBars)
+   if(obAgeBars > cfg_InpOBMaxAgeBars)
       return false;
    if(!(mid >= obLow && mid <= obHigh))
       return false;
@@ -2607,31 +2516,31 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    setupScore += 10;
 
    entry = (dir == DIR_LONG) ? SymbolInfoDouble(g_symbol, SYMBOL_ASK) : SymbolInfoDouble(g_symbol, SYMBOL_BID);
-   double atrBuf = atrM15 * InpSL_ATR_Mult;
+   double atrBuf = atrM15 * cfg_InpSL_ATR_Mult;
    double spreadBuf = SpreadPoints() * g_point * 0.5;
-   double buffer = MathMax(InpSL_MinBufferPrice, MathMax(atrBuf, spreadBuf));
+   double buffer = MathMax(PriceFromPoints(cfg_SL_MinBufferPoints), MathMax(atrBuf, spreadBuf));
 
    sl = (dir == DIR_LONG) ? (lastLow - buffer) : (lastHigh + buffer);
    riskR = MathAbs(entry - sl);
    if(riskR <= 0.0)
       return false;
 
-   if(InpUseMMSL)
+   if(cfg_InpUseMMSL)
    {
-      double mmsl = InpMMSL_Pips * PipPrice() + InpMMSL_ExtraBufferPrice;
+      double mmsl = cfg_InpMMSL_Pips * PipPrice() + PriceFromPoints(cfg_MMSL_ExtraBufferPoints);
       if(riskR < mmsl)
          return false;
       entryMask |= ENTRY_MMSL;
    }
 
-   tp = (dir == DIR_LONG) ? (entry + riskR * InpTP_RR_Main) : (entry - riskR * InpTP_RR_Main);
+   tp = (dir == DIR_LONG) ? (entry + riskR * cfg_InpTP_RR_Main) : (entry - riskR * cfg_InpTP_RR_Main);
    double rr = MathAbs(tp - entry) / riskR;
-   if(rr < InpMinRRAllowed)
+   if(rr < cfg_InpMinRRAllowed)
       return false;
    entryMask |= ENTRY_RR;
 
    tp1 = (dir == DIR_LONG) ? (entry + riskR) : (entry - riskR);
-   if(InpUseTP1Partial && InpTP1_UseKeyLevelFirst)
+   if(cfg_InpUseTP1Partial && cfg_InpTP1_UseKeyLevelFirst)
    {
       if(dir == DIR_LONG)
       {
@@ -2650,7 +2559,7 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    double target = (dir == DIR_LONG) ? MathMin(MathMin(pdh, psh > 0.0 ? psh : pdh), hod)
                                      : MathMax(MathMax(pdl, psl > 0.0 ? psl : pdl), lod);
    double space = (dir == DIR_LONG) ? (target - entry) : (entry - target);
-   if(space < InpMinPDArrayDistance)
+   if(space < PriceFromPoints(cfg_MinPDArrayDistancePoints))
    {
       skipMask |= SKIP_PDARRAY;
       return false;
@@ -2706,11 +2615,11 @@ void ManagePosition(double riskR)
    else
       tp1Hit = (tp1price > 0.0 && SymbolInfoDouble(g_symbol, SYMBOL_ASK) <= tp1price);
 
-   if(InpUseTP1Partial && !tp1done && tp1Hit)
+   if(cfg_InpUseTP1Partial && !tp1done && tp1Hit)
    {
       double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
       double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
-      double closeVol = MathFloor((volume * InpTP1_CloseFrac) / step) * step;
+      double closeVol = MathFloor((volume * cfg_InpTP1_CloseFrac) / step) * step;
       closeVol = NormalizeVolumeByStep(closeVol);
       if(closeVol >= minLot && (volume - closeVol) >= minLot && FreezeOkForClose())
       {
@@ -2725,25 +2634,28 @@ void ManagePosition(double riskR)
       }
    }
 
-   if(InpUseSmartBE && profitR >= InpBE_MinProfitR)
+   if(cfg_InpUseSmartBE && profitR >= cfg_InpBE_MinProfitR)
    {
-      double newSL = (type == POSITION_TYPE_BUY) ? (entry + InpBE_OffsetPrice) : (entry - InpBE_OffsetPrice);
+      double newSL = (type == POSITION_TYPE_BUY) ? (entry + PriceFromPoints(cfg_BE_OffsetPoints))
+                                                 : (entry - PriceFromPoints(cfg_BE_OffsetPoints));
       TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
       if(CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp) &&
          ((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl)))
          trade.PositionModify(ticket, newSL, tp);
    }
 
-   if(InpUseATRTrailAfterTP1 && tp1done)
+   if(cfg_InpUseATRTrailAfterTP1 && tp1done)
    {
-      if(!InpTrailOnNewBarOnly || IsNewBar(PERIOD_M15, g_lastM15Bar))
+      if(!cfg_InpTrailOnNewBarOnly || IsNewBar(PERIOD_M15, g_lastM15Bar))
       {
          double atr = ATR(PERIOD_M15, 1);
-         double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * InpTrailATR_Mult) : (price + atr * InpTrailATR_Mult);
+         double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * cfg_InpTrailATR_Mult) : (price + atr * cfg_InpTrailATR_Mult);
          TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
-         if(type == POSITION_TYPE_BUY && newSL > sl + InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp))
+         if(type == POSITION_TYPE_BUY && newSL > sl + PriceFromPoints(cfg_TrailMinImprovePoints) && CanModifyStops(newSL) &&
+            StopsOk(dir, entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
-         else if(type == POSITION_TYPE_SELL && newSL < sl - InpTrailMinImprovePrice && CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp))
+         else if(type == POSITION_TYPE_SELL && newSL < sl - PriceFromPoints(cfg_TrailMinImprovePoints) && CanModifyStops(newSL) &&
+                 StopsOk(dir, entry, newSL, tp))
             trade.PositionModify(ticket, newSL, tp);
       }
    }
@@ -2752,13 +2664,13 @@ void ManagePosition(double riskR)
 
 void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
 {
-   if(!InpUsePyramiding || !pyramidAllowed)
+   if(!cfg_InpUsePyramiding || !pyramidAllowed)
       return;
    if(!SelectOurPosition())
       return;
 
    int addCount = GVGetInt("addCount", 0);
-   if(addCount >= InpMaxAdds)
+   if(addCount >= cfg_InpMaxAdds)
       return;
 
    int type = (int)PositionGetInteger(POSITION_TYPE);
@@ -2767,15 +2679,15 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
    double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
    double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
 
-   if(profitR < InpPyramidMinProfitR)
+   if(profitR < cfg_InpPyramidMinProfitR)
       return;
 
    double lastAddPrice = GVGetDouble("lastAddPrice", entry);
    double atr = ATR(PERIOD_M15, 1);
-   if(MathAbs(price - lastAddPrice) < atr * InpPyramidSpacingATR)
+   if(MathAbs(price - lastAddPrice) < atr * cfg_InpPyramidSpacingATR)
       return;
 
-   if(InpPyramidRequireMainBE)
+   if(cfg_InpPyramidRequireMainBE)
    {
       if(type == POSITION_TYPE_BUY && sl < entry + g_point)
          return;
@@ -2783,10 +2695,10 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
          return;
    }
 
-   if(InpPyramidOnlyInTrend && regime != REGIME_TREND)
+   if(cfg_InpPyramidOnlyInTrend && regime != REGIME_TREND)
       return;
 
-   if(InpPyramidRequireAdxRising)
+   if(cfg_InpPyramidRequireAdxRising)
    {
       double adx1 = ADX(PERIOD_H1, 1);
       double adx2 = ADX(PERIOD_H1, 2);
@@ -2794,21 +2706,21 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
          return;
    }
 
-   if(InpPyramidUsePeakDDCap)
+   if(cfg_InpPyramidUsePeakDDCap)
    {
       double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
       double equity = AccountInfoDouble(ACCOUNT_EQUITY);
       double dd = (peak - equity) / peak * 100.0;
-      if(dd > InpPyramidMaxPeakDDPct)
+      if(dd > cfg_InpPyramidMaxPeakDDPct)
          return;
    }
 
-   double riskMult = (addCount == 0) ? InpAddRiskMult1 : InpAddRiskMult2;
-   double addLots = CalcLots(riskR, InpBaseRiskPct * riskMult);
+   double riskMult = (addCount == 0) ? cfg_InpAddRiskMult1 : cfg_InpAddRiskMult2;
+   double addLots = CalcLots(riskR, cfg_InpBaseRiskPct * riskMult);
    if(addLots <= 0.0)
       return;
 
-   double addTp = (type == POSITION_TYPE_BUY) ? (price + riskR * InpTP_RR_Main) : (price - riskR * InpTP_RR_Main);
+   double addTp = (type == POSITION_TYPE_BUY) ? (price + riskR * cfg_InpTP_RR_Main) : (price - riskR * cfg_InpTP_RR_Main);
    TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
    if(!StopsOk(dir, price, sl, addTp))
       return;
@@ -2835,12 +2747,14 @@ int OnInit()
    g_symbol = ResolveSymbol();
    g_digits = (int)SymbolInfoInteger(g_symbol, SYMBOL_DIGITS);
    g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
+   g_isGoldSymbol = IsGoldSymbol(g_symbol);
+   g_profile = DetectSymbolProfile(g_symbol);
    g_pip = g_point * 10.0;
 
    ApplyPreset();
 
-   trade.SetExpertMagicNumber((uint)InpMagic);
-   trade.SetDeviationInPoints(InpMaxSlippagePoints);
+   trade.SetExpertMagicNumber((uint)cfg_InpMagic);
+   trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
 
    double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
    double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
@@ -2908,7 +2822,7 @@ void OnTick()
    int maxTrades = 0;
    double dailyRiskMult = 0.0;
    bool pyramidAllowed = false;
-   if(InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
+   if(cfg_InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
    {
       skipMask |= SKIP_DAILY_SCORE;
       double bosLevel = 0.0;
@@ -2919,8 +2833,8 @@ void OnTick()
       return;
    }
 
-   int allowedTrades = InpHardMaxTradesPerDay;
-   if(InpUseDailyTradeControl)
+   int allowedTrades = cfg_InpHardMaxTradesPerDay;
+   if(cfg_InpUseDailyTradeControl)
       allowedTrades = MathMin(allowedTrades, maxTrades);
    if(dayTrades >= allowedTrades)
    {
@@ -2962,7 +2876,7 @@ void OnTick()
       return;
 
    double riskMult = CurrentRiskMultiplier(dailyRiskMult);
-   double lots = CalcLots(riskR, InpBaseRiskPct * riskMult);
+   double lots = CalcLots(riskR, cfg_InpBaseRiskPct * riskMult);
    if(lots <= 0.0)
       return;
 
@@ -3007,7 +2921,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
       return;
    if(trans.symbol != g_symbol)
       return;
-   if(trans.magic != InpMagic)
+   if(trans.magic != cfg_InpMagic)
       return;
 
    double profit = trans.profit + trans.commission + trans.swap;

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -1,6 +1,13 @@
 //+------------------------------------------------------------------+
 //|                                     XAUUSD Killer XM (MT5)       |
 //|   Trend-follow + SMC light - production-safe single file EA      |
+//|                                                                  |
+//| CHANGELOG                                                       |
+//| - Added ICT/SMC modules: NY killzones, PD arrays, liquidity      |
+//|   sweeps, displacement, MSS/BOS, order blocks + RTO/MT, and OTE  |
+//|   premium/discount filters with HTF swings.                      |
+//| - Expanded CSV logging to include ICT context (killzone, PDH/PDL,|
+//|   sweep/displacement/OB/OTE metadata).                           |
 //+------------------------------------------------------------------+
 #property strict
 #include <Trade/Trade.mqh>
@@ -42,6 +49,13 @@ input bool InpUseSessionFilter = true;
 input int  InpStartHour = 6;
 input int  InpEndHour = 23;
 
+input bool InpUseICTTime = true;
+input bool InpUseManualNYOffset = true;
+input int  InpNYOffsetHours = -5;
+input bool InpUseKillzoneAsia = true;
+input bool InpUseKillzoneLondon = true;
+input bool InpUseKillzoneNY = true;
+
 input int    InpATRPeriod = 14;
 input int    InpADXPeriod = 14;
 input int    InpRSIPeriod = 14;
@@ -54,6 +68,21 @@ input int    InpRegimeLockBarsH1 = 4;
 input int    InpPivotLen = 3;
 input int    InpPivotConfirmBars = 2;
 input int    InpMaxBarsAfterBOS = 6;
+
+input double InpEqToleranceATR = 0.25;
+input double InpEqToleranceMinPoints = 8;
+input int    InpEqClusterMin = 2;
+input int    InpEqScanBars = 40;
+input double InpDisplacementATR = 1.1;
+input double InpDisplacementBodyRatio = 0.55;
+input int    InpOBLookback = 10;
+input int    InpOBMaxAgeBars = 12;
+
+input ENUM_TIMEFRAMES InpOTE_HTF = PERIOD_H1;
+input int    InpOTE_SwingLookback = 48;
+input double InpOTE_Min = 0.62;
+input double InpOTE_Max = 0.79;
+input double InpMinPDArrayDistance = 0.80;
 
 input bool   InpUseBreakRetest = true;
 input double InpRetestTolATR = 0.15;
@@ -188,7 +217,9 @@ enum SkipMask
    SKIP_LOSS_BLOCK = 1 << 8,
    SKIP_DAILY_MAX = 1 << 9,
    SKIP_DAILY_SCORE = 1 << 10,
-   SKIP_STOPS = 1 << 11
+   SKIP_STOPS = 1 << 11,
+   SKIP_KILLZONE = 1 << 12,
+   SKIP_PDARRAY = 1 << 13
 };
 
 enum EntryMask
@@ -207,7 +238,15 @@ enum EntryMask
    ENTRY_SPIKE = 1 << 10,
    ENTRY_RSI_LOSS = 1 << 11,
    ENTRY_MMSL = 1 << 12,
-   ENTRY_RR = 1 << 13
+   ENTRY_RR = 1 << 13,
+   ENTRY_KILLZONE = 1 << 14,
+   ENTRY_SWEEP = 1 << 15,
+   ENTRY_DISPLACEMENT = 1 << 16,
+   ENTRY_MSS = 1 << 17,
+   ENTRY_OB_RTO = 1 << 18,
+   ENTRY_OTE = 1 << 19,
+   ENTRY_PDARRAY = 1 << 20,
+   ENTRY_SR = 1 << 21
 };
 
 string GVName(const string key)
@@ -278,6 +317,41 @@ int MinutesOfDay(datetime t)
    MqlDateTime dt;
    TimeToStruct(t, dt);
    return dt.hour * 60 + dt.min;
+}
+
+int GetServerUtcOffsetSeconds()
+{
+   return (int)(TimeTradeServer() - TimeGMT());
+}
+
+datetime ToNYTime(datetime serverTime)
+{
+   int serverOffset = GetServerUtcOffsetSeconds();
+   int nyOffset = InpUseManualNYOffset ? (InpNYOffsetHours * 3600) : (-5 * 3600);
+   return serverTime - serverOffset + nyOffset;
+}
+
+int MinutesOfDayNY(datetime serverTime)
+{
+   datetime ny = ToNYTime(serverTime);
+   return MinutesOfDay(ny);
+}
+
+bool KillzoneActive(bool &isAsia, bool &isLondon, bool &isNY)
+{
+   isAsia = false;
+   isLondon = false;
+   isNY = false;
+   if(!InpUseICTTime)
+      return false;
+   int minNY = MinutesOfDayNY(TimeCurrent());
+   if(InpUseKillzoneAsia && minNY >= 20 * 60 && minNY < 22 * 60)
+      isAsia = true;
+   if(InpUseKillzoneLondon && minNY >= 2 * 60 && minNY < 5 * 60)
+      isLondon = true;
+   if(InpUseKillzoneNY && minNY >= 7 * 60 && minNY < 9 * 60)
+      isNY = true;
+   return (isAsia || isLondon || isNY);
 }
 
 bool TimeInRange(const string start, const string end)
@@ -514,6 +588,240 @@ int BOSAgeBars(double &bosLevel)
    if(bosTime == 0)
       return -1;
    return iBarShift(g_symbol, PERIOD_M15, bosTime, true);
+}
+
+int NYDayId(datetime serverTime)
+{
+   MqlDateTime dt;
+   TimeToStruct(ToNYTime(serverTime), dt);
+   return dt.year * 10000 + dt.mon * 100 + dt.day;
+}
+
+void GetPDLevels(double &pdh, double &pdl)
+{
+   pdh = iHigh(g_symbol, PERIOD_D1, 1);
+   pdl = iLow(g_symbol, PERIOD_D1, 1);
+}
+
+void GetHODLOD(double &hod, double &lod)
+{
+   hod = -DBL_MAX;
+   lod = DBL_MAX;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int todayId = NYDayId(TimeCurrent());
+   for(int i = 0; i < bars; i++)
+   {
+      datetime t = iTime(g_symbol, PERIOD_M15, i);
+      if(NYDayId(t) != todayId)
+         break;
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      hod = MathMax(hod, high);
+      lod = MathMin(lod, low);
+   }
+   if(hod == -DBL_MAX)
+      hod = iHigh(g_symbol, PERIOD_D1, 0);
+   if(lod == DBL_MAX)
+      lod = iLow(g_symbol, PERIOD_D1, 0);
+}
+
+bool GetSessionHighLowNY(int startMin, int endMin, int dayOffset, double &high, double &low)
+{
+   high = -DBL_MAX;
+   low = DBL_MAX;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int targetDay = NYDayId(TimeCurrent() + dayOffset * 86400);
+   for(int i = 0; i < bars; i++)
+   {
+      datetime t = iTime(g_symbol, PERIOD_M15, i);
+      if(NYDayId(t) != targetDay)
+         continue;
+      int minNY = MinutesOfDayNY(t);
+      if(minNY >= startMin && minNY < endMin)
+      {
+         high = MathMax(high, iHigh(g_symbol, PERIOD_M15, i));
+         low = MathMin(low, iLow(g_symbol, PERIOD_M15, i));
+      }
+   }
+   return (high > -DBL_MAX && low < DBL_MAX);
+}
+
+void GetPSHPSL(double &psh, double &psl)
+{
+   psh = 0.0;
+   psl = 0.0;
+   int minNY = MinutesOfDayNY(TimeCurrent());
+   double high = 0.0;
+   double low = 0.0;
+   if(minNY >= 9 * 60)
+   {
+      if(GetSessionHighLowNY(7 * 60, 9 * 60, 0, high, low))
+      {
+         psh = high;
+         psl = low;
+         return;
+      }
+   }
+   if(minNY >= 5 * 60)
+   {
+      if(GetSessionHighLowNY(2 * 60, 5 * 60, 0, high, low))
+      {
+         psh = high;
+         psl = low;
+         return;
+      }
+   }
+   if(GetSessionHighLowNY(20 * 60, 22 * 60, -1, high, low))
+   {
+      psh = high;
+      psl = low;
+   }
+}
+
+bool FindEqualHighCluster(double &level)
+{
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   int count = 0;
+   level = 0.0;
+   for(int i = 2; i < InpEqScanBars; i++)
+   {
+      if(!IsConfirmedPivotHigh(i))
+         continue;
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      if(count == 0)
+      {
+         level = high;
+         count = 1;
+      }
+      else if(MathAbs(high - level) <= tol)
+      {
+         count++;
+      }
+      if(count >= InpEqClusterMin)
+         return true;
+   }
+   return false;
+}
+
+bool FindEqualLowCluster(double &level)
+{
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   int count = 0;
+   level = 0.0;
+   for(int i = 2; i < InpEqScanBars; i++)
+   {
+      if(!IsConfirmedPivotLow(i))
+         continue;
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      if(count == 0)
+      {
+         level = low;
+         count = 1;
+      }
+      else if(MathAbs(low - level) <= tol)
+      {
+         count++;
+      }
+      if(count >= InpEqClusterMin)
+         return true;
+   }
+   return false;
+}
+
+bool DetectLiquiditySweep(TradeDir &sweepDir, double &sweepLevel)
+{
+   sweepDir = DIR_NONE;
+   sweepLevel = 0.0;
+   double eqHigh = 0.0;
+   double eqLow = 0.0;
+   bool hasHigh = FindEqualHighCluster(eqHigh);
+   bool hasLow = FindEqualLowCluster(eqLow);
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * InpEqToleranceATR, InpEqToleranceMinPoints * g_point);
+   if(hasHigh && high1 > eqHigh + tol && close1 < eqHigh)
+   {
+      sweepDir = DIR_SHORT;
+      sweepLevel = eqHigh;
+      return true;
+   }
+   if(hasLow && low1 < eqLow - tol && close1 > eqLow)
+   {
+      sweepDir = DIR_LONG;
+      sweepLevel = eqLow;
+      return true;
+   }
+   return false;
+}
+
+bool DisplacementOk(TradeDir dir, double &score)
+{
+   score = 0.0;
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double open1 = iOpen(g_symbol, PERIOD_M15, 1);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double range = high1 - low1;
+   double body = MathAbs(close1 - open1);
+   double atr = ATR(PERIOD_M15, 1);
+   double bodyRatio = (range > 0.0) ? body / range : 0.0;
+   bool dirOk = (dir == DIR_LONG) ? (close1 > open1) : (close1 < open1);
+   bool sizeOk = range >= atr * InpDisplacementATR && bodyRatio >= InpDisplacementBodyRatio;
+   if(dirOk && sizeOk)
+      score = range / (atr > 0.0 ? atr : 1.0);
+   return dirOk && sizeOk;
+}
+
+bool FindOrderBlock(TradeDir dir, double &obHigh, double &obLow, double &obMT, int &obAgeBars)
+{
+   obHigh = 0.0;
+   obLow = 0.0;
+   obMT = 0.0;
+   obAgeBars = -1;
+   for(int i = 2; i <= InpOBLookback; i++)
+   {
+      double open = iOpen(g_symbol, PERIOD_M15, i);
+      double close = iClose(g_symbol, PERIOD_M15, i);
+      bool opposite = (dir == DIR_LONG) ? (close < open) : (close > open);
+      if(opposite)
+      {
+         obHigh = iHigh(g_symbol, PERIOD_M15, i);
+         obLow = iLow(g_symbol, PERIOD_M15, i);
+         obMT = (obHigh + obLow) / 2.0;
+         obAgeBars = i;
+         return true;
+      }
+   }
+   return false;
+}
+
+bool OTEOk(TradeDir dir, double price, double &oteMin, double &oteMax, double &swingHigh, double &swingLow)
+{
+   swingHigh = -DBL_MAX;
+   swingLow = DBL_MAX;
+   int bars = iBars(g_symbol, InpOTE_HTF);
+   int lookback = MathMin(InpOTE_SwingLookback, bars - 1);
+   for(int i = 1; i <= lookback; i++)
+   {
+      swingHigh = MathMax(swingHigh, iHigh(g_symbol, InpOTE_HTF, i));
+      swingLow = MathMin(swingLow, iLow(g_symbol, InpOTE_HTF, i));
+   }
+   if(swingHigh <= swingLow)
+      return false;
+   double range = swingHigh - swingLow;
+   if(dir == DIR_LONG)
+   {
+      oteMin = swingHigh - range * InpOTE_Max;
+      oteMax = swingHigh - range * InpOTE_Min;
+      return (price >= oteMin && price <= oteMax && price <= (swingHigh - range * 0.5));
+   }
+   oteMin = swingLow + range * InpOTE_Min;
+   oteMax = swingLow + range * InpOTE_Max;
+   return (price >= oteMin && price <= oteMax && price >= (swingLow + range * 0.5));
 }
 
 bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, double &prevLow)
@@ -1172,7 +1480,10 @@ bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const s
 
 void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
             int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
-            int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey)
+            int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
+            int killzoneActive, double pdh, double pdl, double psh, double psl, double hod, double lod,
+            int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
+            int oteOk)
 {
    if(!InpEnableCSV)
       return;
@@ -1189,7 +1500,9 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
       FileWrite(handle, "time", "sym", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
                 "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
                 "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
-                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price");
+                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
+                "killzoneActive", "pdh", "pdl", "psh", "psl", "hod", "lod",
+                "sweepDir", "sweepLevel", "displacementScore", "obHigh", "obLow", "obMT", "oteOk");
    }
 
    int lossStreak = GVGetInt("lossStreak", 0);
@@ -1236,14 +1549,31 @@ void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp
              DoubleToString(bosLevel, g_digits),
              bosAgeBars,
              DoubleToString(nearestKey, g_digits),
-             DoubleToString(tp1, g_digits));
+             DoubleToString(tp1, g_digits),
+             killzoneActive,
+             DoubleToString(pdh, g_digits),
+             DoubleToString(pdl, g_digits),
+             DoubleToString(psh, g_digits),
+             DoubleToString(psl, g_digits),
+             DoubleToString(hod, g_digits),
+             DoubleToString(lod, g_digits),
+             sweepDir,
+             DoubleToString(sweepLevel, g_digits),
+             DoubleToString(displacementScore, 2),
+             DoubleToString(obHigh, g_digits),
+             DoubleToString(obLow, g_digits),
+             DoubleToString(obMT, g_digits),
+             oteOk);
 
    FileClose(handle);
 }
 
 bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
                     int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
-                    double &nearestKey, double &bosLevel, int &bosAgeBars)
+                    double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                    double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                    int &sweepDir, double &sweepLevel, double &displacementScore,
+                    double &obHigh, double &obLow, double &obMT, int &oteOk)
 {
    setupScore = 0;
    timingScore = 0;
@@ -1254,6 +1584,13 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    nearestKey = 0.0;
    bosLevel = 0.0;
    bosAgeBars = -1;
+   killzoneActive = 0;
+   pdh = pdl = psh = psl = hod = lod = 0.0;
+   sweepDir = 0;
+   sweepLevel = 0.0;
+   displacementScore = 0.0;
+   obHigh = obLow = obMT = 0.0;
+   oteOk = 0;
 
    TradeDir bias = BiasH1();
    if(bias == DIR_NONE)
@@ -1261,6 +1598,43 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    dir = bias;
    setupScore += 20;
    entryMask |= ENTRY_BIAS;
+
+   bool kzAsia = false;
+   bool kzLondon = false;
+   bool kzNY = false;
+   if(InpUseICTTime)
+   {
+      bool kzActive = KillzoneActive(kzAsia, kzLondon, kzNY);
+      killzoneActive = kzActive ? 1 : 0;
+      if(!kzActive)
+      {
+         skipMask |= SKIP_KILLZONE;
+         return false;
+      }
+      entryMask |= ENTRY_KILLZONE;
+      setupScore += 5;
+   }
+
+   GetPDLevels(pdh, pdl);
+   GetPSHPSL(psh, psl);
+   GetHODLOD(hod, lod);
+
+   TradeDir sweepDirFound = DIR_NONE;
+   double sweepLevelFound = 0.0;
+   if(!DetectLiquiditySweep(sweepDirFound, sweepLevelFound))
+      return false;
+   if(sweepDirFound != dir)
+      return false;
+   sweepDir = (int)sweepDirFound;
+   sweepLevel = sweepLevelFound;
+   entryMask |= ENTRY_SWEEP;
+   setupScore += 10;
+
+   double atrM15 = ATR(PERIOD_M15, 1);
+   if(!DisplacementOk(sweepDirFound, displacementScore))
+      return false;
+   entryMask |= ENTRY_DISPLACEMENT;
+   setupScore += 10;
 
    double lastHigh = 0.0, prevHigh = 0.0, lastLow = 0.0, prevLow = 0.0;
    if(!FindRecentPivots(lastHigh, prevHigh, lastLow, prevLow))
@@ -1274,11 +1648,16 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    setupScore += 10;
    entryMask |= ENTRY_HL_LH;
 
-   bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
    double close1 = iClose(g_symbol, PERIOD_M15, 1);
-   bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
-   double atrM15 = ATR(PERIOD_M15, 1);
+   if(dir == DIR_LONG && close1 <= lastHigh)
+      return false;
+   if(dir == DIR_SHORT && close1 >= lastLow)
+      return false;
+   entryMask |= ENTRY_MSS;
+   timingScore += 10;
 
+   bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
+   bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
    if(closeConfirm)
    {
       entryMask |= ENTRY_BOS_CLOSE;
@@ -1293,7 +1672,6 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
       bosAgeBars = BOSAgeBars(bosLevel);
       return false;
    }
-   timingScore += 10;
 
    double mid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
    if(!KeyLevelNearOk(mid, nearestKey))
@@ -1303,20 +1681,35 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    if(!AntiChaseOk(dir, mid, nearestKey))
       return false;
    entryMask |= ENTRY_ANTICHASE;
-   setupScore += 10;
-
-   if(!FVGOk(dir, mid, atrM15))
-      return false;
-   entryMask |= ENTRY_FVG;
    setupScore += 5;
+
+   if(InpUseFVGFeature)
+   {
+      if(!FVGOk(dir, mid, atrM15))
+         return false;
+      entryMask |= ENTRY_FVG;
+      setupScore += 5;
+   }
 
    bool oteBonus = false;
    if(!FibFilterOk(dir, mid, lastLow, lastHigh, oteBonus))
       return false;
    entryMask |= ENTRY_FIB;
-   setupScore += 15;
+   setupScore += 10;
    if(oteBonus)
       setupScore += InpOTEBonusPoints;
+
+   double oteMin = 0.0;
+   double oteMax = 0.0;
+   double swingHigh = 0.0;
+   double swingLow = 0.0;
+   if(!OTEOk(dir, mid, oteMin, oteMax, swingHigh, swingLow))
+      return false;
+   oteOk = 1;
+   entryMask |= ENTRY_OTE;
+   setupScore += 10;
+   if(MathAbs(mid - swingHigh) <= InpKeyNearPrice || MathAbs(mid - swingLow) <= InpKeyNearPrice)
+      entryMask |= ENTRY_SR;
 
    bool absorption = false;
    bool acceptance = true;
@@ -1333,6 +1726,16 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
    if(!RSIAfterLossOk(dir))
       return false;
    entryMask |= ENTRY_RSI_LOSS;
+
+   int obAgeBars = -1;
+   if(!FindOrderBlock(dir, obHigh, obLow, obMT, obAgeBars))
+      return false;
+   if(obAgeBars > InpOBMaxAgeBars)
+      return false;
+   if(!(mid >= obLow && mid <= obHigh))
+      return false;
+   entryMask |= ENTRY_OB_RTO;
+   setupScore += 10;
 
    entry = (dir == DIR_LONG) ? SymbolInfoDouble(g_symbol, SYMBOL_ASK) : SymbolInfoDouble(g_symbol, SYMBOL_BID);
    double atrBuf = atrM15 * InpSL_ATR_Mult;
@@ -1374,6 +1777,16 @@ bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double
             tp1 = key;
       }
    }
+
+   double target = (dir == DIR_LONG) ? MathMin(MathMin(pdh, psh > 0.0 ? psh : pdh), hod)
+                                     : MathMax(MathMax(pdl, psl > 0.0 ? psl : pdl), lod);
+   double space = (dir == DIR_LONG) ? (target - entry) : (entry - target);
+   if(space < InpMinPDArrayDistance)
+   {
+      skipMask |= SKIP_PDARRAY;
+      return false;
+   }
+   entryMask |= ENTRY_PDARRAY;
 
    bosAgeBars = BOSAgeBars(bosLevel);
    totalScore = setupScore + timingScore;
@@ -1438,7 +1851,8 @@ void ManagePosition(double riskR)
          double bosLevel = 0.0;
          int bosAgeBars = BOSAgeBars(bosLevel);
          LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0,
-                0, 0, bosLevel, bosAgeBars, 0.0);
+                0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
       }
    }
 
@@ -1541,7 +1955,8 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("PYR", dir, price, sl, addTp, 0.0, addLots, 0, 0, 0, 0, 0, 0,
-             retcode, lasterr, bosLevel, bosAgeBars, 0.0);
+             retcode, lasterr, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
    }
 }
 
@@ -1596,7 +2011,8 @@ void OnTick()
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
-             0, 0, bosLevel, bosAgeBars, 0.0);
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
       return;
    }
    if(!HardGuardsOk(skipMask))
@@ -1604,7 +2020,8 @@ void OnTick()
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
-             0, 0, bosLevel, bosAgeBars, 0.0);
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
       return;
    }
 
@@ -1619,7 +2036,8 @@ void OnTick()
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
-             0, 0, bosLevel, bosAgeBars, 0.0);
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
       return;
    }
 
@@ -1632,7 +2050,8 @@ void OnTick()
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
-             0, 0, bosLevel, bosAgeBars, 0.0);
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
       return;
    }
 
@@ -1643,12 +2062,21 @@ void OnTick()
    double nearestKey = 0.0;
    double bosLevel = 0.0;
    int bosAgeBars = -1;
+   int killzoneActive = 0;
+   double pdh = 0.0, pdl = 0.0, psh = 0.0, psl = 0.0, hod = 0.0, lod = 0.0;
+   int sweepDir = 0;
+   double sweepLevel = 0.0;
+   double displacementScore = 0.0;
+   double obHigh = 0.0, obLow = 0.0, obMT = 0.0;
+   int oteOk = 0;
 
    if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask,
-                      nearestKey, bosLevel, bosAgeBars))
+                      nearestKey, bosLevel, bosAgeBars, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+                      sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk))
    {
       LogCSV("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             0, 0, bosLevel, bosAgeBars, nearestKey);
+             0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
       return;
    }
 
@@ -1664,7 +2092,8 @@ void OnTick()
    {
       skipMask |= SKIP_STOPS;
       LogCSV("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             0, 0, bosLevel, bosAgeBars, nearestKey);
+             0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
       return;
    }
 
@@ -1683,12 +2112,14 @@ void OnTick()
       GVSetDouble("lastAddPrice", entry);
 
       LogCSV("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             retcode, lasterr, bosLevel, bosAgeBars, nearestKey);
+             retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
    }
    else
    {
       LogCSV("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
-             retcode, lasterr, bosLevel, bosAgeBars, nearestKey);
+             retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+             sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk);
    }
 }
 
@@ -1716,6 +2147,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
       int bosAgeBars = BOSAgeBars(bosLevel);
       LogCSV("EXIT", DIR_NONE, trans.price, 0.0, 0.0, 0.0, trans.volume,
              DailyScore((RegimeState)GVGetInt("regime", REGIME_RANGE)), 0, 0, 0, 0, 0,
-             0, 0, bosLevel, bosAgeBars, 0.0);
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
    }
 }


### PR DESCRIPTION
### Motivation
- Implement a production-ready single-file MT5 Expert Advisor for XM GOLD / XAUUSD that follows the provided trend-follow + SMC “light” specification and broker quirks (digits=2, pip price, spread in points, MMSL). 
- Provide robust trade gating, risk management and persistence so the EA can operate safely with aggressive-but-protected sizing and daily/market protections. 
- Replace the prior simpler EA logic with the full strategy (bias/regime, pivots/BOS/retest, Fib/FVG/footprint filters, pyramiding, CSV logging, GlobalVariables state). 

### Description
- Added a complete set of inputs matching the spec (symbol override, `InpMagic`, `InpPipPrice`, spread/slippage/retries, spread-multiple, rollover/session filters, ATR/ADX/RSI/EMA params, pivot/pivot-confirm, FVG, Fib/OTE, footprint proxy, spike guard, MMSL, SL/TP/TP1/BE/trail, pyramiding, daily controls, CSV file name). 
- Implemented regime and bias detection on H1 (`ClassifyRegime`, `BiasH1`) with hysteresis (`InpRegimeConfirmBarsH1`, `InpRegimeLockBarsH1`) and spread EMA / spread-instability and spread-multiple blocking. 
- Implemented M15 structure entry gating: pivot detection (`FindRecentPivots`), HL/LH checks, BOS/close-confirm and Break&Retest (`BreakRetestOk`), key-level proximity/anti-chase (`NearestKeyLevel`, `KeyLevelOk`), optional FVG (`FVGDirection`, `FVGOk`), Fib base filter + OTE bonus (`FibFilterOk`), footprint proxy acceptance/absorption (`FootprintOk`), spike guard and RSI-after-loss gating (`RSIAfterLossOk`). 
- Risk and trade management: SL buffer calculation using ATR/spread/min buffer, MMSL enforcement, TP/TP1 calculation, TP1 partial exit, smart BE and ATR-based trailing after TP1, position management (`ManagePosition`), pyramiding (`TryPyramiding`) with add-sizing and DD caps, lot sizing via `CalcLots`. 
- Persistence and logging: global state stored in GlobalVariables using `GVName` helpers (lossStreak, day counters, tp1 flags, addCount, lastAddPrice, origRisk, etc.) and CSV logging via `LogCSV`. 
- Infrastructure and fixes: added `BuildTimeStruct` and updated `TimeInRange` to correctly build time structs, unified symbol resolution `ResolveSymbol`, spread EMA update, daily reset logic `UpdateDailyReset`, and handled trade exit processing in `OnTradeTransaction` (lossStreak updates, exit logging). 

### Testing
- No automated tests or compilation were run in this rollout; the change was implemented and saved as a single `.mq5` file (`Grok3xAI.mq5`) and is ready for compilation and platform testing. 
- Recommend compiling in MetaEditor and running a strategy-test/backtest on XAUUSD (digits=2) with the provided default inputs before live deployment. 
- After compilation, run a quick backtest using the M15/H1 configuration to validate pivot detection, MMSL enforcement, TP1/BE/trail behavior and CSV output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a4758bc88323afc59fcbc5932479)