### PR TITLE
Add Telegraf Telegram bot starter project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# MAX
+# Telegram Bot (Telegraf)
+
+Bot Telegram con Telegraf che espone i comandi `/start`, `/menu`, `/vip`, `/support` e usa una tastiera inline per aprire app, area VIP e supporto.
+
+## Requisiti
+
+- Node.js 18+
+- Un bot Telegram creato con @BotFather
+
+## Configurazione
+
+Crea un file `.env` (oppure imposta le variabili d'ambiente) con:
+
+```bash
+BOT_TOKEN=your-telegram-bot-token
+WEBAPP_URL=https://example.com/webapp
+VIP_URL=https://example.com/vip
+SUPPORT_URL=https://example.com/support
+```
+
+## Avvio locale
+
+```bash
+npm install
+npm start
+```
+
+## Import to Replit + Secrets + Run
+
+1. Importa questo repository in Replit (Import from GitHub).
+2. Vai su **Tools > Secrets** e aggiungi:
+   - `BOT_TOKEN`
+   - `WEBAPP_URL`
+   - `VIP_URL`
+   - `SUPPORT_URL`
+3. Clicca **Run** per avviare il bot in polling.
+
+## Comandi
+
+- `/start` → onboarding + tastiera inline
+- `/menu` → mostra la tastiera inline
+- `/vip` → link diretto area VIP
+- `/support` → link diretto supporto

--- a/index.js
+++ b/index.js
@@ -1,0 +1,74 @@
+require('dotenv').config();
+
+const { Telegraf, Markup } = require('telegraf');
+
+const { BOT_TOKEN, WEBAPP_URL, VIP_URL, SUPPORT_URL } = process.env;
+
+if (!BOT_TOKEN || !WEBAPP_URL || !VIP_URL || !SUPPORT_URL) {
+  console.error('Missing required environment variables.');
+  console.error('Required: BOT_TOKEN, WEBAPP_URL, VIP_URL, SUPPORT_URL');
+  process.exit(1);
+}
+
+const bot = new Telegraf(BOT_TOKEN);
+
+const onboardingText =
+  'Benvenuto!\n\n' +
+  'Da qui puoi aprire l\'app, accedere all\'area VIP o contattare il supporto.';
+
+const mainKeyboard = Markup.inlineKeyboard([
+  [Markup.button.webApp('🔓 Apri App', WEBAPP_URL)],
+  [Markup.button.url('⭐ Area VIP', VIP_URL)],
+  [Markup.button.url('📩 Supporto', SUPPORT_URL)],
+]);
+
+const sendMenu = async (ctx) => {
+  try {
+    await ctx.reply(onboardingText, mainKeyboard);
+  } catch (error) {
+    console.error('Failed to send menu:', error);
+  }
+};
+
+bot.start(sendMenu);
+bot.command('menu', sendMenu);
+bot.command('vip', async (ctx) => {
+  try {
+    await ctx.reply('Accedi all\'area VIP:', Markup.inlineKeyboard([
+      [Markup.button.url('⭐ Area VIP', VIP_URL)],
+    ]));
+  } catch (error) {
+    console.error('Failed to send VIP link:', error);
+  }
+});
+
+bot.command('support', async (ctx) => {
+  try {
+    await ctx.reply('Contatta il supporto:', Markup.inlineKeyboard([
+      [Markup.button.url('📩 Supporto', SUPPORT_URL)],
+    ]));
+  } catch (error) {
+    console.error('Failed to send support link:', error);
+  }
+});
+
+bot.catch((error, ctx) => {
+  console.error('Bot error', error, 'for update', ctx.update);
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught exception:', error);
+});
+
+bot.launch({
+  polling: true,
+});
+
+console.log('Bot avviato in polling.');
+
+process.once('SIGINT', () => bot.stop('SIGINT'));
+process.once('SIGTERM', () => bot.stop('SIGTERM'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "telegram-telegraf-bot",
+  "version": "1.0.0",
+  "description": "Telegram bot con Telegraf",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [
+    "telegram",
+    "telegraf",
+    "bot"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "telegraf": "^4.16.3"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Node.js (Telegraf) Telegram bot skeleton that implements onboarding and quick-access commands for an app, VIP area and support. 
- Ensure the bot is configurable via environment variables and is easy to run in environments like Replit using secrets. 
- Include basic operational safety with polling and simple error handling to make the project ready to start and extend.

### Description
- Added `index.js` which loads `dotenv`, reads `BOT_TOKEN`, `WEBAPP_URL`, `VIP_URL`, and `SUPPORT_URL` from the environment and exits if any are missing, registers `/start`, `/menu`, `/vip`, and `/support` commands, builds an inline keyboard with a web_app button and URL buttons, configures basic `bot.catch` and process-level error handlers, and launches the bot using polling. 
- Added `package.json` with metadata and dependencies (`dotenv` and `telegraf`) and a `start` script that runs `node index.js`. 
- Added `.gitignore` to ignore `node_modules`, `.env` and common logs, and expanded `README.md` with setup and usage instructions including `Import to Replit + Secrets + Run` and examples for the required environment variables.

### Testing
- No automated tests were run for this change (no CI or unit tests were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a7664d0a08323b6d752509a40d65a)