### PR TITLE
Add local Telegram WebApp + licensing backend stack (tunnel-ready)

### DIFF
--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -60,7 +60,7 @@ input PresetMode InpPresetMode = PRESET_CUSTOM;
 
 input string InpSymbolOverride = "";
 input long   InpMagic = 3011;
-input double InpPipPrice = 0.10; // if 0 -> auto pip size (FX/JPY/indices)
+input double InpPipPrice = 0.10; // DEPRECATED name: acts as pip size override (if 0 -> auto)
 input int    InpMaxSpreadPoints = 35;
 input int    InpMaxSlippagePoints = 35;
 input int    InpMaxRetries = 2;
@@ -124,7 +124,7 @@ input double InpDailyDDSoft = 2.0;
 input double InpDailyDDHard = 4.0;
 input int    InpCatastrophicSL_Points = 150;
 
-input int MaxSpreadPoints = 30;
+input int MaxSpreadPoints = 30; // DEPRECATED: use InpMaxSpreadPoints
 input bool UseInstitutionalScore = true;
 input int InstitutionalMinScore = 60;
 input bool LogInstitutional = true;
@@ -338,6 +338,7 @@ bool g_rsiEngulfTouchReady = false;
 datetime g_lastM15Bar = 0;
 datetime g_lastH1Bar = 0;
 double g_spreadEma = 0.0;
+bool g_csvOpenWarned = false;
 
 int g_irEntryScore = 0;
 string g_irTier = "NA";
@@ -370,12 +371,17 @@ double IR_GetRegimeMultiplier(double spreadPoints, double atrRatio, bool &blockO
 double IR_GetDailyDDPct();
 double IR_GetFearMultiplier(int lossStreak, double dailyDrawdownPct, bool &blockOut);
 double IR_ClampRiskPct(double riskPct);
+double RiskInputToPercent(double v);
 double IR_CalcLotsFromRiskPct(double entryPrice, double stopPrice, double riskPct, double &riskMoneyOut, double &stopDistancePointsOut);
 bool IR_ComputeLots(TradeDir dir, double entryPrice, double &stopPrice, int entryScore, double &lotsOut, string &tierOut, string &reasonOut);
 void IR_ResetTelemetry();
 
 EPattern50 MapDetectorToEPattern50(int detectorIdOrEnum, bool isBullish);
 void ComputeInstitutionalAdapter(int detectorIdOrEnum, bool isBullish, int entryMask, int killzoneActive, int &outTotalScore, double &outRiskMult, int &outPatternScore, EPattern50 &outPattern);
+string ExplainSkipMask(int mask);
+string ExplainEntryMask(int mask);
+datetime GetTradingDayStart(datetime t);
+int GetTradingDayId(datetime t);
 
 struct IndicatorEntry
 {
@@ -791,6 +797,14 @@ double PipsFromPoints(double points)
    double price = PriceFromPoints(points);
    return PipsFromPrice(price);
 }
+
+// Canonical helpers to avoid pip/point ambiguity in risk and stops.
+double GetPipSize() { return g_pip; }
+double GetPointSize() { return g_point; }
+double PriceToPoints(double priceDistance) { return PointsFromPrice(priceDistance); }
+double PointsToPrice(double points) { return PriceFromPoints(points); }
+double PipsToPoints(double pips) { return PointsFromPips(pips); }
+double PointsToPips(double points) { return PipsFromPoints(points); }
 
 double NormalizePrice(double p)
 {
@@ -1267,11 +1281,30 @@ int BOSAgeBars(double &bosLevel)
    return iBarShift(g_symbol, PERIOD_M15, bosTime, true);
 }
 
-int NYDayId(datetime serverTime)
+
+datetime GetTradingDayStart(datetime t)
+{
+   datetime ny = ToNYTime(t);
+   MqlDateTime dt;
+   TimeToStruct(ny, dt);
+   dt.hour = 0;
+   dt.min = 0;
+   dt.sec = 0;
+   datetime nyStart = StructToTime(dt);
+   int nyOffset = cfg_InpUseManualNYOffset ? (EffectiveNYOffsetHours() * 3600) : (-5 * 3600);
+   return nyStart - nyOffset;
+}
+
+int GetTradingDayId(datetime t)
 {
    MqlDateTime dt;
-   TimeToStruct(ToNYTime(serverTime), dt);
+   TimeToStruct(ToNYTime(t), dt);
    return dt.year * 10000 + dt.mon * 100 + dt.day;
+}
+
+int NYDayId(datetime serverTime)
+{
+   return GetTradingDayId(serverTime);
 }
 
 void GetPDLevels(double &pdh, double &pdl)
@@ -2195,12 +2228,11 @@ bool CooldownActive()
 void UpdateDailyReset()
 {
    datetime now = TimeCurrent();
-   datetime todayStart = (datetime)StringToTime(TimeToString(now, TIME_DATE));
+   datetime todayStart = GetTradingDayStart(now);
 
-   datetime stored = (datetime)GVGetDouble("dayStart", 0.0);
-   datetime storedStart = (stored == 0) ? 0 : (datetime)StringToTime(TimeToString(stored, TIME_DATE));
+   datetime storedStart = (datetime)GVGetDouble("dayStart", 0.0);
 
-   if(stored == 0 || storedStart != todayStart)
+   if(storedStart == 0 || storedStart != todayStart)
    {
       GVSetDouble("dayStart", (double)todayStart);
 
@@ -2212,6 +2244,57 @@ void UpdateDailyReset()
       GVSetInt("tp1done", 0);
       GVSetInt("addCount", 0);
    }
+}
+
+
+string AppendReason(string base, string add)
+{
+   if(StringLen(add) == 0)
+      return base;
+   if(StringLen(base) == 0)
+      return add;
+   return base + "|" + add;
+}
+
+string ExplainSkipMask(int mask)
+{
+   if(mask == SKIP_NONE)
+      return "NONE";
+   string out = "";
+   if((mask & SKIP_SESSION) != 0) out = AppendReason(out, "SESSION");
+   if((mask & SKIP_ROLLOVER) != 0) out = AppendReason(out, "ROLLOVER");
+   if((mask & SKIP_SPREAD) != 0) out = AppendReason(out, "SPREAD");
+   if((mask & SKIP_SPREAD_MULT) != 0) out = AppendReason(out, "SPREAD_MULT");
+   if((mask & SKIP_SPREAD_INSTAB) != 0) out = AppendReason(out, "SPREAD_INSTAB");
+   if((mask & SKIP_LOWVOL) != 0) out = AppendReason(out, "LOWVOL");
+   if((mask & SKIP_DAILY_LOCK) != 0) out = AppendReason(out, "DAILY_LOCK");
+   if((mask & SKIP_COOLDOWN) != 0) out = AppendReason(out, "COOLDOWN");
+   if((mask & SKIP_LOSS_BLOCK) != 0) out = AppendReason(out, "LOSS_BLOCK");
+   if((mask & SKIP_DAILY_MAX) != 0) out = AppendReason(out, "DAILY_MAX");
+   if((mask & SKIP_DAILY_SCORE) != 0) out = AppendReason(out, "DAILY_SCORE");
+   if((mask & SKIP_STOPS) != 0) out = AppendReason(out, "STOPS");
+   if((mask & SKIP_KILLZONE) != 0) out = AppendReason(out, "KILLZONE");
+   if((mask & SKIP_PDARRAY) != 0) out = AppendReason(out, "PDARRAY");
+   return out;
+}
+
+string ExplainEntryMask(int mask)
+{
+   if(mask == ENTRY_NONE)
+      return "NONE";
+   string out = "";
+   if((mask & ENTRY_BIAS) != 0) out = AppendReason(out, "BIAS");
+   if((mask & ENTRY_PIVOT) != 0) out = AppendReason(out, "PIVOT");
+   if((mask & ENTRY_HL_LH) != 0) out = AppendReason(out, "HL_LH");
+   if((mask & ENTRY_BOS_CLOSE) != 0) out = AppendReason(out, "BOS_CLOSE");
+   if((mask & ENTRY_BOS_RETEST) != 0) out = AppendReason(out, "BOS_RETEST");
+   if((mask & ENTRY_KILLZONE) != 0) out = AppendReason(out, "KILLZONE");
+   if((mask & ENTRY_SWEEP) != 0) out = AppendReason(out, "SWEEP");
+   if((mask & ENTRY_DISPLACEMENT) != 0) out = AppendReason(out, "DISPLACEMENT");
+   if((mask & ENTRY_MSS) != 0) out = AppendReason(out, "MSS");
+   if((mask & ENTRY_PDARRAY) != 0) out = AppendReason(out, "PDARRAY");
+   if((mask & ENTRY_RR) != 0) out = AppendReason(out, "RR");
+   return out;
 }
 
 void BuildContext(MarketContext &ctx)
@@ -2558,7 +2641,7 @@ void ApplyPreset()
    cfg_InpUseSessionFilter = InpUseSessionFilter;
    cfg_InpStartHour = InpStartHour;
    cfg_InpEndHour = InpEndHour;
-   cfg_InpMaxSpreadPoints = InpMaxSpreadPoints;
+   cfg_InpMaxSpreadPoints = (InpMaxSpreadPoints > 0 ? InpMaxSpreadPoints : MaxSpreadPoints);
    cfg_InpMaxSlippagePoints = InpMaxSlippagePoints;
    cfg_InpMaxRetries = InpMaxRetries;
    cfg_InpRetryDelayMs = InpRetryDelayMs;
@@ -2886,6 +2969,10 @@ void LogPresetConfig()
                (cfg_InpPyramidOnlyInTrend ? "true" : "false"), (cfg_InpPyramidRequireAdxRising ? "true" : "false"),
                (cfg_InpPyramidUsePeakDDCap ? "true" : "false"), cfg_InpPyramidMaxPeakDDPct,
                cfg_InpAddRiskMult1, cfg_InpAddRiskMult2);
+
+   double irBasePct = RiskInputToPercent(InpRiskBasePct);
+   if(irBasePct > 50.0 || irBasePct < 0.01)
+      PrintFormat("Warning: Institutional base risk out of sane range (%.4f%%).", irBasePct);
 }
 
 void LogSymbolCheck()
@@ -2944,14 +3031,23 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
       handle = FileOpen(cfg_InpCSVName, FILE_WRITE | FILE_CSV | FILE_ANSI);
 
    if(handle == INVALID_HANDLE)
+   {
+      if(!g_csvOpenWarned)
+      {
+         Print("Warning: CSV log file open failed; continuing without CSV logging.");
+         g_csvOpenWarned = true;
+      }
       return;
+   }
+
+   g_csvOpenWarned = false;
 
    if(FileSize(handle) == 0)
    {
       FileWrite(handle, "time", "sym", "profile", "point", "pipSize", "tickSize", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
                 "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
                 "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
-                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
+                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Target", "tp1FillPrice",
                 "killzoneActive", "pdh", "pdl", "psh", "psl", "hod", "lod",
                 "sweepDir", "sweepLevel", "displacementScore", "obHigh", "obLow", "obMT", "oteOk",
                 "sdHit", "sdType", "sdDistATR", "sdFresh", "candleHit", "candleType",
@@ -3010,6 +3106,7 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
              bosAgeBars,
              DoubleToString(nearestKey, g_digits),
              DoubleToString(tp1, g_digits),
+             DoubleToString(GVGetDouble("tp1FillPrice", 0.0), g_digits),
              killzoneActive,
              DoubleToString(pdh, g_digits),
              DoubleToString(pdl, g_digits),
@@ -3453,7 +3550,7 @@ void ManagePosition(double riskR)
       {
          trade.PositionClosePartial(ticket, closeVol);
          GVSetInt("tp1done", 1);
-         GVSetDouble("tp1price", price);
+         GVSetDouble("tp1FillPrice", price);
          double bosLevel = 0.0;
          int bosAgeBars = BOSAgeBars(bosLevel);
          LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0,
@@ -3671,6 +3768,7 @@ void OnTick()
       skipMask |= SKIP_LOSS_BLOCK;
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
+      PrintFormat("[SKIP] %s", ExplainSkipMask(skipMask));
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
@@ -3680,6 +3778,7 @@ void OnTick()
    {
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);
+      PrintFormat("[SKIP] %s", ExplainSkipMask(skipMask));
       LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
              0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
              0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
@@ -3748,6 +3847,7 @@ void OnTick()
                       sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
                       sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2))
    {
+      PrintFormat("[NOENTRY] skip=%s entry=%s", ExplainSkipMask(skipMask), ExplainEntryMask(entryMask));
       LogCSVEx("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
                0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
                sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
@@ -3815,6 +3915,7 @@ void OnTick()
       GVSetDouble("origRisk", riskR);
       GVSetInt("tp1done", 0);
       GVSetDouble("tp1price", tp1);
+      GVSetDouble("tp1FillPrice", 0.0);
       GVSetInt("addCount", 0);
       GVSetDouble("lastAddPrice", entry);
       if(InpUseReactionProbabilityModel)
@@ -4789,7 +4890,7 @@ void IR_ResetTelemetry()
 {
    g_irEntryScore = 0;
    g_irTier = "NA";
-   g_irRiskBasePct = InpRiskBasePct;
+   g_irRiskBasePct = RiskInputToPercent(InpRiskBasePct);
    g_irScoreMult = 0.0;
    g_irRegimeMult = 0.0;
    g_irFearMult = 0.0;
@@ -4905,10 +5006,22 @@ double IR_GetFearMultiplier(int lossStreak, double dailyDrawdownPct, bool &block
    return mult;
 }
 
+double RiskInputToPercent(double v)
+{
+   // Backward compatible: values <= 1.0 are treated as fraction (0.005 => 0.5%).
+   if(v <= 0.0)
+      return 0.0;
+   if(v <= 1.0)
+      return v * 100.0;
+   return v;
+}
+
 double IR_ClampRiskPct(double riskPct)
 {
-   double lo = MathMin(InpRiskMinPct, InpRiskMaxPct);
-   double hi = MathMax(InpRiskMinPct, InpRiskMaxPct);
+   double minPct = RiskInputToPercent(InpRiskMinPct);
+   double maxPct = RiskInputToPercent(InpRiskMaxPct);
+   double lo = MathMin(minPct, maxPct);
+   double hi = MathMax(minPct, maxPct);
    return MathMax(lo, MathMin(hi, riskPct));
 }
 
@@ -4934,7 +5047,7 @@ double IR_CalcLotsFromRiskPct(double entryPrice, double stopPrice, double riskPc
       return 0.0;
 
    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
-   riskMoneyOut = equity * riskPct;
+   riskMoneyOut = equity * (riskPct / 100.0);
    if(riskMoneyOut <= 0.0)
       return 0.0;
 
@@ -4984,10 +5097,10 @@ bool IR_ComputeLots(TradeDir dir, double entryPrice, double &stopPrice, int entr
       return false;
    }
 
-   double riskPctRaw = InpRiskBasePct * g_irScoreMult * g_irRegimeMult * g_irFearMult;
+   double riskPctRaw = RiskInputToPercent(InpRiskBasePct) * g_irScoreMult * g_irRegimeMult * g_irFearMult;
    if(UseInstitutionalScore)
       riskPctRaw *= MathMax(0.0, g_instRiskMult);
-   g_irRiskBasePct = InpRiskBasePct;
+   g_irRiskBasePct = RiskInputToPercent(InpRiskBasePct);
    g_irFinalRiskPct = IR_ClampRiskPct(riskPctRaw);
 
    lotsOut = IR_CalcLotsFromRiskPct(entryPrice, stopPrice, g_irFinalRiskPct, g_irRiskMoney, g_irStopDistancePoints);

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -1,568 +1,5068 @@
 //+------------------------------------------------------------------+
-//|                                                    GROK 3xAI     |
-//|        Expert Advisor Multi-Conferma - MetaTrader 5 (MQL5)       |
+//|                                     XAUUSD Killer XM (MT5)       |
+//|   Trend-follow + SMC light - production-safe single file EA      |
+//|                                                                  |
+//| FIXES                                                           |
+//| - Normalize pip/point/tick handling across FX/JPY/indices.       |
+//| - Harden symbol profile detection for XM index variants.         |
+//| - Convert GOLD-tuned distances to profile-aware points.          |
+//| - Fix index key-step units and volume step rounding.             |
+//| - Add tickSize/pipSize to logs and sanity warnings.              |
+//| - Add optional SD/candle/momentum bonus scoring + CSV fields.    |
+//|                                                                  |
+//| CHANGELOG                                                       |
+//| - Added ICT/SMC modules: NY killzones, PD arrays, liquidity      |
+//|   sweeps, displacement, MSS/BOS, order blocks + RTO/MT, and OTE  |
+//|   premium/discount filters with HTF swings.                      |
+//| - Expanded CSV logging to include ICT context (killzone, PDH/PDL,|
+//|   sweep/displacement/OB/OTE metadata).                           |
 //+------------------------------------------------------------------+
 #property strict
-#include <Trade\Trade.mqh>
+#include <Trade/Trade.mqh>
+#include <GROK/PatternScores.mqh>
+#include "Strategy_RSIEngulfTouch.mqh"
+#include "mql5/LicenseClient.mqh"
 
 CTrade trade;
 
-string Trim(string text)
+enum RegimeState
 {
-   return StringTrimLeft(StringTrimRight(text));
+   REGIME_RANGE = 0,
+   REGIME_TRANSITION = 1,
+   REGIME_TREND = 2,
+   REGIME_EXPANSION = 3
+};
+
+enum TradeDir
+{
+   DIR_NONE = 0,
+   DIR_LONG = 1,
+   DIR_SHORT = -1
+};
+
+enum PresetMode
+{
+   PRESET_CUSTOM = 0,
+   PRESET_BALANCED = 1,
+   PRESET_CONSERVATIVE = 2
+};
+
+enum SymbolProfile
+{
+   PROFILE_FX_MAJORS_5DIG = 0,
+   PROFILE_FX_JPY_3DIG = 1,
+   PROFILE_INDICES = 2
+};
+
+input PresetMode InpPresetMode = PRESET_CUSTOM;
+
+input string InpSymbolOverride = "";
+input long   InpMagic = 3011;
+input double InpPipPrice = 0.10; // if 0 -> auto pip size (FX/JPY/indices)
+input int    InpMaxSpreadPoints = 35;
+input int    InpMaxSlippagePoints = 35;
+input int    InpMaxRetries = 2;
+input int    InpRetryDelayMs = 350;
+
+// RSI Engulf Touch strategy (modulo separato, attivabile)
+input bool   Enable_RSIEngulfTouch = true;
+input int    RSI_Length = 7;
+input double RSI_OB = 70;
+input double RSI_OS = 30;
+input double Lots = 0.01;
+input double PipSize = 0.01;
+input double SL_Pips = 70;
+input double TP1_Pips = 50;
+input double TP2_Pips = 100;
+input double MaxSpreadPips = 25;
+input bool   OneSetPerBar = true;
+input int    CooldownSeconds = 90;
+input long   MagicBase = 91001;
+input ENUM_TIMEFRAMES SignalTF = PERIOD_CURRENT;
+input double TrendThresholdMultiplier = 1.0;
+input RSITrendMode TrendMode = TRENDMODE_DISABLED;
+input bool   InpUseSMCZ3C = false;
+input bool   InpDrawZones = true;
+input string InpSMCTFs = "PERIOD_M5,PERIOD_M15,PERIOD_M30,PERIOD_H1,PERIOD_H4";
+input int    InpScanBars = 300;
+input double InpBodyEngulfEpsPoints = 2.0;
+input double InpDispATRMult = 0.8;
+input int    InpSwingLookbackBars = 80;
+input int    InpPivotLR = 2;
+input double InpMitigatePct = 50.0;
+input int    InpMaxTouches = 3;
+input double InpInvalidationBufferPoints = 5.0;
+input double InpMergeTolPoints = 5.0;
+input double InpMinScoreToKeep = 50.0;
+input double InpTimeFactor = 1.0;
+
+input bool   InpUseReactionProbabilityModel = true;
+input int    InpMaxTradesPerDay = 3;
+input int    InpCooldownMinutes = 30;
+input int    InpMaxLossStreak = 3;
+input bool   InpOneTradePerZone = true;
+input bool   InpNoTradeAgainstHTF = true;
+input int    InpZoneOldAgeBars = 120;
+input double InpReactionNearATRMult = 0.25;
+input double InpReactionDispATRMult = 1.2;
+input int    InpSweepReclaimBars = 3;
+input double InpSweepPoints = 15.0;
+input double InpRiskATRBufferMult = 0.5;
+
+input int    InpEntryThreshold = 70;
+input double InpRiskBasePct = 0.005;
+input double InpRiskMinPct = 0.001;
+input double InpRiskMaxPct = 0.0125;
+input double InpMaxRiskMultiplier = 1.25;
+input double InpAtrSpikeRatio = 1.8;
+input int    InpAtrMaPeriod = 20;
+input bool   InpUseSessionRiskMultiplier = true;
+input double InpSessionRiskMultiplier = 0.75;
+input double InpDailyDDSoft = 2.0;
+input double InpDailyDDHard = 4.0;
+input int    InpCatastrophicSL_Points = 150;
+
+input int MaxSpreadPoints = 30;
+input bool UseInstitutionalScore = true;
+input int InstitutionalMinScore = 60;
+input bool LogInstitutional = true;
+
+input bool   InpUseSpreadMultiple = true;
+input double InpSpreadMultiple = 3.0;
+input int    InpSpreadMultipleBlockMin = 45; // minutes
+
+input bool   InpUseRolloverBlock = true;
+input string InpRolloverStart = "23:55";
+input string InpRolloverEnd = "00:15";
+
+input bool InpUseSessionFilter = true;
+input int  InpStartHour = 6;
+input int  InpEndHour = 23;
+
+input bool InpUseICTTime = true;
+input bool InpUseManualNYOffset = true;
+input int  InpNYOffsetHours = -5;
+input bool InpAutoNYDST = false;
+input int  InpNYOffsetSummerHours = -4;
+input bool InpUseKillzoneAsia = true;
+input bool InpUseKillzoneLondon = true;
+input bool InpUseKillzoneNY = true;
+
+input int    InpATRPeriod = 14;
+input int    InpADXPeriod = 14;
+input int    InpRSIPeriod = 14;
+input int    InpEMA_Fast = 50;
+input int    InpEMA_Slow = 200;
+
+input int    InpRegimeConfirmBarsH1 = 2;
+input int    InpRegimeLockBarsH1 = 4;
+
+input int    InpPivotLen = 3;
+input int    InpPivotConfirmBars = 2;
+input int    InpMaxBarsAfterBOS = 6;
+
+input double InpEqToleranceATR = 0.25;
+input double InpEqToleranceMinPoints = 8;
+input int    InpEqClusterMin = 2;
+input int    InpEqScanBars = 40;
+input double InpDisplacementATR = 1.1;
+input double InpDisplacementBodyRatio = 0.55;
+input int    InpDisplacementSearchBars = 4;
+input int    InpOBLookback = 10;
+input int    InpOBMaxAgeBars = 12;
+
+input ENUM_TIMEFRAMES InpOTE_HTF = PERIOD_H1;
+input int    InpOTE_SwingLookback = 48;
+input double InpOTE_Min = 0.62;
+input double InpOTE_Max = 0.79;
+input double InpMinPDArrayDistance = 0.80;
+input double InpMinPDArrayATR = 1.0;
+input int    InpMinPDArrayMinPoints = 80;
+
+input bool   InpUseBreakRetest = true;
+input double InpRetestTolATR = 0.15;
+
+input double InpKeyLevelStepPrice = 3.0;
+input double InpKeyNearPrice = 0.35;
+input double InpKeyChaseMaxDistPrice = 0.90;
+
+input bool   InpUseFVGFeature = true;
+input int    InpFVGScanBars = 30;
+input double InpFVGMaxDistATR = 1.2;
+
+input bool   InpUseFibFilter = true;
+input double InpFibBaseMin = 0.50;
+input double InpFibBaseMax = 0.618;
+input double InpFibTolPrice = 0.20;
+input bool   InpUseOTEBonus = true;
+input double InpOTEMin = 0.62;
+input double InpOTEMax = 0.79;
+input int    InpOTEBonusPoints = 6;
+
+input bool   InpUseFootprintProxy = true;
+input int    InpFP_VolMAPeriod = 48;
+input double InpFP_VolSpikeRatio = 1.35;
+input double InpFP_BodyMinRatio = 0.55;
+input double InpFP_CloseSideMin = 0.65;
+input double InpFP_AbsorpVolRatio = 1.50;
+input double InpFP_AbsorpRangeATR = 0.45;
+input bool   InpFP_RequireAcceptance = true;
+input int    InpFP_ScoreBonus = 10;
+
+input bool   InpUseSupplyDemandBonus = true;
+input ENUM_TIMEFRAMES InpSD_TF = PERIOD_H1;
+input int    InpSD_LookbackBars = 200;
+input double InpSD_MinImpulseATR = 1.2;
+input int    InpSD_MaxBaseBars = 3;
+input double InpSD_ZonePadATR = 0.15;
+input double InpSD_MaxDistATR = 0.8;
+input int    InpSD_BonusPoints = 6;
+input int    InpSD_FreshnessBonus = 3;
+
+input bool   InpUseCandleBonus = true;
+input int    InpCandleBonusPoints = 4;
+
+input bool   InpUseMomentumBonus = true;
+input int    InpMomentumBonusPoints = 4;
+input bool   InpRequireBiasAlignWithSweep = true;
+
+input bool   InpUseSpikeGuard = true;
+input double InpSpikeMultATR = 2.5;
+
+input double InpSL_ATR_Mult = 0.25;
+input double InpSL_MinBufferPrice = 0.15;
+
+input bool   InpUseMMSL = true;
+input int    InpMMSL_Pips = 35;
+input double InpMMSL_ExtraBufferPrice = 0.00;
+
+input double InpTP_RR_Main = 2.0;
+input double InpMinRRAllowed = 1.5;
+
+input bool   InpUseTP1Partial = true;
+input double InpTP1_CloseFrac = 0.50;
+input bool   InpTP1_UseKeyLevelFirst = true;
+
+input bool   InpUseSmartBE = true;
+input double InpBE_MinProfitR = 1.0;
+input double InpBE_OffsetPrice = 0.05;
+
+input bool   InpUseATRTrailAfterTP1 = true;
+input double InpTrailATR_Mult = 1.20;
+input double InpTrailMinImprovePrice = 0.10;
+input bool   InpTrailOnNewBarOnly = true;
+
+input double InpBaseRiskPct = 3.0;
+input double InpMaxLotCap = 2.0;
+
+input bool   InpUseLowVolFilter = true;
+input ENUM_TIMEFRAMES InpVolTF = PERIOD_H1;
+input int    InpVolMAPeriod = 48;
+input double InpLowVolFactor = 0.75;
+
+input bool   InpUseSpreadInstability = true;
+input int    InpSpreadAvgBarsH1 = 24;
+input double InpSpreadSpikeFactor = 1.6;
+input int    InpSpreadSpikeBlockMin = 60;
+
+input bool   InpUseDailyTradeControl = true;
+input int    InpHardMaxTradesPerDay = 4;
+
+input bool   InpUseMaxDailyLossLock = true;
+input double InpMaxDailyLossPct = 4.0;
+
+input bool   InpUseSoftEquityLock = true;
+input double InpSoftEqTrigger1 = 2.0;
+input double InpSoftEqFloor1 = 0.8;
+input double InpSoftEqTrigger2 = 4.0;
+input double InpSoftEqFloor2 = 2.0;
+
+input int    InpCooldownBarsAfterEntry = 2;
+
+input bool   InpUseAntiChop = true;
+input int    InpLossBlock2_Hours = 4;
+input int    InpLossBlock3_Hours = 12;
+input double InpRiskMultAfter3Loss = 0.70;
+input int    InpRiskCutAfter3Loss_H = 24;
+
+input bool   InpUseRSIAfterLoss = true;
+input int    InpLossStreakForRSI = 1;
+
+input bool   InpUsePyramiding = true;
+input int    InpMaxAdds = 2;
+input double InpPyramidMinProfitR = 0.8;
+input bool   InpPyramidRequireMainBE = true;
+input double InpPyramidSpacingATR = 0.7;
+input bool   InpPyramidOnlyInTrend = true;
+input bool   InpPyramidRequireAdxRising = true;
+input bool   InpPyramidUsePeakDDCap = true;
+input double InpPyramidMaxPeakDDPct = 2.0;
+input double InpAddRiskMult1 = 0.50;
+input double InpAddRiskMult2 = 0.35;
+
+input bool   InpEnableCSV = true;
+input string InpCSVName = "xauusd_killer_v314_xm_gold.csv";
+
+const int SETUP_MIN = 50;
+const int TIMING_MIN = 15;
+const int TOTAL_MIN = 68;
+
+// XM suggested starting inputs (not optimized; adjust per broker/spread):
+// Profile   | MaxSpreadPts | MaxSlippagePts | SpreadMultiple | SpreadSpikeFactor | Rollover  | Session
+// FX majors | 25-35        | 30-40          | 2.5-3.0        | 1.5-1.8           | 23:55-00:15 | 06-23
+// FX JPY    | 25-40        | 30-50          | 2.5-3.0        | 1.5-1.8           | 23:55-00:15 | 06-23
+// Indices   | 80-150       | 80-150         | 2.0-2.5        | 1.4-1.7           | 23:55-00:15 | 06-23
+
+string g_symbol = "";
+int g_digits = 2;
+double g_point = 0.01;
+double g_pip = 0.10;
+SymbolProfile g_profile = PROFILE_FX_MAJORS_5DIG;
+bool g_isGoldSymbol = false;
+RSIEngulfTouchStrategy g_rsiEngulfTouch;
+bool g_rsiEngulfTouchReady = false;
+datetime g_lastM15Bar = 0;
+datetime g_lastH1Bar = 0;
+double g_spreadEma = 0.0;
+
+int g_irEntryScore = 0;
+string g_irTier = "NA";
+double g_irRiskBasePct = 0.0;
+double g_irScoreMult = 0.0;
+double g_irRegimeMult = 0.0;
+double g_irFearMult = 0.0;
+double g_irFinalRiskPct = 0.0;
+double g_irRiskMoney = 0.0;
+double g_irStopDistancePoints = 0.0;
+double g_irLots = 0.0;
+double g_irSpreadPoints = 0.0;
+double g_irAtrRatio = 0.0;
+int g_irLossStreak = 0;
+double g_irDailyDD = 0.0;
+
+int g_instTotalScore = 0;
+double g_instRiskMult = 1.0;
+int g_instPatternScore = 0;
+EPattern50 g_instPattern = PAT_DOJI;
+
+
+void SMCZ3C_Update();
+bool RP_ModelGate(TradeDir dir, double entry, double &sl, double &tp, int &scoreOut, string &reasonOut, string &zoneKeyOut);
+void RP_RegisterTrade(const string zoneKey);
+
+double IR_GetScoreMultiplier(int entryScore, string &tierOut);
+double IR_GetAtrRatio();
+double IR_GetRegimeMultiplier(double spreadPoints, double atrRatio, bool &blockOut);
+double IR_GetDailyDDPct();
+double IR_GetFearMultiplier(int lossStreak, double dailyDrawdownPct, bool &blockOut);
+double IR_ClampRiskPct(double riskPct);
+double IR_CalcLotsFromRiskPct(double entryPrice, double stopPrice, double riskPct, double &riskMoneyOut, double &stopDistancePointsOut);
+bool IR_ComputeLots(TradeDir dir, double entryPrice, double &stopPrice, int entryScore, double &lotsOut, string &tierOut, string &reasonOut);
+void IR_ResetTelemetry();
+
+EPattern50 MapDetectorToEPattern50(int detectorIdOrEnum, bool isBullish);
+void ComputeInstitutionalAdapter(int detectorIdOrEnum, bool isBullish, int entryMask, int killzoneActive, int &outTotalScore, double &outRiskMult, int &outPatternScore, EPattern50 &outPattern);
+
+struct IndicatorEntry
+{
+   int type;
+   string sym;
+   ENUM_TIMEFRAMES tf;
+   int p1;
+   int p2;
+   int p3;
+   int handle;
+};
+
+struct IndicatorsCache
+{
+   IndicatorEntry entries[];
+};
+
+IndicatorsCache g_indicators;
+int g_hodlodDayId = 0;
+datetime g_hodlodBarTime = 0;
+double g_cachedHod = 0.0;
+double g_cachedLod = 0.0;
+
+// Runtime config (preset-applied)
+PresetMode cfg_InpPresetMode;
+string cfg_InpSymbolOverride;
+long cfg_InpMagic;
+double cfg_InpPipPrice;
+bool cfg_InpUseSessionFilter;
+int cfg_InpStartHour;
+int cfg_InpEndHour;
+int cfg_InpMaxSpreadPoints;
+int cfg_InpMaxSlippagePoints;
+int cfg_InpMaxRetries;
+int cfg_InpRetryDelayMs;
+bool cfg_InpUseICTTime;
+bool cfg_InpUseManualNYOffset;
+int cfg_InpNYOffsetHours;
+bool cfg_InpAutoNYDST;
+int cfg_InpNYOffsetSummerHours;
+bool cfg_InpUseKillzoneAsia;
+bool cfg_InpUseKillzoneLondon;
+bool cfg_InpUseKillzoneNY;
+int cfg_InpATRPeriod;
+int cfg_InpADXPeriod;
+int cfg_InpRSIPeriod;
+int cfg_InpEMA_Fast;
+int cfg_InpEMA_Slow;
+int cfg_InpRegimeConfirmBarsH1;
+int cfg_InpRegimeLockBarsH1;
+int cfg_InpPivotLen;
+int cfg_InpPivotConfirmBars;
+int cfg_InpMaxBarsAfterBOS;
+double cfg_InpEqToleranceATR;
+double cfg_InpEqToleranceMinPoints;
+int cfg_InpEqClusterMin;
+int cfg_InpEqScanBars;
+double cfg_InpDisplacementATR;
+double cfg_InpDisplacementBodyRatio;
+int cfg_InpDisplacementSearchBars;
+int cfg_InpOBLookback;
+int cfg_InpOBMaxAgeBars;
+ENUM_TIMEFRAMES cfg_InpOTE_HTF;
+int cfg_InpOTE_SwingLookback;
+double cfg_InpOTE_Min;
+double cfg_InpOTE_Max;
+double cfg_InpMinPDArrayDistance;
+double cfg_InpMinPDArrayATR;
+int cfg_InpMinPDArrayMinPoints;
+bool cfg_InpUseBreakRetest;
+double cfg_InpRetestTolATR;
+double cfg_InpKeyLevelStepPrice;
+double cfg_InpKeyNearPrice;
+double cfg_InpKeyChaseMaxDistPrice;
+bool cfg_InpUseFVGFeature;
+int cfg_InpFVGScanBars;
+double cfg_InpFVGMaxDistATR;
+bool cfg_InpUseFibFilter;
+double cfg_InpFibBaseMin;
+double cfg_InpFibBaseMax;
+double cfg_InpFibTolPrice;
+bool cfg_InpUseOTEBonus;
+double cfg_InpOTEMin;
+double cfg_InpOTEMax;
+int cfg_InpOTEBonusPoints;
+bool cfg_InpUseFootprintProxy;
+int cfg_InpFP_VolMAPeriod;
+double cfg_InpFP_VolSpikeRatio;
+double cfg_InpFP_BodyMinRatio;
+double cfg_InpFP_CloseSideMin;
+double cfg_InpFP_AbsorpVolRatio;
+double cfg_InpFP_AbsorpRangeATR;
+bool cfg_InpFP_RequireAcceptance;
+int cfg_InpFP_ScoreBonus;
+bool cfg_InpUseSupplyDemandBonus;
+ENUM_TIMEFRAMES cfg_InpSD_TF;
+int cfg_InpSD_LookbackBars;
+double cfg_InpSD_MinImpulseATR;
+int cfg_InpSD_MaxBaseBars;
+double cfg_InpSD_ZonePadATR;
+double cfg_InpSD_MaxDistATR;
+int cfg_InpSD_BonusPoints;
+int cfg_InpSD_FreshnessBonus;
+bool cfg_InpUseCandleBonus;
+int cfg_InpCandleBonusPoints;
+bool cfg_InpUseMomentumBonus;
+int cfg_InpMomentumBonusPoints;
+bool cfg_InpRequireBiasAlignWithSweep;
+bool cfg_InpUseSpikeGuard;
+double cfg_InpSpikeMultATR;
+double cfg_InpSL_ATR_Mult;
+double cfg_InpSL_MinBufferPrice;
+bool cfg_InpUseMMSL;
+int cfg_InpMMSL_Pips;
+double cfg_InpMMSL_ExtraBufferPrice;
+double cfg_InpTP_RR_Main;
+double cfg_InpMinRRAllowed;
+bool cfg_InpUseTP1Partial;
+double cfg_InpTP1_CloseFrac;
+bool cfg_InpTP1_UseKeyLevelFirst;
+bool cfg_InpUseSmartBE;
+double cfg_InpBE_MinProfitR;
+double cfg_InpBE_OffsetPrice;
+bool cfg_InpUseATRTrailAfterTP1;
+double cfg_InpTrailATR_Mult;
+double cfg_InpTrailMinImprovePrice;
+bool cfg_InpTrailOnNewBarOnly;
+double cfg_InpBaseRiskPct;
+double cfg_InpMaxLotCap;
+bool cfg_InpUseLowVolFilter;
+ENUM_TIMEFRAMES cfg_InpVolTF;
+int cfg_InpVolMAPeriod;
+double cfg_InpLowVolFactor;
+bool cfg_InpUseSpreadMultiple;
+double cfg_InpSpreadMultiple;
+int cfg_InpSpreadMultipleBlockMin;
+bool cfg_InpUseSpreadInstability;
+int cfg_InpSpreadAvgBarsH1;
+double cfg_InpSpreadSpikeFactor;
+int cfg_InpSpreadSpikeBlockMin;
+bool cfg_InpUseRolloverBlock;
+string cfg_InpRolloverStart;
+string cfg_InpRolloverEnd;
+bool cfg_InpUseDailyTradeControl;
+int cfg_InpHardMaxTradesPerDay;
+bool cfg_InpUseMaxDailyLossLock;
+double cfg_InpMaxDailyLossPct;
+bool cfg_InpUseSoftEquityLock;
+double cfg_InpSoftEqTrigger1;
+double cfg_InpSoftEqFloor1;
+double cfg_InpSoftEqTrigger2;
+double cfg_InpSoftEqFloor2;
+int cfg_InpCooldownBarsAfterEntry;
+bool cfg_InpUseAntiChop;
+int cfg_InpLossBlock2_Hours;
+int cfg_InpLossBlock3_Hours;
+double cfg_InpRiskMultAfter3Loss;
+int cfg_InpRiskCutAfter3Loss_H;
+bool cfg_InpUseRSIAfterLoss;
+int cfg_InpLossStreakForRSI;
+bool cfg_InpUsePyramiding;
+int cfg_InpMaxAdds;
+double cfg_InpPyramidMinProfitR;
+bool cfg_InpPyramidRequireMainBE;
+double cfg_InpPyramidSpacingATR;
+bool cfg_InpPyramidOnlyInTrend;
+bool cfg_InpPyramidRequireAdxRising;
+bool cfg_InpPyramidUsePeakDDCap;
+double cfg_InpPyramidMaxPeakDDPct;
+double cfg_InpAddRiskMult1;
+double cfg_InpAddRiskMult2;
+bool cfg_InpEnableCSV;
+string cfg_InpCSVName;
+
+double cfg_KeyLevelStepPoints;
+double cfg_KeyNearPoints;
+double cfg_KeyChaseMaxDistPoints;
+double cfg_EqToleranceMinPoints;
+double cfg_SL_MinBufferPoints;
+double cfg_MMSL_ExtraBufferPoints;
+double cfg_BE_OffsetPoints;
+double cfg_TrailMinImprovePoints;
+double cfg_FibTolPoints;
+double cfg_MinPDArrayDistancePoints;
+int cfg_MinPDArrayMinPoints;
+
+enum SkipMask
+{
+   SKIP_NONE = 0,
+   SKIP_SESSION = 1 << 0,
+   SKIP_ROLLOVER = 1 << 1,
+   SKIP_SPREAD = 1 << 2,
+   SKIP_SPREAD_MULT = 1 << 3,
+   SKIP_SPREAD_INSTAB = 1 << 4,
+   SKIP_LOWVOL = 1 << 5,
+   SKIP_DAILY_LOCK = 1 << 6,
+   SKIP_COOLDOWN = 1 << 7,
+   SKIP_LOSS_BLOCK = 1 << 8,
+   SKIP_DAILY_MAX = 1 << 9,
+   SKIP_DAILY_SCORE = 1 << 10,
+   SKIP_STOPS = 1 << 11,
+   SKIP_KILLZONE = 1 << 12,
+   SKIP_PDARRAY = 1 << 13
+};
+
+enum EntryMask
+{
+   ENTRY_NONE = 0,
+   ENTRY_BIAS = 1 << 0,
+   ENTRY_PIVOT = 1 << 1,
+   ENTRY_HL_LH = 1 << 2,
+   ENTRY_BOS_CLOSE = 1 << 3,
+   ENTRY_BOS_RETEST = 1 << 4,
+   ENTRY_KEYLEVEL = 1 << 5,
+   ENTRY_ANTICHASE = 1 << 6,
+   ENTRY_FVG = 1 << 7,
+   ENTRY_FIB = 1 << 8,
+   ENTRY_FOOTPRINT = 1 << 9,
+   ENTRY_SPIKE = 1 << 10,
+   ENTRY_RSI_LOSS = 1 << 11,
+   ENTRY_MMSL = 1 << 12,
+   ENTRY_RR = 1 << 13,
+   ENTRY_KILLZONE = 1 << 14,
+   ENTRY_SWEEP = 1 << 15,
+   ENTRY_DISPLACEMENT = 1 << 16,
+   ENTRY_MSS = 1 << 17,
+   ENTRY_OB_RTO = 1 << 18,
+   ENTRY_OTE = 1 << 19,
+   ENTRY_PDARRAY = 1 << 20,
+   ENTRY_SR = 1 << 21,
+   ENTRY_SD = 1 << 22,
+   ENTRY_CANDLE = 1 << 23,
+   ENTRY_MOM = 1 << 24
+};
+
+// --- forward declarations (needed for MQL5 compiler order)
+double NormalizeVolumeByStep(double volume);
+
+int EnsureIndicatorHandle(const int type, const string sym, ENUM_TIMEFRAMES tf, int p1, int p2, int p3);
+double ReadIndicatorValue(const int handle, const int bufferIndex, const int shift);
+void ReleaseIndicatorsCache();
+
+struct MarketContext
+{
+   double bid;
+   double ask;
+   double mid;
+   double spreadPts;
+   double atrM15;
+   double atrH1;
+   double adxH1;
+   double rsi1;
+   double rsi2;
+   double emaFast;
+   double emaSlow;
+   int killzoneActive;
+   double pdh;
+   double pdl;
+   double hod;
+   double lod;
+   int lossStreak;
+   int dayTrades;
+   double spreadEma;
+};
+
+void BuildContext(MarketContext &ctx);
+
+bool CalculateEntryCore(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                        int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                        double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                        double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                        int &sweepDir, double &sweepLevel, double &displacementScore,
+                        double &obHigh, double &obLow, double &obMT, int &oteOk,
+                        int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                        int &candleHit, int &candleType,
+                        int &momHit, double &rsi1, double &rsi2);
+
+void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
+              int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
+              int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
+              int killzoneActive, double pdh, double pdl, double psh, double psl, double hod, double lod,
+              int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
+              int oteOk, int sdHit, int sdType, double sdDistATR, int sdFresh,
+              int candleHit, int candleType, int momHit, double rsi1, double rsi2);
+
+string GVName(const string key)
+{
+   return "XK_" + key + "_" + g_symbol + "_" + (string)cfg_InpMagic;
 }
 
-#ifndef OP_BUY
-#define OP_BUY 0
-#endif
-#ifndef OP_SELL
-#define OP_SELL 1
-#endif
-
-input int SL_Pips = 30;
-input double RR_Low = 2.0;
-input double RR_High = 3.0;
-input double Risk_Low = 2.5;
-input double Risk_High = 20.0;
-input double ATRMultiplier = 1.5;
-input int    MaxTrades     = 3;  // limite operazioni aperte
-
-// Variabili aggiornabili da Telegram
-input double riskPercent   = 2.0; // percentuale di rischio predefinita
-input int    takeProfitPips = 60; // TP iniziale in pips
-input int    stopLossPips   = 30; // SL iniziale in pips
-
-datetime lastTradeTime = 0;
-double initialBalance, maxEquity;
-
-int OnInit() {
-    initialBalance = AccountInfoDouble(ACCOUNT_BALANCE);
-    maxEquity = initialBalance;
-    return(INIT_SUCCEEDED);
+double GVGetDouble(const string key, double defval)
+{
+   string name = GVName(key);
+   if(!GlobalVariableCheck(name))
+   {
+      GlobalVariableSet(name, defval);
+      return defval;
+   }
+   return GlobalVariableGet(name);
 }
 
-//+------------------------------------------------------------------+
-//| Funzione per leggere il controllo da Telegram                    |
-//+------------------------------------------------------------------+
-bool IsEAEnabled()
+void GVSetDouble(const string key, double val)
 {
-   int fileHandle = FileOpen("ea_control.txt", FILE_READ|FILE_ANSI);
-   if(fileHandle==INVALID_HANDLE)
+   GlobalVariableSet(GVName(key), val);
+}
+
+int GVGetInt(const string key, int defval)
+{
+   return (int)GVGetDouble(key, defval);
+}
+
+void GVSetInt(const string key, int val)
+{
+   GVSetDouble(key, (double)val);
+}
+
+bool IsNewBar(ENUM_TIMEFRAMES tf, datetime &lastBarTime)
+{
+   datetime t = iTime(g_symbol, tf, 0);
+   if(t != lastBarTime)
+   {
+      lastBarTime = t;
+      return true;
+   }
+   return false;
+}
+
+string ResolveSymbol()
+{
+   if(StringLen(cfg_InpSymbolOverride) > 0)
+      return cfg_InpSymbolOverride;
+   return _Symbol;
+}
+
+bool ContainsAny(const string text, const string &tokens[])
+{
+   for(int i = 0; i < ArraySize(tokens); i++)
+   {
+      if(StringFind(text, tokens[i]) >= 0)
+         return true;
+   }
+   return false;
+}
+
+SymbolProfile DetectSymbolProfile(const string symbol)
+{
+   string symUpper = symbol;
+   StringToUpper(symUpper);
+   if(StringFind(symUpper, "XAU") >= 0 || StringFind(symUpper, "GOLD") >= 0)
+      return PROFILE_FX_MAJORS_5DIG;
+   string indexTokens[] = {"US30", "DJ30", "WS30", "US30CASH",
+                           "NAS100", "USTEC", "US100", "NAS",
+                           "SPX500", "SPX", "US500", "US_500", "SP500",
+                           "GER40", "DE40", "DAX", "DAX40",
+                           "FTSEMIB", "FTSE_MIB", "ITA40",
+                           "UK100", "FTSE"};
+   if(ContainsAny(symUpper, indexTokens))
+      return PROFILE_INDICES;
+   if(StringFind(symUpper, "JPY") >= 0)
+      return PROFILE_FX_JPY_3DIG;
+   return PROFILE_FX_MAJORS_5DIG;
+}
+
+bool IsGoldSymbol(const string symbol)
+{
+   string symUpper = symbol;
+   StringToUpper(symUpper);
+   return (StringFind(symUpper, "XAU") >= 0 || StringFind(symUpper, "GOLD") >= 0);
+}
+
+string ProfileName(SymbolProfile profile)
+{
+   switch(profile)
+   {
+      case PROFILE_FX_MAJORS_5DIG:
+         return "FX_MAJORS_5DIG";
+      case PROFILE_FX_JPY_3DIG:
+         return "FX_JPY_3DIG";
+      case PROFILE_INDICES:
+         return "INDICES";
+   }
+   return "UNKNOWN";
+}
+
+double PriceFromPoints(double points)
+{
+   return points * g_point;
+}
+
+double PointsFromPrice(double price)
+{
+   return (g_point > 0.0) ? price / g_point : 0.0;
+}
+
+double PriceFromPips(double pips)
+{
+   return pips * g_pip;
+}
+
+double PipsFromPrice(double price)
+{
+   return (g_pip > 0.0) ? price / g_pip : 0.0;
+}
+
+double PointsFromPips(double pips)
+{
+   double price = PriceFromPips(pips);
+   return PointsFromPrice(price);
+}
+
+double PipsFromPoints(double points)
+{
+   double price = PriceFromPoints(points);
+   return PipsFromPrice(price);
+}
+
+double NormalizePrice(double p)
+{
+   return NormalizeDouble(p, g_digits);
+}
+
+double PipPrice()
+{
+   if(cfg_InpPipPrice > 0.0)
+      return cfg_InpPipPrice;
+   return g_pip;
+}
+
+double AutoPipSize(bool useOverride)
+{
+   if(useOverride && cfg_InpPipPrice > 0.0)
+      return cfg_InpPipPrice;
+
+   if(g_profile == PROFILE_INDICES)
+      return 1.0;
+
+   if(g_digits == 3 || g_digits == 5)
+      return g_point * 10.0;
+
+   return g_point;
+}
+
+double SpreadPoints()
+{
+   double ask = SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   double bid = SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   return (ask - bid) / g_point;
+}
+
+int MinutesOfDay(datetime t)
+{
+   MqlDateTime dt;
+   TimeToStruct(t, dt);
+   return dt.hour * 60 + dt.min;
+}
+
+datetime MakeDateTime(int year, int mon, int day, int hour, int min, int sec)
+{
+   MqlDateTime dt;
+   dt.year = year;
+   dt.mon = mon;
+   dt.day = day;
+   dt.hour = hour;
+   dt.min = min;
+   dt.sec = sec;
+   return StructToTime(dt);
+}
+
+datetime FirstSundayUTC(int year, int mon, int hour, int min)
+{
+   MqlDateTime dt;
+   TimeToStruct(MakeDateTime(year, mon, 1, 0, 0, 0), dt);
+   int firstSunday = 1 + ((7 - dt.day_of_week) % 7);
+   return MakeDateTime(year, mon, firstSunday, hour, min, 0);
+}
+
+datetime SecondSundayUTC(int year, int mon, int hour, int min)
+{
+   datetime firstSunday = FirstSundayUTC(year, mon, 0, 0);
+   MqlDateTime dt;
+   TimeToStruct(firstSunday, dt);
+   int secondSunday = dt.day + 7;
+   return MakeDateTime(year, mon, secondSunday, hour, min, 0);
+}
+
+bool IsUSDST(datetime utcTime)
+{
+   MqlDateTime dt;
+   TimeToStruct(utcTime, dt);
+   datetime dstStart = SecondSundayUTC(dt.year, 3, 7, 0);
+   datetime dstEnd = FirstSundayUTC(dt.year, 11, 6, 0);
+   return (utcTime >= dstStart && utcTime < dstEnd);
+}
+
+int EffectiveNYOffsetHours()
+{
+   if(!cfg_InpAutoNYDST)
+      return cfg_InpNYOffsetHours;
+   datetime nowUtc = TimeGMT();
+   return IsUSDST(nowUtc) ? cfg_InpNYOffsetSummerHours : cfg_InpNYOffsetHours;
+}
+
+int GetServerUtcOffsetSeconds()
+{
+   return (int)(TimeTradeServer() - TimeGMT());
+}
+
+datetime ToNYTime(datetime serverTime)
+{
+   int serverOffset = GetServerUtcOffsetSeconds();
+   int nyOffset = cfg_InpUseManualNYOffset ? (EffectiveNYOffsetHours() * 3600) : (-5 * 3600);
+   return serverTime - serverOffset + nyOffset;
+}
+
+int MinutesOfDayNY(datetime serverTime)
+{
+   datetime ny = ToNYTime(serverTime);
+   return MinutesOfDay(ny);
+}
+
+bool KillzoneActive(bool &isAsia, bool &isLondon, bool &isNY)
+{
+   isAsia = false;
+   isLondon = false;
+   isNY = false;
+   if(!cfg_InpUseICTTime)
+      return false;
+   int minNY = MinutesOfDayNY(TimeCurrent());
+   if(cfg_InpUseKillzoneAsia && minNY >= 20 * 60 && minNY < 22 * 60)
+      isAsia = true;
+   if(cfg_InpUseKillzoneLondon && minNY >= 2 * 60 && minNY < 5 * 60)
+      isLondon = true;
+   if(cfg_InpUseKillzoneNY && minNY >= 7 * 60 && minNY < 9 * 60)
+      isNY = true;
+   return (isAsia || isLondon || isNY);
+}
+
+bool TimeInRange(const string start, const string end)
+{
+   int sh = StringToInteger(StringSubstr(start, 0, 2));
+   int sm = StringToInteger(StringSubstr(start, 3, 2));
+   int eh = StringToInteger(StringSubstr(end, 0, 2));
+   int em = StringToInteger(StringSubstr(end, 3, 2));
+
+   int startMin = sh * 60 + sm;
+   int endMin = eh * 60 + em;
+   int nowMin = MinutesOfDay(TimeCurrent());
+
+   if(startMin <= endMin)
+      return (nowMin >= startMin && nowMin < endMin);
+   return (nowMin >= startMin || nowMin < endMin);
+}
+
+void UpdateSpreadEMA()
+{
+   double spread = SpreadPoints();
+   double alpha = 2.0 / (cfg_InpSpreadAvgBarsH1 + 1.0);
+   if(g_spreadEma <= 0.0)
+      g_spreadEma = spread;
+   else
+      g_spreadEma = alpha * spread + (1.0 - alpha) * g_spreadEma;
+}
+
+bool SpreadMultipleWouldBlock(double spread, double spreadEma)
+{
+   if(!cfg_InpUseSpreadMultiple || spreadEma <= 0.0)
+      return false;
+   return (spread > spreadEma * cfg_InpSpreadMultiple);
+}
+
+bool SpreadInstabilityWouldBlock(double spread, double spreadEma)
+{
+   if(!cfg_InpUseSpreadInstability || spreadEma <= 0.0)
+      return false;
+   return (spread > spreadEma * cfg_InpSpreadSpikeFactor);
+}
+
+bool SpreadMultipleBlocked()
+{
+   if(!cfg_InpUseSpreadMultiple)
       return false;
 
-   string status = FileReadString(fileHandle);
-   FileClose(fileHandle);
-   status = Trim(status);
-   return (status=="ACTIVE");
+   double spread = SpreadPoints();
+   if(g_spreadEma <= 0.0)
+      return false;
+
+   if(spread > g_spreadEma * cfg_InpSpreadMultiple)
+   {
+      datetime until = TimeCurrent() + cfg_InpSpreadMultipleBlockMin * 60;
+      GVSetDouble("spreadBlockUntil", (double)until);
+   }
+
+   datetime blockUntil = (datetime)GVGetDouble("spreadBlockUntil", 0.0);
+   return (blockUntil > TimeCurrent());
 }
 
-//+------------------------------------------------------------------+
-//| Gestione comandi avanzati da file Telegram                       |
-//+------------------------------------------------------------------+
-void CheckTelegramCommands()
+bool SpreadInstabilityBlocked()
 {
-   string command="";
-   int handle = FileOpen("ea_command.txt", FILE_READ|FILE_ANSI);
-   if(handle==INVALID_HANDLE)
+   if(!cfg_InpUseSpreadInstability || g_spreadEma <= 0.0)
+      return false;
+
+   double spread = SpreadPoints();
+   if(spread > g_spreadEma * cfg_InpSpreadSpikeFactor)
+   {
+      datetime until = TimeCurrent() + cfg_InpSpreadSpikeBlockMin * 60;
+      GVSetDouble("spreadSpikeUntil", (double)until);
+   }
+
+   datetime blockUntil = (datetime)GVGetDouble("spreadSpikeUntil", 0.0);
+   return (blockUntil > TimeCurrent());
+}
+
+bool SessionAllowed()
+{
+   if(!cfg_InpUseSessionFilter)
+      return true;
+   int hour = TimeHour(TimeCurrent());
+   if(cfg_InpStartHour <= cfg_InpEndHour)
+      return (hour >= cfg_InpStartHour && hour <= cfg_InpEndHour);
+   return (hour >= cfg_InpStartHour || hour <= cfg_InpEndHour);
+}
+
+bool RolloverBlocked()
+{
+   if(!cfg_InpUseRolloverBlock)
+      return false;
+   return TimeInRange(cfg_InpRolloverStart, cfg_InpRolloverEnd);
+}
+
+int EnsureIndicatorHandle(const int type, const string sym, ENUM_TIMEFRAMES tf, int p1, int p2, int p3)
+{
+   for(int i = 0; i < ArraySize(g_indicators.entries); i++)
+   {
+      IndicatorEntry e = g_indicators.entries[i];
+      if(e.type == type && e.sym == sym && e.tf == tf && e.p1 == p1 && e.p2 == p2 && e.p3 == p3)
+         return e.handle;
+   }
+
+   int handle = INVALID_HANDLE;
+   if(type == 1)
+      handle = iATR(sym, tf, p1);
+   else if(type == 2)
+      handle = iADX(sym, tf, p1);
+   else if(type == 3)
+      handle = iRSI(sym, tf, p1, p2);
+   else if(type == 4)
+      handle = iMA(sym, tf, p1, p2, (ENUM_MA_METHOD)p3, PRICE_CLOSE);
+
+   if(handle == INVALID_HANDLE)
+      return INVALID_HANDLE;
+
+   IndicatorEntry ne;
+   ne.type = type;
+   ne.sym = sym;
+   ne.tf = tf;
+   ne.p1 = p1;
+   ne.p2 = p2;
+   ne.p3 = p3;
+   ne.handle = handle;
+   int n = ArraySize(g_indicators.entries);
+   ArrayResize(g_indicators.entries, n + 1);
+   g_indicators.entries[n] = ne;
+   return handle;
+}
+
+double ReadIndicatorValue(const int handle, const int bufferIndex, const int shift)
+{
+   if(handle == INVALID_HANDLE)
+      return EMPTY_VALUE;
+   double buf[];
+   ArraySetAsSeries(buf, true);
+   if(CopyBuffer(handle, bufferIndex, shift, 1, buf) <= 0)
+      return EMPTY_VALUE;
+   return buf[0];
+}
+
+void ReleaseIndicatorsCache()
+{
+   for(int i = 0; i < ArraySize(g_indicators.entries); i++)
+   {
+      if(g_indicators.entries[i].handle != INVALID_HANDLE)
+      {
+         IndicatorRelease(g_indicators.entries[i].handle);
+         g_indicators.entries[i].handle = INVALID_HANDLE;
+      }
+   }
+   ArrayResize(g_indicators.entries, 0);
+}
+
+double GetRSI(const string sym, ENUM_TIMEFRAMES tf, int period, int applied_price, int shift = 0)
+{
+   int handle = EnsureIndicatorHandle(3, sym, tf, period, applied_price, 0);
+   return ReadIndicatorValue(handle, 0, shift);
+}
+
+double GetMA(const string sym, ENUM_TIMEFRAMES tf, int period, int ma_shift, ENUM_MA_METHOD method, int applied_price, int shift = 0)
+{
+   int handle = EnsureIndicatorHandle(4, sym, tf, period, ma_shift, (int)method);
+   return ReadIndicatorValue(handle, 0, shift);
+}
+
+double GetATR(const string sym, ENUM_TIMEFRAMES tf, int period, int shift = 0)
+{
+   int handle = EnsureIndicatorHandle(1, sym, tf, period, 0, 0);
+   return ReadIndicatorValue(handle, 0, shift);
+}
+
+double GetADX(const string sym, ENUM_TIMEFRAMES tf, int period, int shift = 0)
+{
+   int handle = EnsureIndicatorHandle(2, sym, tf, period, 0, 0);
+   return ReadIndicatorValue(handle, 0, shift);
+}
+
+double ATR(ENUM_TIMEFRAMES tf, int shift)
+{
+   return GetATR(g_symbol, tf, cfg_InpATRPeriod, shift);
+}
+
+double ADX(ENUM_TIMEFRAMES tf, int shift)
+{
+   return GetADX(g_symbol, tf, cfg_InpADXPeriod, shift);
+}
+
+double RSI(ENUM_TIMEFRAMES tf, int shift)
+{
+   return GetRSI(g_symbol, tf, cfg_InpRSIPeriod, PRICE_CLOSE, shift);
+}
+
+double EMA(ENUM_TIMEFRAMES tf, int period, int shift)
+{
+   return GetMA(g_symbol, tf, period, 0, MODE_EMA, PRICE_CLOSE, shift);
+}
+
+double VolumeMA(ENUM_TIMEFRAMES tf, int period, int shift)
+{
+   double sum = 0.0;
+   for(int i = shift; i < shift + period; i++)
+      sum += (double)iVolume(g_symbol, tf, i);
+   return sum / MathMax(1, period);
+}
+
+bool LowVolumeBlocked()
+{
+   if(!cfg_InpUseLowVolFilter)
+      return false;
+
+   double vol = (double)iVolume(g_symbol, cfg_InpVolTF, 0);
+   double avg = VolumeMA(cfg_InpVolTF, cfg_InpVolMAPeriod, 1);
+   if(avg <= 0.0)
+      return false;
+   return vol < avg * cfg_InpLowVolFactor;
+}
+
+TradeDir BiasH1()
+{
+   double emaFast = EMA(PERIOD_H1, cfg_InpEMA_Fast, 1);
+   double emaSlow = EMA(PERIOD_H1, cfg_InpEMA_Slow, 1);
+   double close = iClose(g_symbol, PERIOD_H1, 1);
+   if(emaFast > emaSlow && close > emaFast)
+      return DIR_LONG;
+   if(emaFast < emaSlow && close < emaFast)
+      return DIR_SHORT;
+   return DIR_NONE;
+}
+
+RegimeState ClassifyRegime()
+{
+   double atr = ATR(PERIOD_H1, 1);
+   double close = iClose(g_symbol, PERIOD_H1, 1);
+   double atrRel = (close > 0.0) ? (atr / close) * 100.0 : 0.0;
+   bool isExpansion = atrRel > 0.18;
+   double adx = ADX(PERIOD_H1, 1);
+   TradeDir bias = BiasH1();
+
+   if(isExpansion && adx < 18.0)
+      return REGIME_EXPANSION;
+   if(adx >= 25.0 && bias != DIR_NONE)
+      return REGIME_TREND;
+   if(adx >= 18.0)
+      return REGIME_TRANSITION;
+   return REGIME_RANGE;
+}
+
+RegimeState UpdateRegime()
+{
+   RegimeState current = (RegimeState)GVGetInt("regime", REGIME_RANGE);
+   int lockBars = GVGetInt("regimeLock", 0);
+   int confirmBars = GVGetInt("regimeConfirm", 0);
+
+   RegimeState next = ClassifyRegime();
+
+   if(lockBars > 0)
+   {
+      GVSetInt("regimeLock", lockBars - 1);
+      return current;
+   }
+
+   if(next != current)
+   {
+      confirmBars++;
+      if(confirmBars >= cfg_InpRegimeConfirmBarsH1)
+      {
+         current = next;
+         GVSetInt("regime", (int)current);
+         GVSetInt("regimeConfirm", 0);
+         GVSetInt("regimeLock", cfg_InpRegimeLockBarsH1);
+         return current;
+      }
+      GVSetInt("regimeConfirm", confirmBars);
+      return current;
+   }
+
+   GVSetInt("regimeConfirm", 0);
+   return current;
+}
+
+bool IsPivotHigh(int index)
+{
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotLen < 0 || index + cfg_InpPivotLen >= bars)
+      return false;
+   double high = iHigh(g_symbol, PERIOD_M15, index);
+   for(int j = 1; j <= cfg_InpPivotLen; j++)
+   {
+      if(high <= iHigh(g_symbol, PERIOD_M15, index - j) || high <= iHigh(g_symbol, PERIOD_M15, index + j))
+         return false;
+   }
+   return true;
+}
+
+bool IsPivotLow(int index)
+{
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotLen < 0 || index + cfg_InpPivotLen >= bars)
+      return false;
+   double low = iLow(g_symbol, PERIOD_M15, index);
+   for(int j = 1; j <= cfg_InpPivotLen; j++)
+   {
+      if(low >= iLow(g_symbol, PERIOD_M15, index - j) || low >= iLow(g_symbol, PERIOD_M15, index + j))
+         return false;
+   }
+   return true;
+}
+
+bool IsConfirmedPivotHigh(int index)
+{
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotConfirmBars < 0)
+      return false;
+   if(!IsPivotHigh(index))
+      return false;
+   for(int j = 1; j <= cfg_InpPivotConfirmBars; j++)
+   {
+      if(iHigh(g_symbol, PERIOD_M15, index - j) >= iHigh(g_symbol, PERIOD_M15, index))
+         return false;
+   }
+   return true;
+}
+
+bool IsConfirmedPivotLow(int index)
+{
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0 || index <= 0 || index >= bars)
+      return false;
+   if(index - cfg_InpPivotConfirmBars < 0)
+      return false;
+   if(!IsPivotLow(index))
+      return false;
+   for(int j = 1; j <= cfg_InpPivotConfirmBars; j++)
+   {
+      if(iLow(g_symbol, PERIOD_M15, index - j) <= iLow(g_symbol, PERIOD_M15, index))
+         return false;
+   }
+   return true;
+}
+
+int BOSAgeBars(double &bosLevel)
+{
+   bosLevel = GVGetDouble("bosLevel", 0.0);
+   datetime bosTime = (datetime)GVGetDouble("bosTime", 0.0);
+   if(bosTime == 0)
+      return -1;
+   return iBarShift(g_symbol, PERIOD_M15, bosTime, true);
+}
+
+int NYDayId(datetime serverTime)
+{
+   MqlDateTime dt;
+   TimeToStruct(ToNYTime(serverTime), dt);
+   return dt.year * 10000 + dt.mon * 100 + dt.day;
+}
+
+void GetPDLevels(double &pdh, double &pdl)
+{
+   pdh = iHigh(g_symbol, PERIOD_D1, 1);
+   pdl = iLow(g_symbol, PERIOD_D1, 1);
+}
+
+void GetHODLOD(double &hod, double &lod)
+{
+   hod = -DBL_MAX;
+   lod = DBL_MAX;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0)
+   {
+      hod = iHigh(g_symbol, PERIOD_D1, 0);
+      lod = iLow(g_symbol, PERIOD_D1, 0);
       return;
-
-   command = FileReadString(handle);
-   FileClose(handle);
-   command = Trim(command);
-
-      if(command == "/emergency_stop")
-      {
-         CloseAllPositions();
-         int h=FileOpen("ea_control.txt", FILE_WRITE|FILE_ANSI);
-         if(h!=INVALID_HANDLE)
-         {
-            FileWriteString(h, "INACTIVE");
-            FileClose(h);
-         }
-         Print("Emergency Stop attivato!");
-      }
-      else if(StringFind(command, "/set_risk") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 10));
-         riskPercent = val;
-         Print("Risk aggiornato: ", riskPercent);
-      }
-      else if(StringFind(command, "/set_tp") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 8));
-         takeProfitPips = (int)val;
-         Print("TakeProfit aggiornato: ", takeProfitPips);
-      }
-      else if(StringFind(command, "/set_sl") == 0)
-      {
-         double val = StringToDouble(StringSubstr(command, 8));
-         stopLossPips = (int)val;
-         Print("StopLoss aggiornato: ", stopLossPips);
-      }
+   }
+   int todayId = NYDayId(TimeCurrent());
+   for(int i = 0; i < bars; i++)
+   {
+      datetime t = iTime(g_symbol, PERIOD_M15, i);
+      if(NYDayId(t) != todayId)
+         break;
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      hod = MathMax(hod, high);
+      lod = MathMin(lod, low);
+   }
+   if(hod == -DBL_MAX)
+      hod = iHigh(g_symbol, PERIOD_D1, 0);
+   if(lod == DBL_MAX)
+      lod = iLow(g_symbol, PERIOD_D1, 0);
 }
 
-//+------------------------------------------------------------------+
-//| Funzione per chiudere tutte le operazioni                        |
-//+------------------------------------------------------------------+
-void CloseAllPositions()
+
+void GetHODLOD_Cached(double &hod, double &lod)
 {
-   for(int i=PositionsTotal()-1; i>=0; i--)
+   int dayId = NYDayId(TimeCurrent());
+   datetime barT = iTime(g_symbol, PERIOD_M15, 0);
+   if(g_hodlodDayId != dayId || g_hodlodBarTime != barT)
+   {
+      GetHODLOD(g_cachedHod, g_cachedLod);
+      g_hodlodDayId = dayId;
+      g_hodlodBarTime = barT;
+   }
+   hod = g_cachedHod;
+   lod = g_cachedLod;
+}
+
+bool GetSessionHighLowNY(int startMin, int endMin, int dayOffset, double &high, double &low)
+{
+   high = -DBL_MAX;
+   low = DBL_MAX;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0)
+      return false;
+   int targetDay = NYDayId(TimeCurrent() + dayOffset * 86400);
+   for(int i = 0; i < bars; i++)
+   {
+      datetime t = iTime(g_symbol, PERIOD_M15, i);
+      if(NYDayId(t) != targetDay)
+         continue;
+      int minNY = MinutesOfDayNY(t);
+      if(minNY >= startMin && minNY < endMin)
+      {
+         high = MathMax(high, iHigh(g_symbol, PERIOD_M15, i));
+         low = MathMin(low, iLow(g_symbol, PERIOD_M15, i));
+      }
+   }
+   return (high > -DBL_MAX && low < DBL_MAX);
+}
+
+void GetPSHPSL(double &psh, double &psl)
+{
+   psh = 0.0;
+   psl = 0.0;
+   int minNY = MinutesOfDayNY(TimeCurrent());
+   double high = 0.0;
+   double low = 0.0;
+   if(minNY >= 9 * 60)
+   {
+      if(GetSessionHighLowNY(7 * 60, 9 * 60, 0, high, low))
+      {
+         psh = high;
+         psl = low;
+         return;
+      }
+   }
+   if(minNY >= 5 * 60)
+   {
+      if(GetSessionHighLowNY(2 * 60, 5 * 60, 0, high, low))
+      {
+         psh = high;
+         psl = low;
+         return;
+      }
+   }
+   if(GetSessionHighLowNY(20 * 60, 22 * 60, -1, high, low))
+   {
+      psh = high;
+      psl = low;
+   }
+}
+
+bool FindEqualHighCluster(double &level)
+{
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
+   int count = 0;
+   level = 0.0;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int scanBars = MathMin(cfg_InpEqScanBars, bars - 1);
+   if(scanBars <= 2)
+      return false;
+   for(int i = 2; i < scanBars; i++)
+   {
+      if(!IsConfirmedPivotHigh(i))
+         continue;
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      if(count == 0)
+      {
+         level = high;
+         count = 1;
+      }
+      else if(MathAbs(high - level) <= tol)
+      {
+         count++;
+      }
+      if(count >= cfg_InpEqClusterMin)
+         return true;
+   }
+   return false;
+}
+
+bool FindEqualLowCluster(double &level)
+{
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
+   int count = 0;
+   level = 0.0;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int scanBars = MathMin(cfg_InpEqScanBars, bars - 1);
+   if(scanBars <= 2)
+      return false;
+   for(int i = 2; i < scanBars; i++)
+   {
+      if(!IsConfirmedPivotLow(i))
+         continue;
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      if(count == 0)
+      {
+         level = low;
+         count = 1;
+      }
+      else if(MathAbs(low - level) <= tol)
+      {
+         count++;
+      }
+      if(count >= cfg_InpEqClusterMin)
+         return true;
+   }
+   return false;
+}
+
+bool DetectLiquiditySweep(TradeDir &sweepDir, double &sweepLevel)
+{
+   sweepDir = DIR_NONE;
+   sweepLevel = 0.0;
+   if(iBars(g_symbol, PERIOD_M15) <= 1)
+      return false;
+   double eqHigh = 0.0;
+   double eqLow = 0.0;
+   bool hasHigh = FindEqualHighCluster(eqHigh);
+   bool hasLow = FindEqualLowCluster(eqLow);
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double atr = ATR(PERIOD_M15, 1);
+   double tol = MathMax(atr * cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints * g_point);
+   if(hasHigh && high1 > eqHigh + tol && close1 < eqHigh)
+   {
+      sweepDir = DIR_SHORT;
+      sweepLevel = eqHigh;
+      return true;
+   }
+   if(hasLow && low1 < eqLow - tol && close1 > eqLow)
+   {
+      sweepDir = DIR_LONG;
+      sweepLevel = eqLow;
+      return true;
+   }
+   return false;
+}
+
+bool DisplacementOk(TradeDir dir, double &score)
+{
+   score = 0.0;
+   if(iBars(g_symbol, PERIOD_M15) <= 1)
+      return false;
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double open1 = iOpen(g_symbol, PERIOD_M15, 1);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double range = high1 - low1;
+   double body = MathAbs(close1 - open1);
+   double atr = ATR(PERIOD_M15, 1);
+   double bodyRatio = (range > 0.0) ? body / range : 0.0;
+   bool dirOk = (dir == DIR_LONG) ? (close1 > open1) : (close1 < open1);
+   bool sizeOk = range >= atr * cfg_InpDisplacementATR && bodyRatio >= cfg_InpDisplacementBodyRatio;
+   if(dirOk && sizeOk)
+      score = range / (atr > 0.0 ? atr : 1.0);
+   return dirOk && sizeOk;
+}
+
+bool FindOrderBlock(TradeDir dir, double &obHigh, double &obLow, double &obMT, int &obAgeBars)
+{
+   obHigh = 0.0;
+   obLow = 0.0;
+   obMT = 0.0;
+   obAgeBars = -1;
+   int bars = iBars(g_symbol, PERIOD_M15);
+   int lookback = MathMin(cfg_InpOBLookback, bars - 1);
+   if(lookback < 2)
+      return false;
+   for(int i = 2; i <= lookback; i++)
+   {
+      double open = iOpen(g_symbol, PERIOD_M15, i);
+      double close = iClose(g_symbol, PERIOD_M15, i);
+      bool opposite = (dir == DIR_LONG) ? (close < open) : (close > open);
+      if(opposite)
+      {
+         obHigh = iHigh(g_symbol, PERIOD_M15, i);
+         obLow = iLow(g_symbol, PERIOD_M15, i);
+         obMT = (obHigh + obLow) / 2.0;
+         obAgeBars = i;
+         return true;
+      }
+   }
+   return false;
+}
+
+bool OTEOk(TradeDir dir, double price, double &oteMin, double &oteMax, double &swingHigh, double &swingLow)
+{
+   swingHigh = -DBL_MAX;
+   swingLow = DBL_MAX;
+   int bars = iBars(g_symbol, cfg_InpOTE_HTF);
+   if(bars <= 1)
+      return false;
+   int lookback = MathMin(cfg_InpOTE_SwingLookback, bars - 1);
+   if(lookback < 1)
+      return false;
+   for(int i = 1; i <= lookback; i++)
+   {
+      swingHigh = MathMax(swingHigh, iHigh(g_symbol, cfg_InpOTE_HTF, i));
+      swingLow = MathMin(swingLow, iLow(g_symbol, cfg_InpOTE_HTF, i));
+   }
+   if(swingHigh <= swingLow)
+      return false;
+   double range = swingHigh - swingLow;
+   if(dir == DIR_LONG)
+   {
+      oteMin = swingHigh - range * cfg_InpOTE_Max;
+      oteMax = swingHigh - range * cfg_InpOTE_Min;
+      return (price >= oteMin && price <= oteMax && price <= (swingHigh - range * 0.5));
+   }
+   oteMin = swingLow + range * cfg_InpOTE_Min;
+   oteMax = swingLow + range * cfg_InpOTE_Max;
+   return (price >= oteMin && price <= oteMax && price >= (swingLow + range * 0.5));
+}
+
+bool FindRecentPivots(double &lastHigh, double &prevHigh, double &lastLow, double &prevLow)
+{
+   int foundHigh = 0;
+   int foundLow = 0;
+   lastHigh = prevHigh = 0.0;
+   lastLow = prevLow = 0.0;
+
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 0)
+      return false;
+   int start = cfg_InpPivotLen + cfg_InpPivotConfirmBars;
+   int end = MathMin(bars - cfg_InpPivotLen - 1, 200);
+   if(end <= start)
+      return false;
+   for(int i = start; i < end; i++)
+   {
+      if(i - cfg_InpPivotConfirmBars < 0)
+         continue;
+
+      if(IsConfirmedPivotHigh(i))
+      {
+         if(foundHigh == 0)
+            lastHigh = iHigh(g_symbol, PERIOD_M15, i);
+         else if(foundHigh == 1)
+            prevHigh = iHigh(g_symbol, PERIOD_M15, i);
+         foundHigh++;
+      }
+      if(IsConfirmedPivotLow(i))
+      {
+         if(foundLow == 0)
+            lastLow = iLow(g_symbol, PERIOD_M15, i);
+         else if(foundLow == 1)
+            prevLow = iLow(g_symbol, PERIOD_M15, i);
+         foundLow++;
+      }
+      if(foundHigh >= 2 && foundLow >= 2)
+         return true;
+   }
+   return false;
+}
+
+void StoreBOS(TradeDir dir, double bosLevel, datetime bosTime)
+{
+   GVSetDouble("bosLevel", bosLevel);
+   GVSetDouble("bosTime", (double)bosTime);
+   GVSetInt("bosDir", (int)dir);
+}
+
+bool BOSStateValid(TradeDir dir, double &bosLevel)
+{
+   int bosDir = GVGetInt("bosDir", 0);
+   if(bosDir != (int)dir)
+      return false;
+
+   bosLevel = GVGetDouble("bosLevel", 0.0);
+   datetime bosTime = (datetime)GVGetDouble("bosTime", 0.0);
+   if(bosTime == 0 || bosLevel <= 0.0)
+      return false;
+
+   int shift = iBarShift(g_symbol, PERIOD_M15, bosTime, true);
+   if(shift < 0)
+      return false;
+   return shift <= cfg_InpMaxBarsAfterBOS;
+}
+
+bool BreakRetestOk(TradeDir dir, double atrM15)
+{
+   if(!cfg_InpUseBreakRetest)
+      return true;
+
+   double storedBosLevel = 0.0;
+   if(!BOSStateValid(dir, storedBosLevel))
+      return false;
+
+   double tol = MathMax(atrM15 * cfg_InpRetestTolATR, 5 * g_point);
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   double low1 = iLow(g_symbol, PERIOD_M15, 1);
+   double high1 = iHigh(g_symbol, PERIOD_M15, 1);
+
+   if(dir == DIR_LONG)
+      return (low1 <= storedBosLevel + tol && close1 > storedBosLevel);
+   if(dir == DIR_SHORT)
+      return (high1 >= storedBosLevel - tol && close1 < storedBosLevel);
+   return false;
+}
+
+double NearestKeyLevel(double price)
+{
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
+   if(step <= 0.0)
+      return price;
+   return MathRound(price / step) * step;
+}
+
+double KeyBelow(double price)
+{
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
+   return MathFloor(price / step) * step;
+}
+
+double KeyAbove(double price)
+{
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
+   return MathCeil(price / step) * step;
+}
+
+bool KeyLevelNearOk(double mid, double &nearest)
+{
+   nearest = NearestKeyLevel(mid);
+   return MathAbs(mid - nearest) <= PriceFromPoints(cfg_KeyNearPoints);
+}
+
+bool AntiChaseOk(TradeDir dir, double mid, double nearest)
+{
+   double step = PriceFromPoints(cfg_KeyLevelStepPoints);
+   if(step <= 0.0)
+      return true;
+   double chaseKey = nearest;
+   if(dir == DIR_LONG && nearest > mid)
+      chaseKey = nearest - step;
+   else if(dir == DIR_SHORT && nearest < mid)
+      chaseKey = nearest + step;
+
+   double chaseMax = PriceFromPoints(cfg_KeyChaseMaxDistPoints);
+   if(dir == DIR_LONG)
+      return (mid - chaseKey <= chaseMax);
+   if(dir == DIR_SHORT)
+      return (chaseKey - mid <= chaseMax);
+   return false;
+}
+
+int FVGDirection(double &zoneMid, double priceMid)
+{
+   if(!cfg_InpUseFVGFeature)
+      return 0;
+
+   int bars = iBars(g_symbol, PERIOD_M15);
+   if(bars <= 3)
+      return 0;
+   double bestDist = DBL_MAX;
+   int bestDir = 0;
+   double bestMid = 0.0;
+
+   int scanBars = MathMin(cfg_InpFVGScanBars, bars - 3);
+   for(int i = 1; i <= scanBars; i++)
+   {
+      if(i + 2 >= bars)
+         break;
+      double low = iLow(g_symbol, PERIOD_M15, i);
+      double high = iHigh(g_symbol, PERIOD_M15, i);
+      double low2 = iLow(g_symbol, PERIOD_M15, i + 2);
+      double high2 = iHigh(g_symbol, PERIOD_M15, i + 2);
+
+      if(low > high2)
+      {
+         double mid = (low + high2) / 2.0;
+         double dist = MathAbs(priceMid - mid);
+         if(dist < bestDist)
+         {
+            bestDist = dist;
+            bestDir = DIR_LONG;
+            bestMid = mid;
+         }
+      }
+      if(high < low2)
+      {
+         double mid = (high + low2) / 2.0;
+         double dist = MathAbs(priceMid - mid);
+         if(dist < bestDist)
+         {
+            bestDist = dist;
+            bestDir = DIR_SHORT;
+            bestMid = mid;
+         }
+      }
+   }
+   zoneMid = bestMid;
+   return bestDir;
+}
+
+bool FVGOk(TradeDir dir, double mid, double atrM15)
+{
+   if(!cfg_InpUseFVGFeature)
+      return true;
+
+   double zoneMid = 0.0;
+   int fvgDir = FVGDirection(zoneMid, mid);
+   if(fvgDir == 0 || fvgDir != dir)
+      return false;
+
+   return MathAbs(mid - zoneMid) <= atrM15 * cfg_InpFVGMaxDistATR;
+}
+
+bool FibFilterOk(TradeDir dir, double mid, double lastLow, double lastHigh, bool &oteBonus)
+{
+   oteBonus = false;
+   if(!cfg_InpUseFibFilter)
+      return true;
+
+   double range = MathAbs(lastHigh - lastLow);
+   if(range <= 0.0)
+      return false;
+
+   double lvl50 = 0.0;
+   double lvl618 = 0.0;
+   if(dir == DIR_LONG)
+   {
+      lvl50 = lastHigh - range * cfg_InpFibBaseMin;
+      lvl618 = lastHigh - range * cfg_InpFibBaseMax;
+   }
+   else
+   {
+      lvl50 = lastLow + range * cfg_InpFibBaseMin;
+      lvl618 = lastLow + range * cfg_InpFibBaseMax;
+   }
+
+   double tol = PriceFromPoints(cfg_FibTolPoints);
+   double minLvl = MathMin(lvl50, lvl618) - tol;
+   double maxLvl = MathMax(lvl50, lvl618) + tol;
+   bool inBase = (mid >= minLvl && mid <= maxLvl);
+
+   if(cfg_InpUseOTEBonus)
+   {
+      double otemin = 0.0;
+      double otemax = 0.0;
+      if(dir == DIR_LONG)
+      {
+         otemin = lastHigh - range * cfg_InpOTEMax;
+         otemax = lastHigh - range * cfg_InpOTEMin;
+      }
+      else
+      {
+         otemin = lastLow + range * cfg_InpOTEMin;
+         otemax = lastLow + range * cfg_InpOTEMax;
+      }
+      double omin = MathMin(otemin, otemax);
+      double omax = MathMax(otemin, otemax);
+      if(mid >= omin && mid <= omax)
+         oteBonus = true;
+   }
+
+   return inBase;
+}
+
+bool FootprintOk(TradeDir dir, double atrM15, bool &absorption, bool &accepted)
+{
+   absorption = false;
+   accepted = true;
+   if(!cfg_InpUseFootprintProxy)
+      return true;
+
+   double vol = (double)iVolume(g_symbol, PERIOD_M15, 1);
+   double volMA = VolumeMA(PERIOD_M15, cfg_InpFP_VolMAPeriod, 2);
+   double volRatio = (volMA > 0.0) ? vol / volMA : 0.0;
+   double high = iHigh(g_symbol, PERIOD_M15, 1);
+   double low = iLow(g_symbol, PERIOD_M15, 1);
+   double open = iOpen(g_symbol, PERIOD_M15, 1);
+   double close = iClose(g_symbol, PERIOD_M15, 1);
+   double range = high - low;
+   double body = MathAbs(close - open);
+   double bodyRatio = (range > 0.0) ? body / range : 0.0;
+   double closeSide = 0.5;
+   if(range > 0.0)
+   {
+      if(dir == DIR_LONG)
+         closeSide = (close - low) / range;
+      else
+         closeSide = 1.0 - (close - low) / range;
+   }
+
+   accepted = (volRatio >= cfg_InpFP_VolSpikeRatio && bodyRatio >= cfg_InpFP_BodyMinRatio && closeSide >= cfg_InpFP_CloseSideMin);
+
+   if(volRatio >= cfg_InpFP_AbsorpVolRatio && range <= atrM15 * cfg_InpFP_AbsorpRangeATR && closeSide < 0.55)
+      absorption = true;
+
+   if(cfg_InpFP_RequireAcceptance)
+      return accepted && !absorption;
+   return !absorption;
+}
+
+bool DetectSupplyDemandBonus(TradeDir dir, int &sdType, double &sdDistATR, int &sdFresh)
+{
+   sdType = 0;
+   sdDistATR = 0.0;
+   sdFresh = 0;
+   if(!cfg_InpUseSupplyDemandBonus)
+      return false;
+
+   int bars = iBars(g_symbol, cfg_InpSD_TF);
+   if(bars <= cfg_InpSD_MaxBaseBars + 2)
+      return false;
+
+   int lookback = MathMin(cfg_InpSD_LookbackBars, bars - cfg_InpSD_MaxBaseBars - 2);
+   if(lookback < cfg_InpSD_MaxBaseBars + 2)
+      return false;
+
+   double atrM15 = ATR(PERIOD_M15, 1);
+   if(atrM15 <= 0.0)
+      return false;
+
+   double bestDist = DBL_MAX;
+   bool zoneFresh = false;
+   int zoneType = 0;
+
+   for(int i = 1; i <= lookback; i++)
+   {
+      double atr = GetATR(g_symbol, cfg_InpSD_TF, cfg_InpATRPeriod, i);
+      if(atr <= 0.0)
+         continue;
+      double impOpen = iOpen(g_symbol, cfg_InpSD_TF, i);
+      double impClose = iClose(g_symbol, cfg_InpSD_TF, i);
+      double impHigh = iHigh(g_symbol, cfg_InpSD_TF, i);
+      double impLow = iLow(g_symbol, cfg_InpSD_TF, i);
+      double impRange = impHigh - impLow;
+      double impBody = MathAbs(impClose - impOpen);
+      double bodyRatio = (impRange > 0.0) ? (impBody / impRange) : 0.0;
+      if(impRange < atr * cfg_InpSD_MinImpulseATR || bodyRatio < 0.55)
+         continue;
+
+      int baseBars = 0;
+      double baseMinLow = DBL_MAX;
+      double baseMaxHigh = -DBL_MAX;
+      double baseMinBody = DBL_MAX;
+      double baseMaxBody = -DBL_MAX;
+      for(int b = 1; b <= cfg_InpSD_MaxBaseBars; b++)
+      {
+         int shift = i + b;
+         if(shift >= bars)
+            break;
+         double bHigh = iHigh(g_symbol, cfg_InpSD_TF, shift);
+         double bLow = iLow(g_symbol, cfg_InpSD_TF, shift);
+         double bOpen = iOpen(g_symbol, cfg_InpSD_TF, shift);
+         double bClose = iClose(g_symbol, cfg_InpSD_TF, shift);
+         double bRange = bHigh - bLow;
+         if(bRange >= atr * 0.8)
+            break;
+         baseBars++;
+         baseMinLow = MathMin(baseMinLow, bLow);
+         baseMaxHigh = MathMax(baseMaxHigh, bHigh);
+         baseMinBody = MathMin(baseMinBody, MathMin(bOpen, bClose));
+         baseMaxBody = MathMax(baseMaxBody, MathMax(bOpen, bClose));
+      }
+      if(baseBars <= 0)
+         continue;
+
+      bool impulseUp = impClose > impOpen;
+      int candidateType = impulseUp ? 1 : -1;
+      if(dir == DIR_LONG && candidateType != 1)
+         continue;
+      if(dir == DIR_SHORT && candidateType != -1)
+         continue;
+
+      double pad = atr * cfg_InpSD_ZonePadATR;
+      double candLow = (candidateType == 1) ? baseMinLow : baseMinBody;
+      double candHigh = (candidateType == 1) ? baseMaxBody : baseMaxHigh;
+      candLow -= pad;
+      candHigh += pad;
+
+      bool mitigated = false;
+      for(int j = i - 1; j >= 1; j--)
+      {
+         double jHigh = iHigh(g_symbol, cfg_InpSD_TF, j);
+         double jLow = iLow(g_symbol, cfg_InpSD_TF, j);
+         if(jLow <= candHigh && jHigh >= candLow)
+         {
+            mitigated = true;
+            break;
+         }
+      }
+
+      double price = iClose(g_symbol, PERIOD_M15, 1);
+      double dist = 0.0;
+      if(price < candLow)
+         dist = candLow - price;
+      else if(price > candHigh)
+         dist = price - candHigh;
+      else
+         dist = 0.0;
+
+      double distAtr = dist / atrM15;
+      if(distAtr > cfg_InpSD_MaxDistATR)
+         continue;
+
+      if(distAtr < bestDist)
+      {
+         bestDist = distAtr;
+         zoneFresh = !mitigated;
+         zoneType = candidateType;
+      }
+   }
+
+   if(bestDist == DBL_MAX)
+      return false;
+
+   sdType = zoneType;
+   sdDistATR = bestDist;
+   sdFresh = zoneFresh ? 1 : 0;
+   return true;
+}
+
+bool CandleBonus(TradeDir dir, int &candleType)
+{
+   candleType = 0;
+   if(!cfg_InpUseCandleBonus)
+      return false;
+
+   double o1 = iOpen(g_symbol, PERIOD_M15, 1);
+   double c1 = iClose(g_symbol, PERIOD_M15, 1);
+   double h1 = iHigh(g_symbol, PERIOD_M15, 1);
+   double l1 = iLow(g_symbol, PERIOD_M15, 1);
+   double o2 = iOpen(g_symbol, PERIOD_M15, 2);
+   double c2 = iClose(g_symbol, PERIOD_M15, 2);
+   double range = h1 - l1;
+   if(range <= 0.0)
+      return false;
+
+   double body = MathAbs(c1 - o1);
+   double upperWick = h1 - MathMax(o1, c1);
+   double lowerWick = MathMin(o1, c1) - l1;
+
+   bool bullish = c1 > o1;
+   bool bearish = c1 < o1;
+
+   bool bullEngulf = bullish && c1 >= o2 && o1 <= c2;
+   bool bearEngulf = bearish && c1 <= o2 && o1 >= c2;
+
+   bool bullPin = lowerWick > body * 2.0 && lowerWick > upperWick;
+   bool bearPin = upperWick > body * 2.0 && upperWick > lowerWick;
+
+   bool doji = body <= range * 0.25;
+   bool dojiBull = doji && lowerWick > upperWick * 1.5;
+   bool dojiBear = doji && upperWick > lowerWick * 1.5;
+
+   if(dir == DIR_LONG)
+   {
+      if(bullEngulf)
+      {
+         candleType = 1;
+         return true;
+      }
+      if(bullPin)
+      {
+         candleType = 3;
+         return true;
+      }
+      if(dojiBull)
+      {
+         candleType = 5;
+         return true;
+      }
+   }
+   else if(dir == DIR_SHORT)
+   {
+      if(bearEngulf)
+      {
+         candleType = 2;
+         return true;
+      }
+      if(bearPin)
+      {
+         candleType = 4;
+         return true;
+      }
+      if(dojiBear)
+      {
+         candleType = 6;
+         return true;
+      }
+   }
+
+   return false;
+}
+
+bool MomentumBonus(TradeDir dir, double &rsi1, double &rsi2)
+{
+   rsi1 = RSI(PERIOD_M15, 1);
+   rsi2 = RSI(PERIOD_M15, 2);
+   if(!cfg_InpUseMomentumBonus)
+      return false;
+   if(dir == DIR_LONG)
+      return (rsi1 > rsi2 && rsi1 > 50.0);
+   if(dir == DIR_SHORT)
+      return (rsi1 < rsi2 && rsi1 < 50.0);
+   return false;
+}
+
+bool SpikeGuardOk(double atrM15)
+{
+   if(!cfg_InpUseSpikeGuard)
+      return true;
+
+   double high = iHigh(g_symbol, PERIOD_M15, 1);
+   double low = iLow(g_symbol, PERIOD_M15, 1);
+   return (high - low) <= atrM15 * cfg_InpSpikeMultATR;
+}
+
+bool RSIAfterLossOk(TradeDir dir)
+{
+   if(!cfg_InpUseRSIAfterLoss)
+      return true;
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   if(lossStreak < cfg_InpLossStreakForRSI)
+      return true;
+
+   double rsi1 = RSI(PERIOD_M15, 1);
+   double rsi2 = RSI(PERIOD_M15, 2);
+   if(dir == DIR_LONG)
+      return (rsi1 >= 52.0 && rsi1 > rsi2);
+   if(dir == DIR_SHORT)
+      return (rsi1 <= 48.0 && rsi1 < rsi2);
+   return false;
+}
+
+bool SelectOurPosition()
+{
+   int total = PositionsTotal();
+   for(int i = 0; i < total; i++)
    {
       if(PositionSelectByIndex(i))
       {
-         ulong ticket = PositionGetInteger(POSITION_TICKET);
-         if(!trade.PositionClose(ticket))
-            Print("Errore chiusura posizione: ", ticket);
+         string symbol = PositionGetString(POSITION_SYMBOL);
+         long magic = PositionGetInteger(POSITION_MAGIC);
+         if(symbol == g_symbol && magic == cfg_InpMagic)
+            return true;
+      }
+   }
+   return false;
+}
+
+bool HasPosition()
+{
+   return SelectOurPosition();
+}
+
+bool DailyLossLocked()
+{
+   if(!cfg_InpUseMaxDailyLossLock)
+      return false;
+
+   double startEquity = GVGetDouble("dayEquityStart", AccountInfoDouble(ACCOUNT_EQUITY));
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   double pct = (startEquity > 0.0) ? (equity - startEquity) / startEquity * 100.0 : 0.0;
+   if(pct <= -cfg_InpMaxDailyLossPct)
+   {
+      GVSetInt("dayLocked", 1);
+      return true;
+   }
+   return false;
+}
+
+bool SoftEquityLocked()
+{
+   if(!cfg_InpUseSoftEquityLock)
+      return false;
+
+   double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   if(equity > peak)
+   {
+      peak = equity;
+      GVSetDouble("dayEquityPeak", peak);
+   }
+
+   double start = GVGetDouble("dayEquityStart", equity);
+   double gainPct = (peak - start) / start * 100.0;
+   double curPct = (equity - start) / start * 100.0;
+   if((gainPct >= cfg_InpSoftEqTrigger2 && curPct <= cfg_InpSoftEqFloor2) ||
+      (gainPct >= cfg_InpSoftEqTrigger1 && curPct <= cfg_InpSoftEqFloor1))
+   {
+      GVSetInt("dayLocked", 1);
+      return true;
+   }
+   return false;
+}
+
+int DailyScore(RegimeState regime)
+{
+   double adx = ADX(PERIOD_H1, 1);
+   double vol = (double)iVolume(g_symbol, PERIOD_H1, 1);
+   double volAvg = VolumeMA(PERIOD_H1, cfg_InpVolMAPeriod, 2);
+   double volScore = (volAvg > 0.0) ? MathMin(30.0, (vol / volAvg) * 15.0) : 0.0;
+   double adxScore = MathMin(30.0, adx);
+
+   double spreadScore = 20.0;
+   if(g_spreadEma > 0.0)
+   {
+      double spread = SpreadPoints();
+      spreadScore = 20.0 * MathMax(0.0, 1.0 - (spread / (g_spreadEma * cfg_InpSpreadSpikeFactor)));
+   }
+
+   double regimeScore = 0.0;
+   if(regime == REGIME_TREND)
+      regimeScore = 20.0;
+   else if(regime == REGIME_TRANSITION)
+      regimeScore = 10.0;
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   double lossPenalty = lossStreak * 5.0;
+   double spreadNow = SpreadPoints();
+   if(SpreadMultipleWouldBlock(spreadNow, g_spreadEma) || SpreadInstabilityWouldBlock(spreadNow, g_spreadEma) || RolloverBlocked())
+      lossPenalty += 10.0;
+
+   double score = volScore + adxScore + spreadScore + regimeScore - lossPenalty;
+   if(score < 0.0)
+      score = 0.0;
+   if(score > 100.0)
+      score = 100.0;
+   return (int)score;
+}
+
+bool DailyTradeAllowed(int dailyScore, int &maxTrades, double &riskMult, bool &pyramidOk)
+{
+   maxTrades = 0;
+   riskMult = 0.0;
+   pyramidOk = false;
+   if(dailyScore >= 70)
+   {
+      maxTrades = 3;
+      riskMult = 1.0;
+      pyramidOk = true;
+   }
+   else if(dailyScore >= 50)
+   {
+      maxTrades = 2;
+      riskMult = 0.8;
+      pyramidOk = true;
+   }
+   else if(dailyScore >= 30)
+   {
+      maxTrades = 1;
+      riskMult = 0.6;
+      pyramidOk = false;
+   }
+   return maxTrades > 0;
+}
+
+bool CooldownActive()
+{
+   datetime lastEntryTime = (datetime)GVGetDouble("lastEntryTime", 0.0);
+   if(lastEntryTime == 0)
+      return false;
+   int shift = iBarShift(g_symbol, PERIOD_M15, lastEntryTime, true);
+   if(shift < 0)
+      return false;
+   return shift <= cfg_InpCooldownBarsAfterEntry;
+}
+
+void UpdateDailyReset()
+{
+   datetime now = TimeCurrent();
+   datetime todayStart = (datetime)StringToTime(TimeToString(now, TIME_DATE));
+
+   datetime stored = (datetime)GVGetDouble("dayStart", 0.0);
+   datetime storedStart = (stored == 0) ? 0 : (datetime)StringToTime(TimeToString(stored, TIME_DATE));
+
+   if(stored == 0 || storedStart != todayStart)
+   {
+      GVSetDouble("dayStart", (double)todayStart);
+
+      double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+      GVSetDouble("dayEquityStart", equity);
+      GVSetDouble("dayEquityPeak", equity);
+      GVSetInt("dayLocked", 0);
+      GVSetInt("dayTrades", 0);
+      GVSetInt("tp1done", 0);
+      GVSetInt("addCount", 0);
+   }
+}
+
+void BuildContext(MarketContext &ctx)
+{
+   ctx.bid = SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   ctx.ask = SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   ctx.mid = (ctx.bid + ctx.ask) * 0.5;
+   ctx.spreadPts = (g_point > 0.0) ? ((ctx.ask - ctx.bid) / g_point) : 0.0;
+   ctx.atrM15 = ATR(PERIOD_M15, 1);
+   ctx.atrH1 = ATR(PERIOD_H1, 1);
+   ctx.adxH1 = ADX(PERIOD_H1, 1);
+   ctx.rsi1 = RSI(PERIOD_M15, 1);
+   ctx.rsi2 = RSI(PERIOD_M15, 2);
+   ctx.emaFast = EMA(PERIOD_H1, cfg_InpEMA_Fast, 1);
+   ctx.emaSlow = EMA(PERIOD_H1, cfg_InpEMA_Slow, 1);
+   bool kzA = false, kzL = false, kzN = false;
+   ctx.killzoneActive = KillzoneActive(kzA, kzL, kzN) ? 1 : 0;
+   GetPDLevels(ctx.pdh, ctx.pdl);
+   GetHODLOD_Cached(ctx.hod, ctx.lod);
+   ctx.lossStreak = GVGetInt("lossStreak", 0);
+   ctx.dayTrades = GVGetInt("dayTrades", 0);
+   ctx.spreadEma = g_spreadEma;
+}
+
+bool HardGuardsOk(int &skipMask, const MarketContext &ctx)
+{
+   skipMask = SKIP_NONE;
+   if(!SessionAllowed())
+   {
+      skipMask |= SKIP_SESSION;
+      return false;
+   }
+   if(RolloverBlocked())
+   {
+      skipMask |= SKIP_ROLLOVER;
+      return false;
+   }
+   if(ctx.spreadPts > cfg_InpMaxSpreadPoints)
+   {
+      skipMask |= SKIP_SPREAD;
+      return false;
+   }
+   if(SpreadMultipleBlocked())
+   {
+      skipMask |= SKIP_SPREAD_MULT;
+      return false;
+   }
+   if(SpreadInstabilityBlocked())
+   {
+      skipMask |= SKIP_SPREAD_INSTAB;
+      return false;
+   }
+   if(LowVolumeBlocked())
+   {
+      skipMask |= SKIP_LOWVOL;
+      return false;
+   }
+   if(DailyLossLocked() || SoftEquityLocked())
+   {
+      skipMask |= SKIP_DAILY_LOCK;
+      return false;
+   }
+   if(GVGetInt("dayLocked", 0) == 1)
+   {
+      skipMask |= SKIP_DAILY_LOCK;
+      return false;
+   }
+   if(CooldownActive())
+   {
+      skipMask |= SKIP_COOLDOWN;
+      return false;
+   }
+   return true;
+}
+
+bool HardGuardsOk(int &skipMask)
+{
+   MarketContext ctx;
+   BuildContext(ctx);
+   return HardGuardsOk(skipMask, ctx);
+}
+
+bool LossBlocksActive()
+{
+   if(!cfg_InpUseAntiChop)
+      return false;
+
+   datetime blockUntil = (datetime)GVGetDouble("blockUntil", 0.0);
+   return (blockUntil > TimeCurrent());
+}
+
+void UpdateLossBlock(int lossStreak)
+{
+   if(!cfg_InpUseAntiChop)
+      return;
+
+   if(lossStreak >= 3)
+   {
+      GVSetDouble("blockUntil", TimeCurrent() + cfg_InpLossBlock3_Hours * 3600.0);
+      GVSetDouble("riskCutUntil", TimeCurrent() + cfg_InpRiskCutAfter3Loss_H * 3600.0);
+   }
+   else if(lossStreak == 2)
+   {
+      GVSetDouble("blockUntil", TimeCurrent() + cfg_InpLossBlock2_Hours * 3600.0);
+   }
+}
+
+double CurrentRiskMultiplier(double dailyRiskMult)
+{
+   double mult = dailyRiskMult;
+   datetime riskCutUntil = (datetime)GVGetDouble("riskCutUntil", 0.0);
+   if(riskCutUntil > TimeCurrent())
+      mult *= cfg_InpRiskMultAfter3Loss;
+   return mult;
+}
+
+double TickValue()
+{
+   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE_PROFIT);
+   if(tickValue <= 0.0)
+      tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE_LOSS);
+   if(tickValue <= 0.0)
+      tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   return tickValue;
+}
+
+double TickSize()
+{
+   double tickSize = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_SIZE);
+   if(tickSize <= 0.0)
+      tickSize = g_point;
+   return tickSize;
+}
+
+double CalcLots(double slDist, double riskPct)
+{
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   double riskMoney = equity * (riskPct / 100.0);
+   double tickSize = TickSize();
+   double tickValue = TickValue();
+   if(tickSize <= 0.0 || tickValue <= 0.0 || slDist <= 0.0)
+      return 0.0;
+
+   double moneyPerLot = (slDist / tickSize) * tickValue;
+   if(moneyPerLot <= 0.0)
+      return 0.0;
+
+   double lot = riskMoney / moneyPerLot;
+   double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+   double maxLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MAX);
+   double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+
+   lot = MathMax(minLot, lot);
+   if(cfg_InpMaxLotCap > 0.0)
+      maxLot = MathMin(maxLot, cfg_InpMaxLotCap);
+   lot = MathMin(lot, maxLot);
+   return NormalizeVolumeByStep(lot);
+}
+
+double NormalizeVolumeByStep(double volume)
+{
+   double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+   double maxLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MAX);
+   double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+   double vol = MathMin(maxLot, MathMax(minLot, volume));
+   vol = MathFloor(vol / step) * step;
+   int decimals = 0;
+   double scaled = step;
+   while(decimals < 8 && MathAbs(scaled - MathRound(scaled)) > 1e-8)
+   {
+      scaled *= 10.0;
+      decimals++;
+   }
+   return NormalizeDouble(vol, decimals);
+}
+
+bool StopsOk(TradeDir dir, double entry, double sl, double tp)
+{
+   int stopsLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_STOPS_LEVEL);
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   double minDist = stopsLevel * g_point;
+   double freezeDist = freezeLevel * g_point;
+   double curMid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) * 0.5;
+   if(dir == DIR_LONG)
+   {
+      if(sl > 0.0 && (sl >= entry || MathAbs(entry - sl) < minDist))
+         return false;
+      if(tp > 0.0 && (tp <= entry || MathAbs(tp - entry) < minDist))
+         return false;
+   }
+   else if(dir == DIR_SHORT)
+   {
+      if(sl > 0.0 && (sl <= entry || MathAbs(entry - sl) < minDist))
+         return false;
+      if(tp > 0.0 && (tp >= entry || MathAbs(tp - entry) < minDist))
+         return false;
+   }
+   if(freezeLevel > 0)
+   {
+      if(sl > 0.0 && MathAbs(curMid - sl) < freezeDist)
+         return false;
+      if(tp > 0.0 && MathAbs(curMid - tp) < freezeDist)
+         return false;
+   }
+   return true;
+}
+
+bool CanModifyStops(double newSl)
+{
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   if(freezeLevel <= 0)
+      return true;
+
+   double price = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   return MathAbs(price - newSl) > freezeLevel * g_point;
+}
+
+bool FreezeOkForClose()
+{
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+   if(freezeLevel <= 0)
+      return true;
+   double price = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   return MathAbs(price - entry) > freezeLevel * g_point;
+}
+
+bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+{
+   retcode = 0;
+   lasterr = 0;
+   for(int attempt = 0; attempt <= cfg_InpMaxRetries; attempt++)
+   {
+      bool ok = false;
+      ResetLastError();
+      if(dir == DIR_LONG)
+         ok = trade.Buy(lots, g_symbol, 0.0, sl, tp, comment);
+      else if(dir == DIR_SHORT)
+         ok = trade.Sell(lots, g_symbol, 0.0, sl, tp, comment);
+
+      retcode = (int)trade.ResultRetcode();
+      lasterr = (int)GetLastError();
+
+      if(ok)
+         return true;
+
+      if(retcode == TRADE_RETCODE_PRICE_CHANGED ||
+         retcode == TRADE_RETCODE_REQUOTE ||
+         retcode == TRADE_RETCODE_OFF_QUOTES ||
+         retcode == TRADE_RETCODE_TRADE_CONTEXT_BUSY ||
+         retcode == TRADE_RETCODE_SERVER_BUSY)
+      {
+         Sleep(cfg_InpRetryDelayMs);
+         continue;
+      }
+      break;
+   }
+   return false;
+}
+
+
+string PresetModeLabel(PresetMode mode);
+void LogPresetConfig();
+void LogSymbolCheck();
+
+double IndexKeyStepPoints()
+{
+   string symUpper = g_symbol;
+   StringToUpper(symUpper);
+   if(StringFind(symUpper, "US30") >= 0 || StringFind(symUpper, "DJ30") >= 0 || StringFind(symUpper, "WS30") >= 0)
+      return 100.0;
+   return 50.0;
+}
+
+void ApplyProfileDefaults()
+{
+   if(g_isGoldSymbol)
+   {
+      cfg_KeyLevelStepPoints = PointsFromPrice(cfg_InpKeyLevelStepPrice);
+      cfg_KeyNearPoints = PointsFromPrice(cfg_InpKeyNearPrice);
+      cfg_KeyChaseMaxDistPoints = PointsFromPrice(cfg_InpKeyChaseMaxDistPrice);
+      cfg_EqToleranceMinPoints = cfg_InpEqToleranceMinPoints;
+      cfg_SL_MinBufferPoints = PointsFromPrice(cfg_InpSL_MinBufferPrice);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(cfg_InpMMSL_ExtraBufferPrice);
+      cfg_BE_OffsetPoints = PointsFromPrice(cfg_InpBE_OffsetPrice);
+      cfg_TrailMinImprovePoints = PointsFromPrice(cfg_InpTrailMinImprovePrice);
+      cfg_FibTolPoints = PointsFromPrice(cfg_InpFibTolPrice);
+      cfg_MinPDArrayDistancePoints = PointsFromPrice(cfg_InpMinPDArrayDistance);
+      cfg_MinPDArrayMinPoints = cfg_InpMinPDArrayMinPoints;
+      return;
+   }
+
+   if(g_profile == PROFILE_INDICES)
+   {
+      cfg_KeyLevelStepPoints = IndexKeyStepPoints();
+      cfg_KeyNearPoints = PointsFromPrice(5.0);
+   }
+   else
+   {
+      cfg_KeyLevelStepPoints = PointsFromPips(50.0);
+      cfg_KeyNearPoints = PointsFromPips(5.0);
+   }
+   cfg_KeyChaseMaxDistPoints = cfg_KeyLevelStepPoints * 0.30;
+
+   double slEquiv = cfg_InpSL_MinBufferPrice / 0.10;
+   double beEquiv = cfg_InpBE_OffsetPrice / 0.10;
+   double trailEquiv = cfg_InpTrailMinImprovePrice / 0.10;
+   double fibEquiv = cfg_InpFibTolPrice / 0.10;
+   double pdEquiv = cfg_InpMinPDArrayDistance / 0.10;
+   double mmslExtraEquiv = cfg_InpMMSL_ExtraBufferPrice / 0.10;
+   double eqTolEquiv = cfg_InpEqToleranceMinPoints / 10.0;
+   double pdMinEquiv = cfg_InpMinPDArrayMinPoints / 10.0;
+
+   if(g_profile == PROFILE_INDICES)
+   {
+      cfg_SL_MinBufferPoints = PointsFromPrice(slEquiv);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPrice(mmslExtraEquiv);
+      cfg_BE_OffsetPoints = PointsFromPrice(beEquiv);
+      cfg_TrailMinImprovePoints = PointsFromPrice(trailEquiv);
+      cfg_FibTolPoints = PointsFromPrice(fibEquiv);
+      cfg_EqToleranceMinPoints = MathRound(PointsFromPrice(eqTolEquiv));
+      cfg_MinPDArrayDistancePoints = PointsFromPrice(pdEquiv);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPrice(pdMinEquiv));
+   }
+   else
+   {
+      cfg_SL_MinBufferPoints = PointsFromPips(slEquiv);
+      cfg_MMSL_ExtraBufferPoints = PointsFromPips(mmslExtraEquiv);
+      cfg_BE_OffsetPoints = PointsFromPips(beEquiv);
+      cfg_TrailMinImprovePoints = PointsFromPips(trailEquiv);
+      cfg_FibTolPoints = PointsFromPips(fibEquiv);
+      cfg_EqToleranceMinPoints = MathRound(PointsFromPips(eqTolEquiv));
+      cfg_MinPDArrayDistancePoints = PointsFromPips(pdEquiv);
+      cfg_MinPDArrayMinPoints = (int)MathRound(PointsFromPips(pdMinEquiv));
+   }
+}
+
+void ApplyPreset()
+{
+   cfg_InpPresetMode = InpPresetMode;
+   cfg_InpSymbolOverride = InpSymbolOverride;
+   cfg_InpMagic = InpMagic;
+   cfg_InpPipPrice = InpPipPrice;
+   cfg_InpUseSessionFilter = InpUseSessionFilter;
+   cfg_InpStartHour = InpStartHour;
+   cfg_InpEndHour = InpEndHour;
+   cfg_InpMaxSpreadPoints = InpMaxSpreadPoints;
+   cfg_InpMaxSlippagePoints = InpMaxSlippagePoints;
+   cfg_InpMaxRetries = InpMaxRetries;
+   cfg_InpRetryDelayMs = InpRetryDelayMs;
+   cfg_InpUseICTTime = InpUseICTTime;
+   cfg_InpUseManualNYOffset = InpUseManualNYOffset;
+   cfg_InpNYOffsetHours = InpNYOffsetHours;
+   cfg_InpAutoNYDST = InpAutoNYDST;
+   cfg_InpNYOffsetSummerHours = InpNYOffsetSummerHours;
+   cfg_InpUseKillzoneAsia = InpUseKillzoneAsia;
+   cfg_InpUseKillzoneLondon = InpUseKillzoneLondon;
+   cfg_InpUseKillzoneNY = InpUseKillzoneNY;
+   cfg_InpATRPeriod = InpATRPeriod;
+   cfg_InpADXPeriod = InpADXPeriod;
+   cfg_InpRSIPeriod = InpRSIPeriod;
+   cfg_InpEMA_Fast = InpEMA_Fast;
+   cfg_InpEMA_Slow = InpEMA_Slow;
+   cfg_InpRegimeConfirmBarsH1 = InpRegimeConfirmBarsH1;
+   cfg_InpRegimeLockBarsH1 = InpRegimeLockBarsH1;
+   cfg_InpPivotLen = InpPivotLen;
+   cfg_InpPivotConfirmBars = InpPivotConfirmBars;
+   cfg_InpMaxBarsAfterBOS = InpMaxBarsAfterBOS;
+   cfg_InpEqToleranceATR = InpEqToleranceATR;
+   cfg_InpEqToleranceMinPoints = InpEqToleranceMinPoints;
+   cfg_InpEqClusterMin = InpEqClusterMin;
+   cfg_InpEqScanBars = InpEqScanBars;
+   cfg_InpDisplacementATR = InpDisplacementATR;
+   cfg_InpDisplacementBodyRatio = InpDisplacementBodyRatio;
+   cfg_InpDisplacementSearchBars = InpDisplacementSearchBars;
+   cfg_InpOBLookback = InpOBLookback;
+   cfg_InpOBMaxAgeBars = InpOBMaxAgeBars;
+   cfg_InpOTE_HTF = InpOTE_HTF;
+   cfg_InpOTE_SwingLookback = InpOTE_SwingLookback;
+   cfg_InpOTE_Min = InpOTE_Min;
+   cfg_InpOTE_Max = InpOTE_Max;
+   cfg_InpMinPDArrayDistance = InpMinPDArrayDistance;
+   cfg_InpMinPDArrayATR = InpMinPDArrayATR;
+   cfg_InpMinPDArrayMinPoints = InpMinPDArrayMinPoints;
+   cfg_InpUseBreakRetest = InpUseBreakRetest;
+   cfg_InpRetestTolATR = InpRetestTolATR;
+   cfg_InpKeyLevelStepPrice = InpKeyLevelStepPrice;
+   cfg_InpKeyNearPrice = InpKeyNearPrice;
+   cfg_InpKeyChaseMaxDistPrice = InpKeyChaseMaxDistPrice;
+   cfg_InpUseFVGFeature = InpUseFVGFeature;
+   cfg_InpFVGScanBars = InpFVGScanBars;
+   cfg_InpFVGMaxDistATR = InpFVGMaxDistATR;
+   cfg_InpUseFibFilter = InpUseFibFilter;
+   cfg_InpFibBaseMin = InpFibBaseMin;
+   cfg_InpFibBaseMax = InpFibBaseMax;
+   cfg_InpFibTolPrice = InpFibTolPrice;
+   cfg_InpUseOTEBonus = InpUseOTEBonus;
+   cfg_InpOTEMin = InpOTEMin;
+   cfg_InpOTEMax = InpOTEMax;
+   cfg_InpOTEBonusPoints = InpOTEBonusPoints;
+   cfg_InpUseFootprintProxy = InpUseFootprintProxy;
+   cfg_InpFP_VolMAPeriod = InpFP_VolMAPeriod;
+   cfg_InpFP_VolSpikeRatio = InpFP_VolSpikeRatio;
+   cfg_InpFP_BodyMinRatio = InpFP_BodyMinRatio;
+   cfg_InpFP_CloseSideMin = InpFP_CloseSideMin;
+   cfg_InpFP_AbsorpVolRatio = InpFP_AbsorpVolRatio;
+   cfg_InpFP_AbsorpRangeATR = InpFP_AbsorpRangeATR;
+   cfg_InpFP_RequireAcceptance = InpFP_RequireAcceptance;
+   cfg_InpFP_ScoreBonus = InpFP_ScoreBonus;
+   cfg_InpUseSupplyDemandBonus = InpUseSupplyDemandBonus;
+   cfg_InpSD_TF = InpSD_TF;
+   cfg_InpSD_LookbackBars = InpSD_LookbackBars;
+   cfg_InpSD_MinImpulseATR = InpSD_MinImpulseATR;
+   cfg_InpSD_MaxBaseBars = InpSD_MaxBaseBars;
+   cfg_InpSD_ZonePadATR = InpSD_ZonePadATR;
+   cfg_InpSD_MaxDistATR = InpSD_MaxDistATR;
+   cfg_InpSD_BonusPoints = InpSD_BonusPoints;
+   cfg_InpSD_FreshnessBonus = InpSD_FreshnessBonus;
+   cfg_InpUseCandleBonus = InpUseCandleBonus;
+   cfg_InpCandleBonusPoints = InpCandleBonusPoints;
+   cfg_InpUseMomentumBonus = InpUseMomentumBonus;
+   cfg_InpMomentumBonusPoints = InpMomentumBonusPoints;
+   cfg_InpRequireBiasAlignWithSweep = InpRequireBiasAlignWithSweep;
+   cfg_InpUseSpikeGuard = InpUseSpikeGuard;
+   cfg_InpSpikeMultATR = InpSpikeMultATR;
+   cfg_InpSL_ATR_Mult = InpSL_ATR_Mult;
+   cfg_InpSL_MinBufferPrice = InpSL_MinBufferPrice;
+   cfg_InpUseMMSL = InpUseMMSL;
+   cfg_InpMMSL_Pips = InpMMSL_Pips;
+   cfg_InpMMSL_ExtraBufferPrice = InpMMSL_ExtraBufferPrice;
+   cfg_InpTP_RR_Main = InpTP_RR_Main;
+   cfg_InpMinRRAllowed = InpMinRRAllowed;
+   cfg_InpUseTP1Partial = InpUseTP1Partial;
+   cfg_InpTP1_CloseFrac = InpTP1_CloseFrac;
+   cfg_InpTP1_UseKeyLevelFirst = InpTP1_UseKeyLevelFirst;
+   cfg_InpUseSmartBE = InpUseSmartBE;
+   cfg_InpBE_MinProfitR = InpBE_MinProfitR;
+   cfg_InpBE_OffsetPrice = InpBE_OffsetPrice;
+   cfg_InpUseATRTrailAfterTP1 = InpUseATRTrailAfterTP1;
+   cfg_InpTrailATR_Mult = InpTrailATR_Mult;
+   cfg_InpTrailMinImprovePrice = InpTrailMinImprovePrice;
+   cfg_InpTrailOnNewBarOnly = InpTrailOnNewBarOnly;
+   cfg_InpBaseRiskPct = InpBaseRiskPct;
+   cfg_InpMaxLotCap = InpMaxLotCap;
+   cfg_InpUseLowVolFilter = InpUseLowVolFilter;
+   cfg_InpVolTF = InpVolTF;
+   cfg_InpVolMAPeriod = InpVolMAPeriod;
+   cfg_InpLowVolFactor = InpLowVolFactor;
+   cfg_InpUseSpreadMultiple = InpUseSpreadMultiple;
+   cfg_InpSpreadMultiple = InpSpreadMultiple;
+   cfg_InpSpreadMultipleBlockMin = InpSpreadMultipleBlockMin;
+   cfg_InpUseSpreadInstability = InpUseSpreadInstability;
+   cfg_InpSpreadAvgBarsH1 = InpSpreadAvgBarsH1;
+   cfg_InpSpreadSpikeFactor = InpSpreadSpikeFactor;
+   cfg_InpSpreadSpikeBlockMin = InpSpreadSpikeBlockMin;
+   cfg_InpUseRolloverBlock = InpUseRolloverBlock;
+   cfg_InpRolloverStart = InpRolloverStart;
+   cfg_InpRolloverEnd = InpRolloverEnd;
+   cfg_InpUseDailyTradeControl = InpUseDailyTradeControl;
+   cfg_InpHardMaxTradesPerDay = InpHardMaxTradesPerDay;
+   cfg_InpUseMaxDailyLossLock = InpUseMaxDailyLossLock;
+   cfg_InpMaxDailyLossPct = InpMaxDailyLossPct;
+   cfg_InpUseSoftEquityLock = InpUseSoftEquityLock;
+   cfg_InpSoftEqTrigger1 = InpSoftEqTrigger1;
+   cfg_InpSoftEqFloor1 = InpSoftEqFloor1;
+   cfg_InpSoftEqTrigger2 = InpSoftEqTrigger2;
+   cfg_InpSoftEqFloor2 = InpSoftEqFloor2;
+   cfg_InpCooldownBarsAfterEntry = InpCooldownBarsAfterEntry;
+   cfg_InpUseAntiChop = InpUseAntiChop;
+   cfg_InpLossBlock2_Hours = InpLossBlock2_Hours;
+   cfg_InpLossBlock3_Hours = InpLossBlock3_Hours;
+   cfg_InpRiskMultAfter3Loss = InpRiskMultAfter3Loss;
+   cfg_InpRiskCutAfter3Loss_H = InpRiskCutAfter3Loss_H;
+   cfg_InpUseRSIAfterLoss = InpUseRSIAfterLoss;
+   cfg_InpLossStreakForRSI = InpLossStreakForRSI;
+   cfg_InpUsePyramiding = InpUsePyramiding;
+   cfg_InpMaxAdds = InpMaxAdds;
+   cfg_InpPyramidMinProfitR = InpPyramidMinProfitR;
+   cfg_InpPyramidRequireMainBE = InpPyramidRequireMainBE;
+   cfg_InpPyramidSpacingATR = InpPyramidSpacingATR;
+   cfg_InpPyramidOnlyInTrend = InpPyramidOnlyInTrend;
+   cfg_InpPyramidRequireAdxRising = InpPyramidRequireAdxRising;
+   cfg_InpPyramidUsePeakDDCap = InpPyramidUsePeakDDCap;
+   cfg_InpPyramidMaxPeakDDPct = InpPyramidMaxPeakDDPct;
+   cfg_InpAddRiskMult1 = InpAddRiskMult1;
+   cfg_InpAddRiskMult2 = InpAddRiskMult2;
+   cfg_InpEnableCSV = InpEnableCSV;
+   cfg_InpCSVName = InpCSVName;
+
+   if(cfg_InpPresetMode == PRESET_BALANCED || cfg_InpPresetMode == PRESET_CONSERVATIVE)
+   {
+      cfg_InpUseICTTime = true;
+      cfg_InpUseManualNYOffset = true;
+      cfg_InpNYOffsetHours = -5;
+      cfg_InpUseKillzoneAsia = false;
+      cfg_InpUseKillzoneLondon = true;
+      cfg_InpUseKillzoneNY = true;
+      cfg_InpUseSessionFilter = true;
+      cfg_InpStartHour = 6;
+      cfg_InpEndHour = 23;
+      cfg_InpMaxSpreadPoints = 35;
+      cfg_InpUseSpreadMultiple = true;
+      cfg_InpSpreadMultiple = 2.7;
+      cfg_InpSpreadMultipleBlockMin = 45;
+      cfg_InpUseSpreadInstability = true;
+      cfg_InpSpreadSpikeFactor = 1.6;
+      cfg_InpSpreadSpikeBlockMin = 60;
+      cfg_InpUseRolloverBlock = true;
+      cfg_InpRolloverStart = "23:55";
+      cfg_InpRolloverEnd = "00:15";
+      cfg_InpEqScanBars = 60;
+      cfg_InpEqClusterMin = 2;
+      cfg_InpEqToleranceATR = 0.20;
+      cfg_InpEqToleranceMinPoints = 12;
+      cfg_InpDisplacementATR = 1.25;
+      cfg_InpDisplacementBodyRatio = 0.60;
+      cfg_InpOBLookback = 14;
+      cfg_InpOBMaxAgeBars = 10;
+      cfg_InpOTE_HTF = PERIOD_H1;
+      cfg_InpOTE_SwingLookback = 72;
+      cfg_InpOTE_Min = 0.62;
+      cfg_InpOTE_Max = 0.79;
+      cfg_InpMinPDArrayDistance = 1.20;
+      cfg_InpKeyLevelStepPrice = 5.0;
+      cfg_InpKeyNearPrice = 0.45;
+      cfg_InpKeyChaseMaxDistPrice = 1.20;
+      cfg_InpUseFVGFeature = true;
+      cfg_InpFVGScanBars = 24;
+      cfg_InpFVGMaxDistATR = 1.0;
+      cfg_InpSL_ATR_Mult = 0.30;
+      cfg_InpSL_MinBufferPrice = 0.20;
+      cfg_InpUseMMSL = true;
+      cfg_InpMMSL_Pips = 35;
+      cfg_InpTP_RR_Main = 2.0;
+      cfg_InpMinRRAllowed = 1.6;
+      cfg_InpUseTP1Partial = true;
+      cfg_InpTP1_CloseFrac = 0.50;
+      cfg_InpUseSmartBE = true;
+      cfg_InpBE_MinProfitR = 1.0;
+      cfg_InpBE_OffsetPrice = 0.06;
+      cfg_InpUseATRTrailAfterTP1 = true;
+      cfg_InpTrailATR_Mult = 1.15;
+      cfg_InpTrailMinImprovePrice = 0.12;
+      cfg_InpTrailOnNewBarOnly = true;
+      cfg_InpBaseRiskPct = 1.0;
+      cfg_InpHardMaxTradesPerDay = 2;
+      cfg_InpUseMaxDailyLossLock = true;
+      cfg_InpMaxDailyLossPct = 3.0;
+      cfg_InpUseSoftEquityLock = true;
+      cfg_InpSoftEqTrigger1 = 2.0;
+      cfg_InpSoftEqFloor1 = 0.8;
+      cfg_InpSoftEqTrigger2 = 4.0;
+      cfg_InpSoftEqFloor2 = 2.0;
+      cfg_InpCooldownBarsAfterEntry = 3;
+      cfg_InpUseAntiChop = true;
+      cfg_InpLossBlock2_Hours = 6;
+      cfg_InpLossBlock3_Hours = 18;
+      cfg_InpRiskMultAfter3Loss = 0.60;
+      cfg_InpRiskCutAfter3Loss_H = 24;
+      cfg_InpUsePyramiding = false;
+
+      if(cfg_InpPresetMode == PRESET_CONSERVATIVE)
+      {
+         cfg_InpUseKillzoneAsia = false;
+         cfg_InpUseKillzoneLondon = false;
+         cfg_InpUseKillzoneNY = true;
+         cfg_InpDisplacementATR = 1.35;
+         cfg_InpEqToleranceATR = 0.18;
+         cfg_InpHardMaxTradesPerDay = 1;
+         cfg_InpBaseRiskPct = 0.7;
+      }
+   }
+
+   double pipSize = AutoPipSize(true);
+   if(cfg_InpPresetMode == PRESET_BALANCED || cfg_InpPresetMode == PRESET_CONSERVATIVE)
+   {
+      if(g_profile == PROFILE_INDICES)
+         cfg_InpMaxSpreadPoints = (int)MathRound(PointsFromPrice(2.5));
+      else
+         cfg_InpMaxSpreadPoints = (int)MathRound((2.0 * pipSize) / g_point);
+   }
+
+   g_pip = pipSize;
+
+   ApplyProfileDefaults();
+   LogPresetConfig();
+}
+
+string PresetModeLabel(PresetMode mode)
+{
+   switch(mode)
+   {
+      case PRESET_CUSTOM:
+         return "CUSTOM";
+      case PRESET_BALANCED:
+         return "BALANCED";
+      case PRESET_CONSERVATIVE:
+         return "CONSERVATIVE";
+   }
+   return "UNKNOWN";
+}
+
+void LogPresetConfig()
+{
+   Print("Preset applied: ", PresetModeLabel(cfg_InpPresetMode));
+   PrintFormat("Profile: %s Symbol=%s Point=%.5f Pip=%.5f TickSize=%.5f",
+               ProfileName(g_profile), g_symbol, g_point, g_pip, TickSize());
+   if(cfg_InpUseManualNYOffset)
+   {
+      string dstNote = cfg_InpAutoNYDST ? "auto DST" : "manual DST";
+      Print("NY offset: ", cfg_InpNYOffsetHours, " (", dstNote, ", summer=", cfg_InpNYOffsetSummerHours, ")");
+   }
+
+   PrintFormat("Session: use=%s hours=%02d-%02d ICT=%s KZ(Asia/London/NY)=%s/%s/%s",
+               (cfg_InpUseSessionFilter ? "true" : "false"), cfg_InpStartHour, cfg_InpEndHour,
+               (cfg_InpUseICTTime ? "true" : "false"),
+               (cfg_InpUseKillzoneAsia ? "true" : "false"),
+               (cfg_InpUseKillzoneLondon ? "true" : "false"),
+               (cfg_InpUseKillzoneNY ? "true" : "false"));
+   PrintFormat("Execution: spreadMaxPts=%d spreadMult=%s x%.2f blockMin=%d spreadInstab=%s spikeFactor=%.2f spikeBlockMin=%d slippagePts=%d retries=%d retryDelayMs=%d",
+               cfg_InpMaxSpreadPoints, (cfg_InpUseSpreadMultiple ? "true" : "false"), cfg_InpSpreadMultiple,
+               cfg_InpSpreadMultipleBlockMin, (cfg_InpUseSpreadInstability ? "true" : "false"),
+               cfg_InpSpreadSpikeFactor, cfg_InpSpreadSpikeBlockMin, cfg_InpMaxSlippagePoints,
+               cfg_InpMaxRetries, cfg_InpRetryDelayMs);
+   PrintFormat("Indicators: ATR=%d ADX=%d RSI=%d EMA=%d/%d RegimeConfirmH1=%d RegimeLockH1=%d",
+               cfg_InpATRPeriod, cfg_InpADXPeriod, cfg_InpRSIPeriod, cfg_InpEMA_Fast, cfg_InpEMA_Slow,
+               cfg_InpRegimeConfirmBarsH1, cfg_InpRegimeLockBarsH1);
+   PrintFormat("SMC: PivotLen=%d PivotConfirm=%d MaxBarsAfterBOS=%d EqScanBars=%d EqClusterMin=%d EqTolATR=%.2f EqTolMinPts=%.2f",
+               cfg_InpPivotLen, cfg_InpPivotConfirmBars, cfg_InpMaxBarsAfterBOS,
+               cfg_InpEqScanBars, cfg_InpEqClusterMin, cfg_InpEqToleranceATR, cfg_EqToleranceMinPoints);
+   PrintFormat("SMC: DisplacementATR=%.2f BodyRatio=%.2f SearchBars=%d OBLookback=%d OBMaxAgeBars=%d",
+               cfg_InpDisplacementATR, cfg_InpDisplacementBodyRatio, cfg_InpDisplacementSearchBars,
+               cfg_InpOBLookback, cfg_InpOBMaxAgeBars);
+   PrintFormat("SMC: OTE_HTF=%d SwingLookback=%d OTE_Min=%.2f OTE_Max=%.2f PDArrayDistPts=%.1f PDArrayATR=%.2f PDArrayMinPts=%d",
+               cfg_InpOTE_HTF, cfg_InpOTE_SwingLookback, cfg_InpOTE_Min, cfg_InpOTE_Max,
+               cfg_MinPDArrayDistancePoints, cfg_InpMinPDArrayATR, cfg_MinPDArrayMinPoints);
+   PrintFormat("Filters: BreakRetest=%s RetestTolATR=%.2f KeyStepPts=%.1f KeyNearPts=%.1f KeyChaseMaxPts=%.1f",
+               (cfg_InpUseBreakRetest ? "true" : "false"), cfg_InpRetestTolATR,
+               cfg_KeyLevelStepPoints, cfg_KeyNearPoints, cfg_KeyChaseMaxDistPoints);
+   PrintFormat("FVG/Fib: FVG=%s ScanBars=%d MaxDistATR=%.2f Fib=%s BaseMin=%.2f BaseMax=%.3f FibTolPts=%.1f OTEBonus=%s OTE_Min=%.2f OTE_Max=%.2f BonusPts=%d",
+               (cfg_InpUseFVGFeature ? "true" : "false"), cfg_InpFVGScanBars, cfg_InpFVGMaxDistATR,
+               (cfg_InpUseFibFilter ? "true" : "false"), cfg_InpFibBaseMin, cfg_InpFibBaseMax,
+               cfg_FibTolPoints, (cfg_InpUseOTEBonus ? "true" : "false"),
+               cfg_InpOTEMin, cfg_InpOTEMax, cfg_InpOTEBonusPoints);
+   PrintFormat("Footprint/Spike: FP=%s VolMAPeriod=%d VolSpike=%.2f BodyMin=%.2f CloseSideMin=%.2f AbsorpVol=%.2f AbsorpRangeATR=%.2f RequireAccept=%s ScoreBonus=%d SpikeGuard=%s SpikeATR=%.2f",
+               (cfg_InpUseFootprintProxy ? "true" : "false"), cfg_InpFP_VolMAPeriod, cfg_InpFP_VolSpikeRatio,
+               cfg_InpFP_BodyMinRatio, cfg_InpFP_CloseSideMin, cfg_InpFP_AbsorpVolRatio, cfg_InpFP_AbsorpRangeATR,
+               (cfg_InpFP_RequireAcceptance ? "true" : "false"), cfg_InpFP_ScoreBonus,
+               (cfg_InpUseSpikeGuard ? "true" : "false"), cfg_InpSpikeMultATR);
+   PrintFormat("Stops/Targets: SL_ATR=%.2f SL_MinBufferPts=%.1f MMSL=%s MMSL_Pips=%d MMSL_ExtraPts=%.1f RR=%.2f MinRR=%.2f TP1=%s TP1_Close=%.2f KeyFirst=%s",
+               cfg_InpSL_ATR_Mult, cfg_SL_MinBufferPoints, (cfg_InpUseMMSL ? "true" : "false"),
+               cfg_InpMMSL_Pips, cfg_MMSL_ExtraBufferPoints, cfg_InpTP_RR_Main, cfg_InpMinRRAllowed,
+               (cfg_InpUseTP1Partial ? "true" : "false"), cfg_InpTP1_CloseFrac,
+               (cfg_InpTP1_UseKeyLevelFirst ? "true" : "false"));
+   PrintFormat("BE/Trail: SmartBE=%s MinProfitR=%.2f BE_OffsetPts=%.1f TrailAfterTP1=%s ATR_Mult=%.2f MinImprovePts=%.1f NewBarOnly=%s",
+               (cfg_InpUseSmartBE ? "true" : "false"), cfg_InpBE_MinProfitR, cfg_BE_OffsetPoints,
+               (cfg_InpUseATRTrailAfterTP1 ? "true" : "false"), cfg_InpTrailATR_Mult,
+               cfg_TrailMinImprovePoints, (cfg_InpTrailOnNewBarOnly ? "true" : "false"));
+   PrintFormat("Risk/Daily: BaseRiskPct=%.2f MaxLot=%.2f DailyControl=%s MaxTrades=%d MaxDailyLoss=%s %.2f%% SoftEqLock=%s Triggers=%.2f/%.2f Floors=%.2f/%.2f CooldownBars=%d",
+               cfg_InpBaseRiskPct, cfg_InpMaxLotCap, (cfg_InpUseDailyTradeControl ? "true" : "false"),
+               cfg_InpHardMaxTradesPerDay, (cfg_InpUseMaxDailyLossLock ? "true" : "false"),
+               cfg_InpMaxDailyLossPct, (cfg_InpUseSoftEquityLock ? "true" : "false"),
+               cfg_InpSoftEqTrigger1, cfg_InpSoftEqTrigger2, cfg_InpSoftEqFloor1, cfg_InpSoftEqFloor2,
+               cfg_InpCooldownBarsAfterEntry);
+   PrintFormat("AntiChop/RSI: AntiChop=%s LossBlock2H=%d LossBlock3H=%d RiskMultAfter3=%.2f RiskCutAfter3H=%d RSIAfterLoss=%s LossStreakRSI=%d",
+               (cfg_InpUseAntiChop ? "true" : "false"), cfg_InpLossBlock2_Hours, cfg_InpLossBlock3_Hours,
+               cfg_InpRiskMultAfter3Loss, cfg_InpRiskCutAfter3Loss_H,
+               (cfg_InpUseRSIAfterLoss ? "true" : "false"), cfg_InpLossStreakForRSI);
+   PrintFormat("Pyramiding: Enable=%s MaxAdds=%d MinProfitR=%.2f RequireMainBE=%s SpacingATR=%.2f OnlyTrend=%s RequireAdxRising=%s PeakDDCap=%s MaxPeakDD=%.2f AddRiskMult=%.2f/%.2f",
+               (cfg_InpUsePyramiding ? "true" : "false"), cfg_InpMaxAdds, cfg_InpPyramidMinProfitR,
+               (cfg_InpPyramidRequireMainBE ? "true" : "false"), cfg_InpPyramidSpacingATR,
+               (cfg_InpPyramidOnlyInTrend ? "true" : "false"), (cfg_InpPyramidRequireAdxRising ? "true" : "false"),
+               (cfg_InpPyramidUsePeakDDCap ? "true" : "false"), cfg_InpPyramidMaxPeakDDPct,
+               cfg_InpAddRiskMult1, cfg_InpAddRiskMult2);
+}
+
+void LogSymbolCheck()
+{
+   string symUpper = g_symbol;
+   StringToUpper(symUpper);
+   bool symbolMatch = (StringFind(symUpper, "GOLD") >= 0 || StringFind(symUpper, "XAU") >= 0);
+   bool digitsOk = (g_digits == 2 && MathAbs(g_point - 0.01) <= 0.000001);
+   double tickSize = TickSize();
+   double expectedPip = AutoPipSize(false);
+
+   Print("Symbol check: symbol=", g_symbol, " profile=", ProfileName(g_profile),
+         " digits=", g_digits, " point=", DoubleToString(g_point, 5),
+         " pip=", DoubleToString(g_pip, 5), " tickSize=", DoubleToString(tickSize, 5));
+
+   if(g_isGoldSymbol)
+   {
+      if(!symbolMatch)
+         Print("Warning: Symbol is not GOLD/XAUUSD. Verify XM GOLD settings.");
+      if(!digitsOk)
+         Print("Warning: Unexpected digits/point for GOLD. Expected digits=2 and point=0.01. Verify cfg_InpPipPrice/g_pip.");
+   }
+
+   if(tickSize > 0.0 && MathAbs(tickSize - g_point) > 1e-7)
+      Print("Warning: TickSize differs from Point. Using tickSize for risk math where applicable.");
+   if(cfg_InpPipPrice <= 0.0 && MathAbs(g_pip - expectedPip) > 1e-7)
+      Print("Warning: Auto pip size differs from expected calculation. Check symbol digits/override.");
+}
+
+void LogCSV(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
+            int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
+            int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
+            int killzoneActive, double pdh, double pdl, double psh, double psl, double hod, double lod,
+            int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
+            int oteOk)
+{
+   LogCSVEx(event, dir, entry, sl, tp, tp1, lot, dailyScore, setup, timing, total, skipMask, entryMask,
+            retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+            sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+            0, 0, 0.0, 0, 0, 0, 0, 0.0, 0.0);
+}
+
+void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double tp, double tp1, double lot,
+              int dailyScore, int setup, int timing, int total, int skipMask, int entryMask,
+              int retcode, int lasterr, double bosLevel, int bosAgeBars, double nearestKey,
+              int killzoneActive, double pdh, double pdl, double psh, double psl, double hod, double lod,
+              int sweepDir, double sweepLevel, double displacementScore, double obHigh, double obLow, double obMT,
+              int oteOk, int sdHit, int sdType, double sdDistATR, int sdFresh,
+              int candleHit, int candleType, int momHit, double rsi1, double rsi2)
+{
+   if(!cfg_InpEnableCSV)
+      return;
+
+   int handle = FileOpen(cfg_InpCSVName, FILE_READ | FILE_WRITE | FILE_CSV | FILE_ANSI);
+   if(handle == INVALID_HANDLE)
+      handle = FileOpen(cfg_InpCSVName, FILE_WRITE | FILE_CSV | FILE_ANSI);
+
+   if(handle == INVALID_HANDLE)
+      return;
+
+   if(FileSize(handle) == 0)
+   {
+      FileWrite(handle, "time", "sym", "profile", "point", "pipSize", "tickSize", "magic", "event", "dir", "entry", "sl", "tp", "tp1", "lot", "spreadPts",
+                "reg", "bias", "adx", "atrM15", "atrH1", "dailyScore", "lossStreak", "skipMask", "entryMask",
+                "setup", "timing", "total", "retcode", "lasterr", "spreadEma", "spreadNow",
+                "stopsLevelPts", "freezeLevelPts", "bosLevel", "bosAgeBars", "nearestKey", "tp1Price",
+                "killzoneActive", "pdh", "pdl", "psh", "psl", "hod", "lod",
+                "sweepDir", "sweepLevel", "displacementScore", "obHigh", "obLow", "obMT", "oteOk",
+                "sdHit", "sdType", "sdDistATR", "sdFresh", "candleHit", "candleType",
+                "momHit", "rsi1", "rsi2",
+                "irEntryScore", "irTier", "irRiskBasePct", "irScoreMult", "irRegimeMult", "irFearMult", "irFinalRiskPct",
+                "irRiskMoney", "irStopDistancePoints", "irLots", "irSpreadPoints", "irAtrRatio", "irLossStreak", "irDailyDD",
+                "instPattern", "instPatternScore", "instTotalScore", "instRiskMult");
+   }
+
+   int lossStreak = GVGetInt("lossStreak", 0);
+   RegimeState reg = (RegimeState)GVGetInt("regime", REGIME_RANGE);
+   TradeDir bias = BiasH1();
+   double adx = ADX(PERIOD_H1, 1);
+   double atrM15 = ATR(PERIOD_M15, 1);
+   double atrH1 = ATR(PERIOD_H1, 1);
+
+   double spreadNow = SpreadPoints();
+   int stopsLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_STOPS_LEVEL);
+   int freezeLevel = (int)SymbolInfoInteger(g_symbol, SYMBOL_TRADE_FREEZE_LEVEL);
+
+   FileWrite(handle,
+             TimeToString(TimeCurrent(), TIME_DATE|TIME_MINUTES),
+             g_symbol,
+             ProfileName(g_profile),
+             DoubleToString(g_point, 5),
+             DoubleToString(g_pip, 5),
+             DoubleToString(TickSize(), 5),
+             (string)cfg_InpMagic,
+             event,
+             (int)dir,
+             DoubleToString(NormalizePrice(entry), g_digits),
+             DoubleToString(NormalizePrice(sl), g_digits),
+             DoubleToString(NormalizePrice(tp), g_digits),
+             DoubleToString(NormalizePrice(tp1), g_digits),
+             DoubleToString(lot, 2),
+             DoubleToString(spreadNow, 1),
+             (int)reg,
+             (int)bias,
+             DoubleToString(adx, 2),
+             DoubleToString(atrM15, 2),
+             DoubleToString(atrH1, 2),
+             dailyScore,
+             lossStreak,
+             skipMask,
+             entryMask,
+             setup,
+             timing,
+             total,
+             retcode,
+             lasterr,
+             DoubleToString(g_spreadEma, 2),
+             DoubleToString(spreadNow, 1),
+             stopsLevel,
+             freezeLevel,
+             DoubleToString(bosLevel, g_digits),
+             bosAgeBars,
+             DoubleToString(nearestKey, g_digits),
+             DoubleToString(tp1, g_digits),
+             killzoneActive,
+             DoubleToString(pdh, g_digits),
+             DoubleToString(pdl, g_digits),
+             DoubleToString(psh, g_digits),
+             DoubleToString(psl, g_digits),
+             DoubleToString(hod, g_digits),
+             DoubleToString(lod, g_digits),
+             sweepDir,
+             DoubleToString(sweepLevel, g_digits),
+             DoubleToString(displacementScore, 2),
+             DoubleToString(obHigh, g_digits),
+             DoubleToString(obLow, g_digits),
+             DoubleToString(obMT, g_digits),
+             oteOk,
+             sdHit,
+             sdType,
+             DoubleToString(sdDistATR, 2),
+             sdFresh,
+             candleHit,
+             candleType,
+             momHit,
+             DoubleToString(rsi1, 2),
+             DoubleToString(rsi2, 2),
+             g_irEntryScore,
+             g_irTier,
+             DoubleToString(g_irRiskBasePct, 5),
+             DoubleToString(g_irScoreMult, 3),
+             DoubleToString(g_irRegimeMult, 3),
+             DoubleToString(g_irFearMult, 3),
+             DoubleToString(g_irFinalRiskPct, 5),
+             DoubleToString(g_irRiskMoney, 2),
+             DoubleToString(g_irStopDistancePoints, 1),
+             DoubleToString(g_irLots, 2),
+             DoubleToString(g_irSpreadPoints, 1),
+             DoubleToString(g_irAtrRatio, 2),
+             g_irLossStreak,
+             DoubleToString(g_irDailyDD, 2),
+             GetPatternName(g_instPattern),
+             g_instPatternScore,
+             g_instTotalScore,
+             DoubleToString(g_instRiskMult, 2));
+
+   FileClose(handle);
+}
+
+bool CalculateEntryCore(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                    int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                    double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                    double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                    int &sweepDir, double &sweepLevel, double &displacementScore,
+                    double &obHigh, double &obLow, double &obMT, int &oteOk,
+                    int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                    int &candleHit, int &candleType,
+                    int &momHit, double &rsi1, double &rsi2)
+{
+   setupScore = 0;
+   timingScore = 0;
+   totalScore = 0;
+   skipMask = 0;
+   entryMask = 0;
+   dir = DIR_NONE;
+   nearestKey = 0.0;
+   bosLevel = 0.0;
+   bosAgeBars = -1;
+   killzoneActive = 0;
+   pdh = pdl = psh = psl = hod = lod = 0.0;
+   sweepDir = 0;
+   sweepLevel = 0.0;
+   displacementScore = 0.0;
+   obHigh = obLow = obMT = 0.0;
+   oteOk = 0;
+   sdHit = 0;
+   sdType = 0;
+   sdDistATR = 0.0;
+   sdFresh = 0;
+   candleHit = 0;
+   candleType = 0;
+   momHit = 0;
+   rsi1 = 0.0;
+   rsi2 = 0.0;
+
+   TradeDir bias = BiasH1();
+   if(bias == DIR_NONE)
+      return false;
+   dir = bias;
+   setupScore += 20;
+   entryMask |= ENTRY_BIAS;
+
+   bool kzAsia = false;
+   bool kzLondon = false;
+   bool kzNY = false;
+   if(cfg_InpUseICTTime)
+   {
+      bool kzActive = KillzoneActive(kzAsia, kzLondon, kzNY);
+      killzoneActive = kzActive ? 1 : 0;
+      if(!kzActive)
+      {
+         skipMask |= SKIP_KILLZONE;
+         return false;
+      }
+      entryMask |= ENTRY_KILLZONE;
+      setupScore += 5;
+   }
+
+   GetPDLevels(pdh, pdl);
+   GetPSHPSL(psh, psl);
+   GetHODLOD_Cached(hod, lod);
+
+   TradeDir sweepDirFound = DIR_NONE;
+   double sweepLevelFound = 0.0;
+   if(!DetectLiquiditySweep(sweepDirFound, sweepLevelFound))
+      return false;
+   if(sweepDirFound != dir)
+   {
+      if(cfg_InpRequireBiasAlignWithSweep)
+         return false;
+      dir = sweepDirFound;
+      setupScore -= 5;
+   }
+   sweepDir = (int)sweepDirFound;
+   sweepLevel = sweepLevelFound;
+   entryMask |= ENTRY_SWEEP;
+   setupScore += 10;
+
+   double atrM15 = ATR(PERIOD_M15, 1);
+   if(!DisplacementOk(sweepDirFound, displacementScore))
+      return false;
+   entryMask |= ENTRY_DISPLACEMENT;
+   setupScore += 10;
+
+   double lastHigh = 0.0, prevHigh = 0.0, lastLow = 0.0, prevLow = 0.0;
+   if(!FindRecentPivots(lastHigh, prevHigh, lastLow, prevLow))
+      return false;
+   entryMask |= ENTRY_PIVOT;
+
+   if(dir == DIR_LONG && !(lastLow > prevLow))
+      return false;
+   if(dir == DIR_SHORT && !(lastHigh < prevHigh))
+      return false;
+   setupScore += 10;
+   entryMask |= ENTRY_HL_LH;
+
+   double close1 = iClose(g_symbol, PERIOD_M15, 1);
+   if(dir == DIR_LONG && close1 <= lastHigh)
+      return false;
+   if(dir == DIR_SHORT && close1 >= lastLow)
+      return false;
+   entryMask |= ENTRY_MSS;
+   timingScore += 10;
+
+   bosLevel = (dir == DIR_LONG) ? lastHigh : lastLow;
+   bool closeConfirm = (dir == DIR_LONG) ? (close1 > bosLevel) : (close1 < bosLevel);
+   if(closeConfirm)
+   {
+      entryMask |= ENTRY_BOS_CLOSE;
+      StoreBOS(dir, bosLevel, iTime(g_symbol, PERIOD_M15, 1));
+   }
+
+   bool brOk = BreakRetestOk(dir, atrM15);
+   if(brOk)
+      entryMask |= ENTRY_BOS_RETEST;
+   if(!closeConfirm && !brOk)
+   {
+      bosAgeBars = BOSAgeBars(bosLevel);
+      return false;
+   }
+
+   double mid = (SymbolInfoDouble(g_symbol, SYMBOL_ASK) + SymbolInfoDouble(g_symbol, SYMBOL_BID)) / 2.0;
+   if(!KeyLevelNearOk(mid, nearestKey))
+      return false;
+   entryMask |= ENTRY_KEYLEVEL;
+
+   if(!AntiChaseOk(dir, mid, nearestKey))
+      return false;
+   entryMask |= ENTRY_ANTICHASE;
+   setupScore += 5;
+
+   if(cfg_InpUseFVGFeature)
+   {
+      if(!FVGOk(dir, mid, atrM15))
+         return false;
+      entryMask |= ENTRY_FVG;
+      setupScore += 5;
+   }
+
+   bool oteBonus = false;
+   if(!FibFilterOk(dir, mid, lastLow, lastHigh, oteBonus))
+      return false;
+   entryMask |= ENTRY_FIB;
+   setupScore += 10;
+   if(oteBonus)
+      setupScore += cfg_InpOTEBonusPoints;
+
+   double oteMin = 0.0;
+   double oteMax = 0.0;
+   double swingHigh = 0.0;
+   double swingLow = 0.0;
+   if(!OTEOk(dir, mid, oteMin, oteMax, swingHigh, swingLow))
+      return false;
+   oteOk = 1;
+   entryMask |= ENTRY_OTE;
+   setupScore += 10;
+   if(MathAbs(mid - swingHigh) <= PriceFromPoints(cfg_KeyNearPoints) ||
+      MathAbs(mid - swingLow) <= PriceFromPoints(cfg_KeyNearPoints))
+      entryMask |= ENTRY_SR;
+
+   bool absorption = false;
+   bool acceptance = true;
+   if(!FootprintOk(dir, atrM15, absorption, acceptance))
+      return false;
+   entryMask |= ENTRY_FOOTPRINT;
+   if(acceptance)
+      timingScore += cfg_InpFP_ScoreBonus;
+
+   if(!SpikeGuardOk(atrM15))
+      return false;
+   entryMask |= ENTRY_SPIKE;
+
+   if(!RSIAfterLossOk(dir))
+      return false;
+   entryMask |= ENTRY_RSI_LOSS;
+
+   if(DetectSupplyDemandBonus(dir, sdType, sdDistATR, sdFresh))
+   {
+      sdHit = 1;
+      entryMask |= ENTRY_SD;
+      setupScore += cfg_InpSD_BonusPoints;
+      if(sdFresh == 1)
+         setupScore += cfg_InpSD_FreshnessBonus;
+   }
+
+   if(CandleBonus(dir, candleType))
+   {
+      candleHit = 1;
+      entryMask |= ENTRY_CANDLE;
+      setupScore += cfg_InpCandleBonusPoints;
+   }
+
+   if(MomentumBonus(dir, rsi1, rsi2))
+   {
+      momHit = 1;
+      entryMask |= ENTRY_MOM;
+      timingScore += cfg_InpMomentumBonusPoints;
+   }
+
+   int obAgeBars = -1;
+   if(!FindOrderBlock(dir, obHigh, obLow, obMT, obAgeBars))
+      return false;
+   if(obAgeBars > cfg_InpOBMaxAgeBars)
+      return false;
+   if(!(mid >= obLow && mid <= obHigh))
+      return false;
+   entryMask |= ENTRY_OB_RTO;
+   setupScore += 10;
+
+   entry = (dir == DIR_LONG) ? SymbolInfoDouble(g_symbol, SYMBOL_ASK) : SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   double atrBuf = atrM15 * cfg_InpSL_ATR_Mult;
+   double spreadBuf = SpreadPoints() * g_point * 0.5;
+   double buffer = MathMax(PriceFromPoints(cfg_SL_MinBufferPoints), MathMax(atrBuf, spreadBuf));
+
+   sl = (dir == DIR_LONG) ? (lastLow - buffer) : (lastHigh + buffer);
+   riskR = MathAbs(entry - sl);
+   if(riskR <= 0.0)
+      return false;
+
+   if(cfg_InpUseMMSL)
+   {
+      double mmsl = cfg_InpMMSL_Pips * PipPrice() + PriceFromPoints(cfg_MMSL_ExtraBufferPoints);
+      if(riskR < mmsl)
+         return false;
+      entryMask |= ENTRY_MMSL;
+   }
+
+   tp = (dir == DIR_LONG) ? (entry + riskR * cfg_InpTP_RR_Main) : (entry - riskR * cfg_InpTP_RR_Main);
+   double rr = MathAbs(tp - entry) / riskR;
+   if(rr < cfg_InpMinRRAllowed)
+      return false;
+   entryMask |= ENTRY_RR;
+
+   tp1 = (dir == DIR_LONG) ? (entry + riskR) : (entry - riskR);
+   if(cfg_InpUseTP1Partial && cfg_InpTP1_UseKeyLevelFirst)
+   {
+      if(dir == DIR_LONG)
+      {
+         double key = KeyAbove(entry);
+         if(key < tp1 && (key - entry) > PipPrice())
+            tp1 = key;
+      }
+      else
+      {
+         double key = KeyBelow(entry);
+         if(key > tp1 && (entry - key) > PipPrice())
+            tp1 = key;
+      }
+   }
+
+   double target = (dir == DIR_LONG) ? MathMin(MathMin(pdh, psh > 0.0 ? psh : pdh), hod)
+                                     : MathMax(MathMax(pdl, psl > 0.0 ? psl : pdl), lod);
+   double space = (dir == DIR_LONG) ? (target - entry) : (entry - target);
+   if(space < PriceFromPoints(cfg_MinPDArrayDistancePoints))
+   {
+      skipMask |= SKIP_PDARRAY;
+      return false;
+   }
+   entryMask |= ENTRY_PDARRAY;
+
+   entry = NormalizePrice(entry);
+   sl = NormalizePrice(sl);
+   tp = NormalizePrice(tp);
+   tp1 = NormalizePrice(tp1);
+
+   bosAgeBars = BOSAgeBars(bosLevel);
+   totalScore = setupScore + timingScore;
+   return true;
+}
+
+class IStrategy
+{
+public:
+   virtual bool Evaluate(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                         int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                         double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                         double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                         int &sweepDir, double &sweepLevel, double &displacementScore,
+                         double &obHigh, double &obLow, double &obMT, int &oteOk,
+                         int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                         int &candleHit, int &candleType,
+                         int &momHit, double &rsi1, double &rsi2) = 0;
+};
+
+class TrendSMCStrategy : public IStrategy
+{
+public:
+   virtual bool Evaluate(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                         int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                         double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                         double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                         int &sweepDir, double &sweepLevel, double &displacementScore,
+                         double &obHigh, double &obLow, double &obMT, int &oteOk,
+                         int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                         int &candleHit, int &candleType,
+                         int &momHit, double &rsi1, double &rsi2)
+   {
+      return CalculateEntryCore(dir, entry, sl, tp, tp1, riskR,
+                                setupScore, timingScore, totalScore, skipMask, entryMask,
+                                nearestKey, bosLevel, bosAgeBars, killzoneActive,
+                                pdh, pdl, psh, psl, hod, lod,
+                                sweepDir, sweepLevel, displacementScore,
+                                obHigh, obLow, obMT, oteOk,
+                                sdHit, sdType, sdDistATR, sdFresh,
+                                candleHit, candleType,
+                                momHit, rsi1, rsi2);
+   }
+};
+
+class StrategyManager
+{
+private:
+   TrendSMCStrategy m_trend;
+public:
+   IStrategy* Select()
+   {
+      return &m_trend;
+   }
+};
+
+bool CalculateEntry(TradeDir &dir, double &entry, double &sl, double &tp, double &tp1, double &riskR,
+                    int &setupScore, int &timingScore, int &totalScore, int &skipMask, int &entryMask,
+                    double &nearestKey, double &bosLevel, int &bosAgeBars, int &killzoneActive,
+                    double &pdh, double &pdl, double &psh, double &psl, double &hod, double &lod,
+                    int &sweepDir, double &sweepLevel, double &displacementScore,
+                    double &obHigh, double &obLow, double &obMT, int &oteOk,
+                    int &sdHit, int &sdType, double &sdDistATR, int &sdFresh,
+                    int &candleHit, int &candleType,
+                    int &momHit, double &rsi1, double &rsi2)
+{
+   static StrategyManager manager;
+   IStrategy *strategy = manager.Select();
+   return strategy->Evaluate(dir, entry, sl, tp, tp1, riskR,
+                            setupScore, timingScore, totalScore, skipMask, entryMask,
+                            nearestKey, bosLevel, bosAgeBars, killzoneActive,
+                            pdh, pdl, psh, psl, hod, lod,
+                            sweepDir, sweepLevel, displacementScore,
+                            obHigh, obLow, obMT, oteOk,
+                            sdHit, sdType, sdDistATR, sdFresh,
+                            candleHit, candleType,
+                            momHit, rsi1, rsi2);
+}
+
+bool ShouldEnterTrade(int setupScore, int timingScore, int totalScore, RegimeState regime)
+{
+   int totalMin = TOTAL_MIN;
+   int lossStreak = GVGetInt("lossStreak", 0);
+
+   if(regime == REGIME_TRANSITION)
+      totalMin += 3;
+   else if(regime == REGIME_EXPANSION)
+      totalMin += 8;
+
+   if(lossStreak == 1)
+      totalMin += 5;
+   else if(lossStreak >= 2)
+      totalMin += 10;
+
+   return (setupScore >= SETUP_MIN && timingScore >= TIMING_MIN && totalScore >= totalMin);
+}
+
+void ManagePosition(double riskR)
+{
+   if(!SelectOurPosition())
+      return;
+
+   ulong ticket = PositionGetInteger(POSITION_TICKET);
+   int type = (int)PositionGetInteger(POSITION_TYPE);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   double sl = PositionGetDouble(POSITION_SL);
+   double tp = PositionGetDouble(POSITION_TP);
+   double volume = PositionGetDouble(POSITION_VOLUME);
+   double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+
+   if(riskR <= 0.0)
+      return;
+   double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
+
+   bool tp1done = GVGetInt("tp1done", 0) == 1;
+   double tp1price = GVGetDouble("tp1price", 0.0);
+
+   bool tp1Hit = false;
+   if(type == POSITION_TYPE_BUY)
+      tp1Hit = (tp1price > 0.0 && SymbolInfoDouble(g_symbol, SYMBOL_BID) >= tp1price);
+   else
+      tp1Hit = (tp1price > 0.0 && SymbolInfoDouble(g_symbol, SYMBOL_ASK) <= tp1price);
+
+   if(cfg_InpUseTP1Partial && !tp1done && tp1Hit)
+   {
+      double step = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_STEP);
+      double minLot = SymbolInfoDouble(g_symbol, SYMBOL_VOLUME_MIN);
+      double closeVol = MathFloor((volume * cfg_InpTP1_CloseFrac) / step) * step;
+      closeVol = NormalizeVolumeByStep(closeVol);
+      if(closeVol >= minLot && (volume - closeVol) >= minLot && FreezeOkForClose())
+      {
+         trade.PositionClosePartial(ticket, closeVol);
+         GVSetInt("tp1done", 1);
+         GVSetDouble("tp1price", price);
+         double bosLevel = 0.0;
+         int bosAgeBars = BOSAgeBars(bosLevel);
+         LogCSV("TP1", (type == POSITION_TYPE_BUY ? DIR_LONG : DIR_SHORT), entry, sl, tp, tp1price, volume, 0, 0, 0, 0, 0, 0,
+                0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      }
+   }
+
+   if(cfg_InpUseSmartBE && profitR >= cfg_InpBE_MinProfitR)
+   {
+      double newSL = (type == POSITION_TYPE_BUY) ? (entry + PriceFromPoints(cfg_BE_OffsetPoints))
+                                                 : (entry - PriceFromPoints(cfg_BE_OffsetPoints));
+      TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+      if(CanModifyStops(newSL) && StopsOk(dir, entry, newSL, tp) &&
+         ((type == POSITION_TYPE_BUY && newSL > sl) || (type == POSITION_TYPE_SELL && newSL < sl)))
+         trade.PositionModify(ticket, newSL, tp);
+   }
+
+   if(cfg_InpUseATRTrailAfterTP1 && tp1done)
+   {
+      if(!cfg_InpTrailOnNewBarOnly || IsNewBar(PERIOD_M15, g_lastM15Bar))
+      {
+         double atr = ATR(PERIOD_M15, 1);
+         double newSL = (type == POSITION_TYPE_BUY) ? (price - atr * cfg_InpTrailATR_Mult) : (price + atr * cfg_InpTrailATR_Mult);
+         TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+         if(type == POSITION_TYPE_BUY && newSL > sl + PriceFromPoints(cfg_TrailMinImprovePoints) && CanModifyStops(newSL) &&
+            StopsOk(dir, entry, newSL, tp))
+            trade.PositionModify(ticket, newSL, tp);
+         else if(type == POSITION_TYPE_SELL && newSL < sl - PriceFromPoints(cfg_TrailMinImprovePoints) && CanModifyStops(newSL) &&
+                 StopsOk(dir, entry, newSL, tp))
+            trade.PositionModify(ticket, newSL, tp);
+      }
+   }
+
+}
+
+void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
+{
+   if(!cfg_InpUsePyramiding || !pyramidAllowed)
+      return;
+   if(!SelectOurPosition())
+      return;
+
+   int addCount = GVGetInt("addCount", 0);
+   if(addCount >= cfg_InpMaxAdds)
+      return;
+
+   int type = (int)PositionGetInteger(POSITION_TYPE);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   double sl = PositionGetDouble(POSITION_SL);
+   double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
+
+   if(profitR < cfg_InpPyramidMinProfitR)
+      return;
+
+   double lastAddPrice = GVGetDouble("lastAddPrice", entry);
+   double atr = ATR(PERIOD_M15, 1);
+   if(MathAbs(price - lastAddPrice) < atr * cfg_InpPyramidSpacingATR)
+      return;
+
+   if(cfg_InpPyramidRequireMainBE)
+   {
+      if(type == POSITION_TYPE_BUY && sl < entry + g_point)
+         return;
+      if(type == POSITION_TYPE_SELL && sl > entry - g_point)
+         return;
+   }
+
+   if(cfg_InpPyramidOnlyInTrend && regime != REGIME_TREND)
+      return;
+
+   if(cfg_InpPyramidRequireAdxRising)
+   {
+      double adx1 = ADX(PERIOD_H1, 1);
+      double adx2 = ADX(PERIOD_H1, 2);
+      if(adx1 <= adx2)
+         return;
+   }
+
+   if(cfg_InpPyramidUsePeakDDCap)
+   {
+      double peak = GVGetDouble("dayEquityPeak", AccountInfoDouble(ACCOUNT_EQUITY));
+      double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+      double dd = (peak - equity) / peak * 100.0;
+      if(dd > cfg_InpPyramidMaxPeakDDPct)
+         return;
+   }
+
+   double riskMult = (addCount == 0) ? cfg_InpAddRiskMult1 : cfg_InpAddRiskMult2;
+   double addLots = CalcLots(riskR, cfg_InpBaseRiskPct * riskMult);
+   if(addLots <= 0.0)
+      return;
+
+   double addTp = (type == POSITION_TYPE_BUY) ? (price + riskR * cfg_InpTP_RR_Main) : (price - riskR * cfg_InpTP_RR_Main);
+   TradeDir dir = (type == POSITION_TYPE_BUY) ? DIR_LONG : DIR_SHORT;
+   if(!StopsOk(dir, price, sl, addTp))
+      return;
+
+   bool result = false;
+   int retcode = 0;
+   int lasterr = 0;
+   result = SendOrderWithRetry(dir, addLots, sl, addTp, "PYR", retcode, lasterr);
+
+   if(result)
+   {
+      GVSetInt("addCount", addCount + 1);
+      GVSetDouble("lastAddPrice", price);
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("PYR", dir, price, sl, addTp, 0.0, addLots, 0, 0, 0, 0, 0, 0,
+             retcode, lasterr, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+   }
+}
+
+int OnInit()
+{
+   g_symbol = ResolveSymbol();
+   g_digits = (int)SymbolInfoInteger(g_symbol, SYMBOL_DIGITS);
+   g_point = SymbolInfoDouble(g_symbol, SYMBOL_POINT);
+   g_isGoldSymbol = IsGoldSymbol(g_symbol);
+   g_profile = DetectSymbolProfile(g_symbol);
+
+   ApplyPreset();
+
+   trade.SetExpertMagicNumber((uint)cfg_InpMagic);
+   trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
+
+   double tickSize = TickSize();
+   double tickValue = SymbolInfoDouble(g_symbol, SYMBOL_TRADE_TICK_VALUE);
+   Print("Symbol=", g_symbol, " Digits=", g_digits, " Point=", DoubleToString(g_point, 5),
+         " Pip=", DoubleToString(g_pip, 5), " TickSize=", DoubleToString(tickSize, 5),
+         " TickValue=", DoubleToString(tickValue, 2));
+   LogSymbolCheck();
+
+   UpdateDailyReset();
+
+   if(Enable_RSIEngulfTouch)
+   {
+      ENUM_TIMEFRAMES tfUsed = (SignalTF == PERIOD_CURRENT) ? (ENUM_TIMEFRAMES)_Period : SignalTF;
+      g_rsiEngulfTouchReady = g_rsiEngulfTouch.Init(g_symbol, tfUsed);
+      if(!g_rsiEngulfTouchReady)
+         Print("[RSIEngulfTouch] disabled: init failed.");
+   }
+   else
+   {
+      g_rsiEngulfTouchReady = false;
+   }
+
+   EventSetTimer(60);
+   License_Refresh();
+
+   return INIT_SUCCEEDED;
+}
+
+void OnDeinit(const int reason)
+{
+   EventKillTimer();
+   g_rsiEngulfTouch.Deinit();
+   g_rsiEngulfTouchReady = false;
+   ReleaseIndicatorsCache();
+}
+
+void OnTimer()
+{
+   License_Refresh();
+}
+
+void OnTick()
+{
+   if(g_symbol == "")
+      return;
+
+   License_Refresh();
+
+   if(InpUseSMCZ3C) SMCZ3C_Update();
+
+   if(Enable_RSIEngulfTouch && g_rsiEngulfTouchReady)
+      g_rsiEngulfTouch.OnTick();
+
+   UpdateDailyReset();
+
+   if(IsNewBar(PERIOD_H1, g_lastH1Bar))
+      UpdateSpreadEMA();
+
+   RegimeState regime = UpdateRegime();
+
+   MarketContext ctx;
+   BuildContext(ctx);
+
+   if(HasPosition())
+   {
+      if(!License_CanManageOpenTrades())
+         return;
+
+      double entryPrice = PositionGetDouble(POSITION_PRICE_OPEN);
+      double slPrice = PositionGetDouble(POSITION_SL);
+      double riskR = MathAbs(entryPrice - slPrice);
+      if(riskR <= 0.0)
+         riskR = GVGetDouble("origRisk", 0.0);
+      ManagePosition(riskR);
+      int dailyScore = DailyScore(regime);
+      bool pyramidAllowed = false;
+      int maxTrades = 0;
+      double dailyRiskMult = 0.0;
+      DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed);
+      TryPyramiding(riskR, pyramidAllowed, regime);
+      return;
+   }
+
+   int skipMask = SKIP_NONE;
+   if(LossBlocksActive())
+   {
+      skipMask |= SKIP_LOSS_BLOCK;
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      return;
+   }
+   if(!HardGuardsOk(skipMask, ctx))
+   {
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      return;
+   }
+
+   int dayTrades = ctx.dayTrades;
+   int dailyScore = DailyScore(regime);
+   int maxTrades = 0;
+   double dailyRiskMult = 0.0;
+   bool pyramidAllowed = false;
+   if(cfg_InpUseDailyTradeControl && !DailyTradeAllowed(dailyScore, maxTrades, dailyRiskMult, pyramidAllowed))
+   {
+      skipMask |= SKIP_DAILY_SCORE;
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      return;
+   }
+
+   int allowedTrades = cfg_InpHardMaxTradesPerDay;
+   if(cfg_InpUseDailyTradeControl)
+      allowedTrades = MathMin(allowedTrades, maxTrades);
+   if(dayTrades >= allowedTrades)
+   {
+      skipMask |= SKIP_DAILY_MAX;
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("SKIP", DIR_NONE, 0.0, 0.0, 0.0, 0.0, 0.0, dailyScore, 0, 0, 0, skipMask, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+      return;
+   }
+
+   if(!License_CanOpenNewTrades())
+      return;
+
+   TradeDir dir;
+   double entry = 0.0, sl = 0.0, tp = 0.0, tp1 = 0.0, riskR = 0.0;
+   int setupScore = 0, timingScore = 0, totalScore = 0, entryMask = 0;
+   skipMask = 0;
+   double nearestKey = 0.0;
+   double bosLevel = 0.0;
+   int bosAgeBars = -1;
+   int killzoneActive = 0;
+   double pdh = 0.0, pdl = 0.0, psh = 0.0, psl = 0.0, hod = 0.0, lod = 0.0;
+   int sweepDir = 0;
+   double sweepLevel = 0.0;
+   double displacementScore = 0.0;
+   double obHigh = 0.0, obLow = 0.0, obMT = 0.0;
+   int oteOk = 0;
+   int sdHit = 0;
+   int sdType = 0;
+   double sdDistATR = 0.0;
+   int sdFresh = 0;
+   int candleHit = 0;
+   int candleType = 0;
+   int momHit = 0;
+   double rsi1 = 0.0;
+   double rsi2 = 0.0;
+
+   if(!CalculateEntry(dir, entry, sl, tp, tp1, riskR, setupScore, timingScore, totalScore, skipMask, entryMask,
+                      nearestKey, bosLevel, bosAgeBars, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+                      sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+                      sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2))
+   {
+      LogCSVEx("NOENTRY", DIR_NONE, 0.0, 0.0, 0.0, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+      return;
+   }
+
+   int entryScore = totalScore;
+   if(entryScore < InpEntryThreshold)
+      return;
+
+   int rpScore = 0;
+   string rpReason = "";
+   string rpZoneKey = "";
+   if(!RP_ModelGate(dir, entry, sl, tp, rpScore, rpReason, rpZoneKey))
+   {
+      Print("[RPModel] SKIP dir=", (int)dir, " score=", rpScore, " reason=", rpReason);
+      return;
+   }
+
+   g_instTotalScore = 0;
+   g_instRiskMult = 1.0;
+   g_instPatternScore = 0;
+   g_instPattern = PAT_DOJI;
+   if(UseInstitutionalScore)
+   {
+      ComputeInstitutionalAdapter(candleType, (dir == DIR_LONG), entryMask, killzoneActive,
+                                  g_instTotalScore, g_instRiskMult, g_instPatternScore, g_instPattern);
+      if(g_instTotalScore < InstitutionalMinScore || g_instRiskMult <= 0.0)
+      {
+         if(LogInstitutional)
+            Print("[INST] SKIP score=", g_instTotalScore, " riskMult=", DoubleToString(g_instRiskMult, 2),
+                  " pattern=", GetPatternName(g_instPattern), " pScore=", g_instPatternScore);
+         return;
+      }
+   }
+
+   string irTier = "NA";
+   string irReason = "";
+   double lots = 0.0;
+   if(!IR_ComputeLots(dir, entry, sl, entryScore, lots, irTier, irReason))
+   {
+      Print("[IREngine] SKIP reason=", irReason, " entryScore=", entryScore);
+      return;
+   }
+
+   if(!StopsOk(dir, entry, sl, tp))
+   {
+      skipMask |= SKIP_STOPS;
+      LogCSVEx("SKIP", DIR_NONE, entry, sl, tp, tp1, 0.0, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               0, 0, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+      return;
+   }
+
+   int retcode = 0;
+   int lasterr = 0;
+   bool sent = SendOrderWithRetry(dir, lots, sl, tp, "ENTRY", retcode, lasterr);
+
+   if(sent)
+   {
+      GVSetInt("dayTrades", dayTrades + 1);
+      GVSetDouble("lastEntryTime", (double)iTime(g_symbol, PERIOD_M15, 0));
+      GVSetDouble("origRisk", riskR);
+      GVSetInt("tp1done", 0);
+      GVSetDouble("tp1price", tp1);
+      GVSetInt("addCount", 0);
+      GVSetDouble("lastAddPrice", entry);
+      if(InpUseReactionProbabilityModel)
+         RP_RegisterTrade(rpZoneKey);
+
+      LogCSVEx("ENTRY", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+   }
+   else
+   {
+      LogCSVEx("ENTRY_FAIL", dir, entry, sl, tp, tp1, lots, dailyScore, setupScore, timingScore, totalScore, skipMask, entryMask,
+               retcode, lasterr, bosLevel, bosAgeBars, nearestKey, killzoneActive, pdh, pdl, psh, psl, hod, lod,
+               sweepDir, sweepLevel, displacementScore, obHigh, obLow, obMT, oteOk,
+               sdHit, sdType, sdDistATR, sdFresh, candleHit, candleType, momHit, rsi1, rsi2);
+   }
+}
+
+void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest &request, const MqlTradeResult &result)
+{
+   if(trans.type != TRADE_TRANSACTION_DEAL_ADD)
+      return;
+   if(trans.symbol != g_symbol)
+      return;
+   if(trans.magic != cfg_InpMagic)
+      return;
+
+   double profit = trans.profit + trans.commission + trans.swap;
+   if(trans.entry == DEAL_ENTRY_OUT)
+   {
+      int lossStreak = GVGetInt("lossStreak", 0);
+      if(profit < 0.0)
+         lossStreak++;
+      else
+         lossStreak = 0;
+      GVSetInt("lossStreak", lossStreak);
+      UpdateLossBlock(lossStreak);
+
+      double bosLevel = 0.0;
+      int bosAgeBars = BOSAgeBars(bosLevel);
+      LogCSV("EXIT", DIR_NONE, trans.price, 0.0, 0.0, 0.0, trans.volume,
+             DailyScore((RegimeState)GVGetInt("regime", REGIME_RANGE)), 0, 0, 0, 0, 0,
+             0, 0, bosLevel, bosAgeBars, 0.0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
+   }
+}
+
+
+/// SMC_Zones_3C BEGIN
+struct SMCZone
+{
+   datetime t0;
+   ENUM_TIMEFRAMES tf;
+   bool bullish;
+   double top;
+   double bottom;
+   int touches;
+   bool mitigated;
+   bool active;
+   double score;
+   double created_at_price;
+   double expectedMitigationHours;
+};
+
+SMCZone g_smcz3cZones[];
+ENUM_TIMEFRAMES g_smcz3cTFs[];
+datetime g_smcz3cLastBarTimes[];
+bool g_smcz3cInited = false;
+
+string SMCZ3C_TFToString(ENUM_TIMEFRAMES tf)
+{
+   switch(tf)
+   {
+      case PERIOD_M1: return "PERIOD_M1";
+      case PERIOD_M2: return "PERIOD_M2";
+      case PERIOD_M3: return "PERIOD_M3";
+      case PERIOD_M4: return "PERIOD_M4";
+      case PERIOD_M5: return "PERIOD_M5";
+      case PERIOD_M6: return "PERIOD_M6";
+      case PERIOD_M10: return "PERIOD_M10";
+      case PERIOD_M12: return "PERIOD_M12";
+      case PERIOD_M15: return "PERIOD_M15";
+      case PERIOD_M20: return "PERIOD_M20";
+      case PERIOD_M30: return "PERIOD_M30";
+      case PERIOD_H1: return "PERIOD_H1";
+      case PERIOD_H2: return "PERIOD_H2";
+      case PERIOD_H3: return "PERIOD_H3";
+      case PERIOD_H4: return "PERIOD_H4";
+      case PERIOD_H6: return "PERIOD_H6";
+      case PERIOD_H8: return "PERIOD_H8";
+      case PERIOD_H12: return "PERIOD_H12";
+      case PERIOD_D1: return "PERIOD_D1";
+      case PERIOD_W1: return "PERIOD_W1";
+      case PERIOD_MN1: return "PERIOD_MN1";
+   }
+   return "PERIOD_M15";
+}
+
+ENUM_TIMEFRAMES SMCZ3C_ParseTFToken(string token)
+{
+   StringTrimLeft(token);
+   StringTrimRight(token);
+   StringToUpper(token);
+   if(token == "PERIOD_CURRENT") return (ENUM_TIMEFRAMES)_Period;
+   if(token == "PERIOD_M1") return PERIOD_M1;
+   if(token == "PERIOD_M2") return PERIOD_M2;
+   if(token == "PERIOD_M3") return PERIOD_M3;
+   if(token == "PERIOD_M4") return PERIOD_M4;
+   if(token == "PERIOD_M5") return PERIOD_M5;
+   if(token == "PERIOD_M6") return PERIOD_M6;
+   if(token == "PERIOD_M10") return PERIOD_M10;
+   if(token == "PERIOD_M12") return PERIOD_M12;
+   if(token == "PERIOD_M15") return PERIOD_M15;
+   if(token == "PERIOD_M20") return PERIOD_M20;
+   if(token == "PERIOD_M30") return PERIOD_M30;
+   if(token == "PERIOD_H1") return PERIOD_H1;
+   if(token == "PERIOD_H2") return PERIOD_H2;
+   if(token == "PERIOD_H3") return PERIOD_H3;
+   if(token == "PERIOD_H4") return PERIOD_H4;
+   if(token == "PERIOD_H6") return PERIOD_H6;
+   if(token == "PERIOD_H8") return PERIOD_H8;
+   if(token == "PERIOD_H12") return PERIOD_H12;
+   if(token == "PERIOD_D1") return PERIOD_D1;
+   if(token == "PERIOD_W1") return PERIOD_W1;
+   if(token == "PERIOD_MN1") return PERIOD_MN1;
+   return PERIOD_CURRENT;
+}
+
+void SMCZ3C_ParseTFs()
+{
+   ArrayResize(g_smcz3cTFs, 0);
+   ArrayResize(g_smcz3cLastBarTimes, 0);
+
+   string parts[];
+   int n = StringSplit(InpSMCTFs, ',', parts);
+   for(int i = 0; i < n; i++)
+   {
+      ENUM_TIMEFRAMES tf = SMCZ3C_ParseTFToken(parts[i]);
+      if(tf == PERIOD_CURRENT)
+         tf = (ENUM_TIMEFRAMES)_Period;
+      bool exists = false;
+      for(int j = 0; j < ArraySize(g_smcz3cTFs); j++)
+      {
+         if(g_smcz3cTFs[j] == tf)
+         {
+            exists = true;
+            break;
+         }
+      }
+      if(!exists)
+      {
+         int k = ArraySize(g_smcz3cTFs);
+         ArrayResize(g_smcz3cTFs, k + 1);
+         ArrayResize(g_smcz3cLastBarTimes, k + 1);
+         g_smcz3cTFs[k] = tf;
+         g_smcz3cLastBarTimes[k] = 0;
+      }
+   }
+   if(ArraySize(g_smcz3cTFs) == 0)
+   {
+      ArrayResize(g_smcz3cTFs, 1);
+      ArrayResize(g_smcz3cLastBarTimes, 1);
+      g_smcz3cTFs[0] = PERIOD_M15;
+      g_smcz3cLastBarTimes[0] = 0;
+   }
+   g_smcz3cInited = true;
+}
+
+double SMCZ3C_BodyHigh(double o, double c) { return MathMax(o, c); }
+double SMCZ3C_BodyLow(double o, double c) { return MathMin(o, c); }
+
+double SMCZ3C_ComputeScore(bool bos, double dispBody, double atr, double bodyC2, int touches, bool mitigated)
+{
+   double score = 0.0;
+   if(bos)
+      score += 30.0;
+   if(atr > 0.0 && dispBody >= 1.0 * atr)
+      score += 20.0;
+   if(atr > 0.0 && bodyC2 <= 0.5 * atr)
+      score += 10.0;
+   score -= (10.0 * touches);
+   if(mitigated)
+      score -= 20.0;
+   if(score < 0.0) score = 0.0;
+   if(score > 100.0) score = 100.0;
+   return score;
+}
+
+bool SMCZ3C_IsPivotHigh(ENUM_TIMEFRAMES tf, int shift, int lr)
+{
+   int bars = iBars(g_symbol, tf);
+   if(shift - lr < 1 || shift + lr >= bars)
+      return false;
+   double h = iHigh(g_symbol, tf, shift);
+   for(int j = 1; j <= lr; j++)
+   {
+      if(h <= iHigh(g_symbol, tf, shift - j) || h <= iHigh(g_symbol, tf, shift + j))
+         return false;
+   }
+   return true;
+}
+
+bool SMCZ3C_IsPivotLow(ENUM_TIMEFRAMES tf, int shift, int lr)
+{
+   int bars = iBars(g_symbol, tf);
+   if(shift - lr < 1 || shift + lr >= bars)
+      return false;
+   double l = iLow(g_symbol, tf, shift);
+   for(int j = 1; j <= lr; j++)
+   {
+      if(l >= iLow(g_symbol, tf, shift - j) || l >= iLow(g_symbol, tf, shift + j))
+         return false;
+   }
+   return true;
+}
+
+bool FindSwingHigh(int startShift, int lookback, int leftRight, ENUM_TIMEFRAMES tf, double &outHigh)
+{
+   int bars = iBars(g_symbol, tf);
+   int endShift = MathMin(startShift + lookback, bars - leftRight - 1);
+   for(int s = startShift; s <= endShift; s++)
+   {
+      if(SMCZ3C_IsPivotHigh(tf, s, leftRight))
+      {
+         outHigh = iHigh(g_symbol, tf, s);
+         return true;
+      }
+   }
+   return false;
+}
+
+bool FindSwingLow(int startShift, int lookback, int leftRight, ENUM_TIMEFRAMES tf, double &outLow)
+{
+   int bars = iBars(g_symbol, tf);
+   int endShift = MathMin(startShift + lookback, bars - leftRight - 1);
+   for(int s = startShift; s <= endShift; s++)
+   {
+      if(SMCZ3C_IsPivotLow(tf, s, leftRight))
+      {
+         outLow = iLow(g_symbol, tf, s);
+         return true;
+      }
+   }
+   return false;
+}
+
+double SMCZ3C_DistanceToNearestEdge(const SMCZone &z, double px)
+{
+   if(px > z.top)
+      return px - z.top;
+   if(px < z.bottom)
+      return z.bottom - px;
+   double d1 = z.top - px;
+   double d2 = px - z.bottom;
+   return MathMin(d1, d2);
+}
+
+void SMCZ3C_UpdateExpectedHours(SMCZone &z)
+{
+   double atr = ATR(z.tf, 1);
+   double tfHours = (double)PeriodSeconds(z.tf) / 3600.0;
+   if(atr <= 0.0 || tfHours <= 0.0)
+   {
+      z.expectedMitigationHours = 0.0;
+      return;
+   }
+   double atrPerHour = atr / tfHours;
+   if(atrPerHour <= 0.0)
+   {
+      z.expectedMitigationHours = 0.0;
+      return;
+   }
+   double px = SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   double dist = SMCZ3C_DistanceToNearestEdge(z, px);
+   z.expectedMitigationHours = (dist / atrPerHour) * InpTimeFactor;
+}
+
+int SMCZ3C_FindExisting(datetime t0, ENUM_TIMEFRAMES tf, bool bullish)
+{
+   for(int i = 0; i < ArraySize(g_smcz3cZones); i++)
+   {
+      if(g_smcz3cZones[i].t0 == t0 && g_smcz3cZones[i].tf == tf && g_smcz3cZones[i].bullish == bullish)
+         return i;
+   }
+   return -1;
+}
+
+void SMCZ3C_AddOrMergeZone(const SMCZone &zone)
+{
+   if(zone.score < InpMinScoreToKeep)
+      return;
+
+   double tol = InpMergeTolPoints * _Point;
+   for(int i = 0; i < ArraySize(g_smcz3cZones); i++)
+   {
+      SMCZone &z = g_smcz3cZones[i];
+      if(z.bullish != zone.bullish)
+         continue;
+      if(MathAbs(z.top - zone.top) < tol && MathAbs(z.bottom - zone.bottom) < tol)
+      {
+         bool replace = (zone.score > z.score) || (zone.t0 > z.t0);
+         if(replace)
+         {
+            int touches = z.touches;
+            bool mitigated = z.mitigated;
+            bool active = z.active;
+            z = zone;
+            z.touches = MathMax(touches, zone.touches);
+            z.mitigated = mitigated || zone.mitigated;
+            z.active = active && zone.active;
+         }
+         return;
+      }
+   }
+
+   int n = ArraySize(g_smcz3cZones);
+   ArrayResize(g_smcz3cZones, n + 1);
+   g_smcz3cZones[n] = zone;
+}
+
+void SMCZ3C_ScanTF(ENUM_TIMEFRAMES tf)
+{
+   int bars = iBars(g_symbol, tf);
+   if(bars < 20)
+      return;
+
+   int maxI = MathMin(InpScanBars, bars - 3);
+   double eps = InpBodyEngulfEpsPoints * _Point;
+
+   for(int i = 1; i <= maxI; i++)
+   {
+      int c3 = i;
+      int c2 = i + 1;
+      int c1 = i + 2;
+
+      double o1 = iOpen(g_symbol, tf, c1), c1c = iClose(g_symbol, tf, c1);
+      double o2 = iOpen(g_symbol, tf, c2), c2c = iClose(g_symbol, tf, c2);
+      double o3 = iOpen(g_symbol, tf, c3), c3c = iClose(g_symbol, tf, c3);
+      if(o1 == 0.0 || o2 == 0.0 || o3 == 0.0)
+         continue;
+
+      double b1h = SMCZ3C_BodyHigh(o1, c1c), b1l = SMCZ3C_BodyLow(o1, c1c);
+      double b2h = SMCZ3C_BodyHigh(o2, c2c), b2l = SMCZ3C_BodyLow(o2, c2c);
+      double b3h = SMCZ3C_BodyHigh(o3, c3c), b3l = SMCZ3C_BodyLow(o3, c3c);
+
+      bool engulf12 = (b1l <= b2l + eps && b1h >= b2h - eps);
+      bool engulf32 = (b3l <= b2l + eps && b3h >= b2h - eps);
+      if(!engulf12 || !engulf32)
+         continue;
+
+      double atr = ATR(tf, c3);
+      double dispBody = MathAbs(c3c - o3);
+      if(atr <= 0.0 || dispBody < InpDispATRMult * atr)
+         continue;
+
+      bool c3Bull = (c3c > o3);
+      bool c3Bear = (c3c < o3);
+      if(!c3Bull && !c3Bear)
+         continue;
+
+      bool bos = false;
+      double swingHigh = 0.0, swingLow = 0.0;
+      if(c3Bull)
+      {
+         if(FindSwingHigh(c3 + 1, InpSwingLookbackBars, InpPivotLR, tf, swingHigh))
+            bos = (c3c > swingHigh);
+      }
+      else
+      {
+         if(FindSwingLow(c3 + 1, InpSwingLookbackBars, InpPivotLR, tf, swingLow))
+            bos = (c3c < swingLow);
+      }
+      if(!bos)
+         continue;
+
+      SMCZone z;
+      z.t0 = iTime(g_symbol, tf, c3);
+      z.tf = tf;
+      z.bullish = c3Bull;
+      z.touches = 0;
+      z.mitigated = false;
+      z.active = true;
+      z.created_at_price = c3c;
+
+      if(c3Bull)
+      {
+         z.bottom = MathMin(iLow(g_symbol, tf, c2), iLow(g_symbol, tf, c1));
+         bool c2Bear = (c2c < o2);
+         bool c1Bear = (c1c < o1);
+         if(c2Bear)
+            z.top = SMCZ3C_BodyHigh(o2, c2c);
+         else if(c1Bear)
+            z.top = SMCZ3C_BodyHigh(o1, c1c);
+         else
+            z.top = iHigh(g_symbol, tf, c2);
+      }
+      else
+      {
+         bool c2Bull = (c2c > o2);
+         bool c1Bull = (c1c > o1);
+         if(c2Bull)
+            z.bottom = SMCZ3C_BodyLow(o2, c2c);
+         else if(c1Bull)
+            z.bottom = SMCZ3C_BodyLow(o1, c1c);
+         else
+            z.bottom = iLow(g_symbol, tf, c2);
+         z.top = MathMax(iHigh(g_symbol, tf, c2), iHigh(g_symbol, tf, c1));
+      }
+
+      if(z.top < z.bottom)
+      {
+         double tmp = z.top;
+         z.top = z.bottom;
+         z.bottom = tmp;
+      }
+
+      z.score = SMCZ3C_ComputeScore(bos, dispBody, atr, MathAbs(c2c - o2), z.touches, z.mitigated);
+      SMCZ3C_UpdateExpectedHours(z);
+
+      if(SMCZ3C_FindExisting(z.t0, z.tf, z.bullish) < 0)
+         SMCZ3C_AddOrMergeZone(z);
+   }
+}
+
+bool SMCZ3C_BoxOverlap(double low, double high, double bottom, double top)
+{
+   return (high >= bottom && low <= top);
+}
+
+void SMCZ3C_UpdateTouchesAndState(SMCZone &z)
+{
+   if(!z.active)
+      return;
+
+   double high1 = iHigh(g_symbol, z.tf, 1);
+   double low1 = iLow(g_symbol, z.tf, 1);
+   double high2 = iHigh(g_symbol, z.tf, 2);
+   double low2 = iLow(g_symbol, z.tf, 2);
+   double close1 = iClose(g_symbol, z.tf, 1);
+
+   bool in1 = SMCZ3C_BoxOverlap(low1, high1, z.bottom, z.top);
+   bool in2 = SMCZ3C_BoxOverlap(low2, high2, z.bottom, z.top);
+
+   if(in1 && !in2)
+      z.touches++;
+
+   double h = z.top - z.bottom;
+   if(h > 0.0)
+   {
+      double overlap = MathMax(0.0, MathMin(high1, z.top) - MathMax(low1, z.bottom));
+      double overlapPct = (overlap / h) * 100.0;
+      if(overlapPct >= InpMitigatePct)
+         z.mitigated = true;
+   }
+
+   double invBuf = InpInvalidationBufferPoints * _Point;
+   if(z.bullish && close1 < (z.bottom - invBuf))
+      z.active = false;
+   if(!z.bullish && close1 > (z.top + invBuf))
+      z.active = false;
+   if(z.touches >= InpMaxTouches)
+      z.active = false;
+
+   z.score = SMCZ3C_ComputeScore(true, ATR(z.tf, 1), ATR(z.tf, 1), 0.0, z.touches, z.mitigated);
+   SMCZ3C_UpdateExpectedHours(z);
+}
+
+void SMCZ3C_DrawZone(const SMCZone &z)
+{
+   string name = "SMCZ3C_" + SMCZ3C_TFToString(z.tf) + "_" + (z.bullish ? "bull_" : "bear_") + (string)z.t0;
+   color clr = z.bullish ? clrLime : clrRed;
+   datetime t1 = z.t0;
+   datetime t2 = TimeCurrent() + PeriodSeconds(z.tf) * 20;
+
+   if(ObjectFind(0, name) < 0)
+      ObjectCreate(0, name, OBJ_RECTANGLE, 0, t1, z.top, t2, z.bottom);
+
+   ObjectSetInteger(0, name, OBJPROP_TIME, 0, t1);
+   ObjectSetDouble(0, name, OBJPROP_PRICE, 0, z.top);
+   ObjectSetInteger(0, name, OBJPROP_TIME, 1, t2);
+   ObjectSetDouble(0, name, OBJPROP_PRICE, 1, z.bottom);
+   ObjectSetInteger(0, name, OBJPROP_COLOR, clr);
+   ObjectSetInteger(0, name, OBJPROP_FILL, true);
+   ObjectSetInteger(0, name, OBJPROP_STYLE, STYLE_SOLID);
+   ObjectSetInteger(0, name, OBJPROP_BACK, false);
+   ObjectSetInteger(0, name, OBJPROP_WIDTH, 1);
+
+   string txt = name + "_TXT";
+   if(ObjectFind(0, txt) < 0)
+      ObjectCreate(0, txt, OBJ_TEXT, 0, t2, z.top);
+   string cap = SMCZ3C_TFToString(z.tf) + " score=" + DoubleToString(z.score, 1) +
+                " t=" + (string)z.touches + " eh=" + DoubleToString(z.expectedMitigationHours, 1);
+   ObjectSetString(0, txt, OBJPROP_TEXT, cap);
+   ObjectSetInteger(0, txt, OBJPROP_COLOR, clr);
+   ObjectSetInteger(0, txt, OBJPROP_ANCHOR, ANCHOR_LEFT_UPPER);
+   ObjectMove(0, txt, 0, t2, z.top);
+}
+
+void SMCZ3C_Update()
+{
+   if(!g_smcz3cInited)
+      SMCZ3C_ParseTFs();
+
+   for(int i = 0; i < ArraySize(g_smcz3cTFs); i++)
+   {
+      ENUM_TIMEFRAMES tf = g_smcz3cTFs[i];
+      datetime barT = iTime(g_symbol, tf, 0);
+      if(barT <= 0)
+         continue;
+
+      if(g_smcz3cLastBarTimes[i] != barT)
+      {
+         g_smcz3cLastBarTimes[i] = barT;
+         SMCZ3C_ScanTF(tf);
+      }
+   }
+
+   for(int z = 0; z < ArraySize(g_smcz3cZones); z++)
+   {
+      SMCZ3C_UpdateTouchesAndState(g_smcz3cZones[z]);
+      if(g_smcz3cZones[z].active && InpDrawZones && g_smcz3cZones[z].score >= InpMinScoreToKeep)
+         SMCZ3C_DrawZone(g_smcz3cZones[z]);
+   }
+}
+
+bool SMCZ3C_GetBestZone(bool wantBullish, double &outTop, double &outBottom, ENUM_TIMEFRAMES &outTf, double &outScore, double &outExpHours)
+{
+   int best = -1;
+   double bestScore = -DBL_MAX;
+   for(int i = 0; i < ArraySize(g_smcz3cZones); i++)
+   {
+      SMCZone &z = g_smcz3cZones[i];
+      if(!z.active || z.mitigated || z.touches != 0)
+         continue;
+      if(z.bullish != wantBullish)
+         continue;
+      if(z.score < InpMinScoreToKeep)
+         continue;
+      if(z.score > bestScore)
+      {
+         bestScore = z.score;
+         best = i;
+      }
+   }
+   if(best < 0)
+      return false;
+
+   outTop = g_smcz3cZones[best].top;
+   outBottom = g_smcz3cZones[best].bottom;
+   outTf = g_smcz3cZones[best].tf;
+   outScore = g_smcz3cZones[best].score;
+   outExpHours = g_smcz3cZones[best].expectedMitigationHours;
+   return true;
+}
+
+int SMCZ3C_GetZonesCount()
+{
+   return ArraySize(g_smcz3cZones);
+}
+
+bool SMCZ3C_GetZoneByIndex(int idx, SMCZone &outZone)
+{
+   if(idx < 0 || idx >= ArraySize(g_smcz3cZones))
+      return false;
+   outZone = g_smcz3cZones[idx];
+   return true;
+}
+/// SMC_Zones_3C END
+
+
+/// REACTION_PROBABILITY BEGIN
+enum RPMarketBias
+{
+   RP_BIAS_NEUTRAL = 0,
+   RP_BIAS_LONG = 1,
+   RP_BIAS_SHORT = -1
+};
+
+enum ZoneType
+{
+   ZONE_SUPPORT = 0,
+   ZONE_RESISTANCE = 1,
+   ZONE_ORDERBLOCK = 2,
+   ZONE_SUPPLYDEMAND = 3,
+   ZONE_TRENDLINE = 4
+};
+
+enum ZoneLifeState
+{
+   ZONE_FRESH = 0,
+   ZONE_SEMI = 1,
+   ZONE_OLD = 2
+};
+
+struct Zone
+{
+   int type;
+   double upper;
+   double lower;
+   datetime createdTime;
+   int touchCount;
+   datetime lastTouchTime;
+   bool mitigated;
+   bool broken;
+   int ageBars;
+   int state;
+   ENUM_TIMEFRAMES tf;
+   bool bullish;
+   double score;
+   string key;
+};
+
+Zone g_rpZones[];
+string g_rpTradedZones[];
+int g_rpTradesToday = 0;
+int g_rpDayId = 0;
+datetime g_rpLastTradeTs = 0;
+datetime g_rpLastM15Bar = 0;
+
+void RP_RegisterTrade(const string zoneKey)
+{
+   int dayId = NYDayId(TimeCurrent());
+   if(g_rpDayId != dayId)
+   {
+      g_rpDayId = dayId;
+      g_rpTradesToday = 0;
+      ArrayResize(g_rpTradedZones, 0);
+   }
+   g_rpTradesToday++;
+   g_rpLastTradeTs = TimeCurrent();
+   if(InpOneTradePerZone && StringLen(zoneKey) > 0)
+   {
+      int n = ArraySize(g_rpTradedZones);
+      ArrayResize(g_rpTradedZones, n + 1);
+      g_rpTradedZones[n] = zoneKey;
+   }
+}
+
+bool RP_ZoneAlreadyTraded(const string zoneKey)
+{
+   if(!InpOneTradePerZone || StringLen(zoneKey) == 0)
+      return false;
+   for(int i = 0; i < ArraySize(g_rpTradedZones); i++)
+      if(g_rpTradedZones[i] == zoneKey)
+         return true;
+   return false;
+}
+
+RPMarketBias RP_GetHTFBias()
+{
+   double cH4 = iClose(g_symbol, PERIOD_H4, 1);
+   double cD1 = iClose(g_symbol, PERIOD_D1, 1);
+   double eH4 = EMA(PERIOD_H4, 50, 1);
+   double eD1 = EMA(PERIOD_D1, 50, 1);
+   if(cH4 > eH4 && cD1 > eD1)
+      return RP_BIAS_LONG;
+   if(cH4 < eH4 && cD1 < eD1)
+      return RP_BIAS_SHORT;
+   return RP_BIAS_NEUTRAL;
+}
+
+void RP_AddZone(const Zone &z)
+{
+   int n = ArraySize(g_rpZones);
+   ArrayResize(g_rpZones, n + 1);
+   g_rpZones[n] = z;
+}
+
+void RP_BuildZonesFromSMC()
+{
+   ArrayResize(g_rpZones, 0);
+   int n = SMCZ3C_GetZonesCount();
+   for(int i = 0; i < n; i++)
+   {
+      SMCZone sz;
+      if(!SMCZ3C_GetZoneByIndex(i, sz))
+         continue;
+      Zone z;
+      z.type = sz.bullish ? ZONE_SUPPLYDEMAND : ZONE_ORDERBLOCK;
+      z.upper = sz.top;
+      z.lower = sz.bottom;
+      z.createdTime = sz.t0;
+      z.touchCount = sz.touches;
+      z.lastTouchTime = 0;
+      z.mitigated = sz.mitigated;
+      z.broken = !sz.active;
+      z.tf = sz.tf;
+      z.ageBars = (int)(iBarShift(g_symbol, sz.tf, sz.t0, false));
+      z.state = (z.touchCount == 0 ? ZONE_FRESH : (z.touchCount == 1 ? ZONE_SEMI : ZONE_OLD));
+      if(z.ageBars > InpZoneOldAgeBars)
+         z.state = ZONE_OLD;
+      z.bullish = sz.bullish;
+      z.score = sz.score;
+      z.key = "RPZ_" + (string)sz.tf + "_" + (sz.bullish ? "B_" : "S_") + (string)sz.t0;
+      RP_AddZone(z);
+   }
+
+   ENUM_TIMEFRAMES tfs[2] = {PERIOD_H1, PERIOD_M15};
+   for(int t=0;t<2;t++)
+   {
+      ENUM_TIMEFRAMES tf=tfs[t];
+      int hiIdx=iHighest(g_symbol, tf, MODE_HIGH, 80, 1);
+      int loIdx=iLowest(g_symbol, tf, MODE_LOW, 80, 1);
+      if(hiIdx>0)
+      {
+         Zone r; r.type=ZONE_RESISTANCE; r.upper=iHigh(g_symbol,tf,hiIdx)+5*g_point; r.lower=iHigh(g_symbol,tf,hiIdx)-5*g_point;
+         r.createdTime=iTime(g_symbol,tf,hiIdx); r.touchCount=0; r.lastTouchTime=0; r.mitigated=false; r.broken=false; r.ageBars=hiIdx;
+         r.state=(hiIdx>InpZoneOldAgeBars?ZONE_OLD:ZONE_FRESH); r.tf=tf; r.bullish=false; r.score=60.0; r.key="RPZ_SR_H_"+(string)tf+"_"+(string)r.createdTime; RP_AddZone(r);
+      }
+      if(loIdx>0)
+      {
+         Zone s; s.type=ZONE_SUPPORT; s.upper=iLow(g_symbol,tf,loIdx)+5*g_point; s.lower=iLow(g_symbol,tf,loIdx)-5*g_point;
+         s.createdTime=iTime(g_symbol,tf,loIdx); s.touchCount=0; s.lastTouchTime=0; s.mitigated=false; s.broken=false; s.ageBars=loIdx;
+         s.state=(loIdx>InpZoneOldAgeBars?ZONE_OLD:ZONE_FRESH); s.tf=tf; s.bullish=true; s.score=60.0; s.key="RPZ_SR_L_"+(string)tf+"_"+(string)s.createdTime; RP_AddZone(s);
       }
    }
 }
 
-void OnTick() {
-    if(!IsEAEnabled())
-        return;
-
-    CheckTelegramCommands();
-
-    if(!NewsFilter() || DailyDrawdownExceeded())
-        return;
-
-    if(!(Period()==PERIOD_M5 || Period()==PERIOD_M15))
-        return;
-
-    if(PositionsTotal() >= MaxTrades)
-        return;
-
-    if(!TimeFilter() || SpreadTooHigh() || !ATRCheck() || !TrendConfirmed() || (TimeCurrent() - lastTradeTime < 180))
-        return;
-
-    int confirmations = CheckConfirmations();
-    double score = CalculateConfidenceScore();
-    if(score < 50 || confirmations < 3)
-        return;
-
-    double stoploss = (stopLossPips * _Point) + ATRMultiplier * iATR(_Symbol, PERIOD_M5, 14, 0);
-    double rr = 2.0;
-    if(score >= 90)
-        rr = 4.0;
-    else if(score >= 70)
-        rr = 3.0;
-    double takeprofit = (takeProfitPips > 0) ? takeProfitPips * _Point : stoploss * rr;
-    double risk = riskPercent;
-    if(score >= 90)
-        risk = MathMin(riskPercent*1.5, Risk_High);
-    double lot = CalculateRiskLot(stoploss, risk);
-    int direction = EntryDirection();
-
-    double sl, tp;
-    if(direction == 1)
-    {
-        double ask = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
-        sl = ask - stoploss;
-        tp = ask + takeprofit;
-        trade.Buy(lot, _Symbol, ask, sl, tp, "Buy");
-    }
-    else if(direction == -1)
-    {
-        double bid = SymbolInfoDouble(_Symbol, SYMBOL_BID);
-        sl = bid + stoploss;
-        tp = bid - takeprofit;
-        trade.Sell(lot, _Symbol, bid, sl, tp, "Sell");
-    }
-
-    ManageRunnerTrade();
-
-    lastTradeTime = TimeCurrent();
-}
-
-bool TimeFilter() {
-    int hour = TimeHour(TimeCurrent());
-    return (hour >= 8 && hour <= 22);
-}
-
-bool SpreadTooHigh() {
-    double spread = (SymbolInfoDouble(_Symbol, SYMBOL_ASK) - SymbolInfoDouble(_Symbol, SYMBOL_BID)) / _Point;
-    return spread > 50;
-}
-
-bool ATRCheck() {
-    double atr_now = iATR(_Symbol, PERIOD_M5, 14, 0);
-    double atr_avg = iATR(_Symbol, PERIOD_M5, 50, 0);
-    return atr_now < (2.3 * atr_avg);
-}
-
-bool NewsFilter()
+bool RP_IsNearZone(const Zone &z, double px, double atrLtf)
 {
-    int h = FileOpen("news_time.txt", FILE_READ|FILE_ANSI);
-    if(h!=INVALID_HANDLE)
-    {
-        datetime t = (datetime)FileReadNumber(h);
-        FileClose(h);
-        if(MathAbs(TimeCurrent()-t) <= 900)
-            return false;
-    }
-    return true;
+   double m = MathMax(g_point, atrLtf * InpReactionNearATRMult);
+   return (px >= z.lower - m && px <= z.upper + m);
 }
 
-bool DailyDrawdownExceeded()
+bool RP_RejectWick(const Zone &z, bool wantLong)
 {
-    static double startEquity = 0;
-    static datetime startTime = 0;
-
-    if(TimeDay(startTime) != TimeDay(TimeCurrent()))
-    {
-        startTime = TimeCurrent();
-        startEquity = AccountInfoDouble(ACCOUNT_EQUITY);
-    }
-
-    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
-    double dd = (startEquity - equity) / startEquity * 100.0;
-    return dd > 20.0;
+   double o=iOpen(g_symbol, PERIOD_M5, 1), c=iClose(g_symbol, PERIOD_M5,1), h=iHigh(g_symbol,PERIOD_M5,1), l=iLow(g_symbol,PERIOD_M5,1);
+   double body=MathAbs(c-o); if(body<=0) return false;
+   double upW=h-MathMax(o,c), dnW=MathMin(o,c)-l;
+   if(wantLong)
+      return (l <= z.upper && c > z.upper && dnW > body*1.2);
+   return (h >= z.lower && c < z.lower && upW > body*1.2);
 }
 
-bool TrendConfirmed()
+bool RP_EngulfOrPin(bool wantLong)
 {
-    double ema50 = iMA(_Symbol, PERIOD_H4, 50, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema200 = iMA(_Symbol, PERIOD_H4, 200, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double price = iClose(_Symbol, PERIOD_H4, 0);
-    if(ema50 > ema200 && price > ema50) return true;
-    if(ema50 < ema200 && price < ema50) return true;
-    return false;
+   double o1=iOpen(g_symbol,PERIOD_M5,1), c1=iClose(g_symbol,PERIOD_M5,1);
+   double o2=iOpen(g_symbol,PERIOD_M5,2), c2=iClose(g_symbol,PERIOD_M5,2);
+   double h1=iHigh(g_symbol,PERIOD_M5,1), l1=iLow(g_symbol,PERIOD_M5,1);
+   bool engulf = wantLong ? (c1>o1 && c1>=o2 && o1<=c2) : (c1<o1 && c1<=o2 && o1>=c2);
+   double body=MathAbs(c1-o1); if(body<=0) body=g_point;
+   bool pin = wantLong ? ((MathMin(o1,c1)-l1) > body*1.5) : ((h1-MathMax(o1,c1)) > body*1.5);
+   return engulf || pin;
 }
 
-bool IsStopHunt()
+bool RP_Displacement(bool wantLong)
 {
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double high1 = iHigh(_Symbol, PERIOD_M5, 1);
-    double low1  = iLow(_Symbol, PERIOD_M5, 1);
-
-    double upper = high1 - MathMax(open1, close1);
-    double lower = MathMin(open1, close1) - low1;
-    double body  = MathAbs(close1 - open1);
-
-    return ((upper > body*2 && close1 < open1) || (lower > body*2 && close1 > open1));
+   double o=iOpen(g_symbol,PERIOD_M5,1), c=iClose(g_symbol,PERIOD_M5,1);
+   double atr=ATR(PERIOD_M5,1);
+   if(atr<=0) return false;
+   double b=MathAbs(c-o);
+   if(b < InpReactionDispATRMult*atr) return false;
+   return wantLong ? (c>o) : (c<o);
 }
 
-bool IsFailedBreakout()
+bool RP_SweepReclaim(const Zone &z, bool wantLong)
 {
-    double high1 = iHigh(_Symbol, PERIOD_M5, 1);
-    double high2 = iHigh(_Symbol, PERIOD_M5, 2);
-    double low1  = iLow(_Symbol, PERIOD_M5, 1);
-    double low2  = iLow(_Symbol, PERIOD_M5, 2);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-
-    bool hb = (high1 > high2) && (close1 < high2);
-    bool lb = (low1 < low2)  && (close1 > low2);
-    return hb || lb;
+   int n=MathMax(1, InpSweepReclaimBars);
+   double sw=InpSweepPoints*g_point;
+   for(int k=1;k<=n;k++)
+   {
+      double h=iHigh(g_symbol,PERIOD_M5,k), l=iLow(g_symbol,PERIOD_M5,k), c=iClose(g_symbol,PERIOD_M5,k);
+      if(wantLong)
+      {
+         if(l < z.lower - sw && c > z.lower)
+            return true;
+      }
+      else
+      {
+         if(h > z.upper + sw && c < z.upper)
+            return true;
+      }
+   }
+   return false;
 }
 
-bool IsLiquidityPOI()
+bool RP_BreakConfirmed(const Zone &z, bool wantLong)
 {
-    double vol_now = iVolume(_Symbol, PERIOD_M5, 0);
-    double vol_avg = (iVolume(_Symbol, PERIOD_M5,1)+iVolume(_Symbol, PERIOD_M5,2)+iVolume(_Symbol, PERIOD_M5,3))/3.0;
-    double price = iClose(_Symbol, PERIOD_M5, 0);
-    double high = iHigh(_Symbol, PERIOD_H1, 1);
-    double low  = iLow(_Symbol, PERIOD_H1, 1);
-    bool near = (MathAbs(price-high) < 20*_Point) || (MathAbs(price-low) < 20*_Point);
-    return (vol_now > vol_avg*1.5 && near);
+   int n=MathMax(1, InpSweepReclaimBars);
+   for(int k=1;k<=n;k++)
+   {
+      double c=iClose(g_symbol,PERIOD_M5,k);
+      if(wantLong && c < z.lower)
+      {
+         bool reclaimed=false;
+         for(int j=1;j<=n;j++) if(iClose(g_symbol,PERIOD_M5,j) > z.lower) reclaimed=true;
+         if(!reclaimed) return true;
+      }
+      if(!wantLong && c > z.upper)
+      {
+         bool reclaimed=false;
+         for(int j=1;j<=n;j++) if(iClose(g_symbol,PERIOD_M5,j) < z.upper) reclaimed=true;
+         if(!reclaimed) return true;
+      }
+   }
+   return false;
 }
 
-int CheckConfirmations() {
-    int conf = 0;
-
-    // RSI
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 30 || rsi > 70) conf++;
-
-    // EMA trend
-    double ema20 = iMA(_Symbol, PERIOD_M5, 20, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double prev_close = iClose(_Symbol, PERIOD_M5, 1);
-    double close_now = iClose(_Symbol, PERIOD_M5, 0);
-    if((prev_close <= ema20 && close_now > ema20) ||
-       (prev_close >= ema20 && close_now < ema20))
-        conf++;
-
-    // ADX trend
-    double adx = iADX(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, MODE_MAIN, 0);
-    if(adx > 25) conf++;
-
-    // Volume spike
-    if(iVolume(_Symbol, PERIOD_M5, 0) > 1.8 * iVolume(_Symbol, PERIOD_M5, 1)) conf++;
-
-    // 4 EMA alignment
-    double ema57 = iMA(_Symbol, PERIOD_M5, 57, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema114 = iMA(_Symbol, PERIOD_M5, 114, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema150 = iMA(_Symbol, PERIOD_M5, 150, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema214 = iMA(_Symbol, PERIOD_M5, 214, 0, MODE_EMA, PRICE_CLOSE, 0);
-    if(ema57 < ema114 && ema114 < ema150 && ema150 < ema214) conf++;
-
-    // Pivot breakout
-    double pivot = (iHigh(NULL, PERIOD_D1, 1) + iLow(NULL, PERIOD_D1, 1) + iClose(NULL, PERIOD_D1, 1)) / 3;
-    double R1 = 2 * pivot - iLow(NULL, PERIOD_D1, 1);
-    double S1 = 2 * pivot - iHigh(NULL, PERIOD_D1, 1);
-    if((iClose(_Symbol, PERIOD_M5, 0) > R1 + 5 * _Point) || (iClose(_Symbol, PERIOD_M5, 0) < S1 - 5 * _Point))
-        conf++;
-
-    // Fibonacci level (approssimato con distanza % dal massimo/minimo giorno precedente)
-    double high = iHigh(NULL, PERIOD_D1, 1);
-    double low = iLow(NULL, PERIOD_D1, 1);
-    double fib_382 = high - 0.382 * (high - low);
-    double fib_618 = high - 0.618 * (high - low);
-    if(iClose(_Symbol, PERIOD_M5, 0) > fib_618 && iClose(_Symbol, PERIOD_M5, 0) < fib_382)
-        conf++;
-
-    // Prossimità a livelli chiave (simulata)
-    if(MathAbs(iClose(_Symbol, PERIOD_M5, 0) - pivot) < 10 * _Point)
-        conf++;
-
-    return conf;
-}
-
-int EntryDirection() {
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 30) return 1;
-    if(rsi > 70) return -1;
-    return 0;
-}
-
-double CalculateRiskLot(double stop_loss, double risk_percent) {
-    double risk_amount = AccountInfoDouble(ACCOUNT_BALANCE) * (risk_percent / 100.0);
-    double tick_size  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
-    double tick_value = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
-    double lot = risk_amount / (stop_loss / tick_size * tick_value);
-    return NormalizeDouble(lot, 2);
-}
-
-
-void ManageRunnerTrade()
+bool RP_PickBestZone(bool wantLong, Zone &outZ)
 {
-    for(int i = PositionsTotal() - 1; i >= 0; i--)
-    {
-        if(PositionSelectByIndex(i))
-        {
-            ulong ticket = PositionGetInteger(POSITION_TICKET);
-            string symbol = PositionGetString(POSITION_SYMBOL);
-            int type = (int)PositionGetInteger(POSITION_TYPE);
-            if(symbol == _Symbol && (type == POSITION_TYPE_BUY || type == POSITION_TYPE_SELL))
-            {
-                datetime opentime = (datetime)PositionGetInteger(POSITION_TIME);
-                ENUM_TIMEFRAMES tf = (TimeCurrent() - opentime > 43200) ? PERIOD_H4 : PERIOD_CURRENT;
-                if(tf != PERIOD_H4 && tf != PERIOD_D1)
-                    continue;
-
-                double open_price = PositionGetDouble(POSITION_PRICE_OPEN);
-                double current_price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID) : SymbolInfoDouble(_Symbol, SYMBOL_ASK);
-                double profit_pips = MathAbs(current_price - open_price) / _Point;
-
-                double sl = PositionGetDouble(POSITION_SL);
-                double new_sl;
-
-                // BE: quando profitto supera 2x SL
-                if(profit_pips >= SL_Pips * 2 && sl == 0)
-                {
-                    new_sl = (type == POSITION_TYPE_BUY) ? open_price + (10 * _Point) : open_price - (10 * _Point);
-                    trade.PositionModify(ticket, new_sl, PositionGetDouble(POSITION_TP));
-                }
-
-                // Take Parziale a 3x SL
-                if(profit_pips >= SL_Pips * 3 && PositionGetDouble(POSITION_VOLUME) >= 0.02)
-                {
-                    double partial = NormalizeDouble(PositionGetDouble(POSITION_VOLUME) / 2.0, 2);
-                    trade.PositionClosePartial(ticket, partial);
-                }
-
-                // Trailing dopo 3x SL superato
-                if(profit_pips >= SL_Pips * 3)
-                {
-                    double trail = SL_Pips * _Point;
-                    new_sl = (type == POSITION_TYPE_BUY) ? current_price - trail : current_price + trail;
-                    if((type == POSITION_TYPE_BUY && new_sl > sl) || (type == POSITION_TYPE_SELL && new_sl < sl))
-                        trade.PositionModify(ticket, new_sl, PositionGetDouble(POSITION_TP));
-                }
-
-                // Uscita in caso di inversione forte (ADX < 20 e RSI opposto)
-                double rsi = iRSI(_Symbol, tf, 14, PRICE_CLOSE, 0);
-                double adx = iADX(_Symbol, tf, 14, PRICE_CLOSE, MODE_MAIN, 0);
-                if(adx < 20 && ((type == POSITION_TYPE_BUY && rsi < 40) || (type == POSITION_TYPE_SELL && rsi > 60)))
-                {
-                    trade.PositionClose(ticket);
-                }
-            }
-        }
-    }
+   double px=SymbolInfoDouble(g_symbol, SYMBOL_BID);
+   double atr=ATR(PERIOD_M5,1);
+   int best=-1; double bestScore=-DBL_MAX;
+   for(int i=0;i<ArraySize(g_rpZones);i++)
+   {
+      Zone &z=g_rpZones[i];
+      if(z.broken) continue;
+      if(wantLong && !z.bullish) continue;
+      if(!wantLong && z.bullish) continue;
+      if(!RP_IsNearZone(z, px, atr)) continue;
+      double freshness = (z.state==ZONE_FRESH?30:(z.state==ZONE_SEMI?20:10));
+      double sc = z.score + freshness - z.touchCount*5.0;
+      if(sc>bestScore){bestScore=sc;best=i;}
+   }
+   if(best<0) return false;
+   outZ=g_rpZones[best];
+   return true;
 }
 
-double CalculateConfidenceScore()
+bool RP_ModelGate(TradeDir dir, double entry, double &sl, double &tp, int &scoreOut, string &reasonOut, string &zoneKeyOut)
 {
-    double score = 0;
+   scoreOut = 0;
+   reasonOut = "";
+   zoneKeyOut = "";
+   if(!InpUseReactionProbabilityModel)
+   {
+      scoreOut = 100;
+      return true;
+   }
 
-    // RSI estremo
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    if(rsi < 18 || rsi > 82)
-        score += 15;
+   int dayId = NYDayId(TimeCurrent());
+   if(g_rpDayId != dayId)
+   {
+      g_rpDayId = dayId;
+      g_rpTradesToday = 0;
+      ArrayResize(g_rpTradedZones, 0);
+   }
 
-    // ADX alto
-    double adx = iADX(_Symbol, PERIOD_H1, 14, PRICE_CLOSE, MODE_MAIN, 0);
-    if(adx > 28)
-        score += 15;
+   bool wantLong = (dir == DIR_LONG);
+   RPMarketBias bias = RP_GetHTFBias();
+   int context = 0;
+   if((wantLong && bias==RP_BIAS_LONG) || (!wantLong && bias==RP_BIAS_SHORT)) context = 30;
+   else if(bias == RP_BIAS_NEUTRAL) context = 15;
+   else context = 0;
 
-    // EMA ben allineate
-    double ema57 = iMA(_Symbol, PERIOD_M5, 57, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema114 = iMA(_Symbol, PERIOD_M5, 114, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema150 = iMA(_Symbol, PERIOD_M5, 150, 0, MODE_EMA, PRICE_CLOSE, 0);
-    double ema214 = iMA(_Symbol, PERIOD_M5, 214, 0, MODE_EMA, PRICE_CLOSE, 0);
-    if(ema57 > ema114 && ema114 > ema150 && ema150 > ema214)
-        score += 15;
+   if(InpNoTradeAgainstHTF && context == 0)
+   {
+      reasonOut = "against_htf";
+      return false;
+   }
 
-    // Volume spike
-    double vol_now = iVolume(_Symbol, PERIOD_M5, 0);
-    double vol_prev = iVolume(_Symbol, PERIOD_M5, 1);
-    if(vol_now > vol_prev * 1.8)
-        score += 10;
+   if(g_rpTradesToday >= InpMaxTradesPerDay)
+   {
+      reasonOut = "max_trades_day";
+      return false;
+   }
 
-    // Supporti/resistenze, pivot (simulati)
-    double s1 = iLow(_Symbol, PERIOD_D1, 0) - 100 * _Point;
-    double r1 = iHigh(_Symbol, PERIOD_D1, 0) + 100 * _Point;
-    double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
-    if(MathAbs(price - s1) < 30 * _Point || MathAbs(price - r1) < 30 * _Point)
-        score += 10;
+   if((TimeCurrent() - g_rpLastTradeTs) < InpCooldownMinutes * 60)
+   {
+      reasonOut = "cooldown";
+      return false;
+   }
 
-    // Order block presente (simulato)
-    if(iClose(_Symbol, PERIOD_M5, 0) > iOpen(_Symbol, PERIOD_M5, 0) && iClose(_Symbol, PERIOD_M5, 1) < iOpen(_Symbol, PERIOD_M5, 1))
-        score += 15;
+   int lossStreak = GVGetInt("lossStreak", 0);
+   if(lossStreak >= InpMaxLossStreak)
+   {
+      reasonOut = "loss_streak";
+      return false;
+   }
 
-    // Fibonacci 61.8% (simulato livello)
-    double fib_level = iLow(_Symbol, PERIOD_H1, 1) + 0.618 * (iHigh(_Symbol, PERIOD_H1, 1) - iLow(_Symbol, PERIOD_H1, 1));
-    if(MathAbs(price - fib_level) < 20 * _Point)
-        score += 10;
+   if(g_rpLastM15Bar != iTime(g_symbol, PERIOD_M15, 0))
+   {
+      g_rpLastM15Bar = iTime(g_symbol, PERIOD_M15, 0);
+      RP_BuildZonesFromSMC();
+   }
 
-    // Pitchfork key level (simulato)
-    if(MathAbs(price - iMA(_Symbol, PERIOD_H1, 100, 0, MODE_EMA, PRICE_CLOSE, 0)) < 25 * _Point)
-        score += 5;
+   Zone z;
+   if(!RP_PickBestZone(wantLong, z))
+   {
+      reasonOut = "no_zone";
+      return false;
+   }
 
-    // Onde di Elliott (simulato se 3 candele a zigzag)
-    double c1 = iClose(_Symbol, PERIOD_M5, 2);
-    double c2 = iClose(_Symbol, PERIOD_M5, 1);
-    double c3 = iClose(_Symbol, PERIOD_M5, 0);
-    if((c1 < c2 && c2 > c3) || (c1 > c2 && c2 < c3))
-        score += 5;
+   zoneKeyOut = z.key;
+   if(RP_ZoneAlreadyTraded(zoneKeyOut))
+   {
+      reasonOut = "zone_already_traded";
+      return false;
+   }
 
-    // Elementi istituzionali
-    if(IsStopHunt())
-        score += 15;
-    if(IsFailedBreakout())
-        score += 15;
-    if(IsLiquidityPOI())
-        score += 10;
-    if(IsCandlestickPatternConfirmed())
-        score += 10;
+   int zoneQuality = (int)MathRound(MathMax(0.0, MathMin(30.0, z.score * 0.3)));
 
-    return score;
+   bool tWick = RP_RejectWick(z, wantLong);
+   bool tEngulf = RP_EngulfOrPin(wantLong);
+   bool tDisp = RP_Displacement(wantLong);
+   bool tSweep = RP_SweepReclaim(z, wantLong);
+   bool breakConfirmed = RP_BreakConfirmed(z, wantLong);
+
+   if(breakConfirmed)
+   {
+      reasonOut = "zone_break_confirmed";
+      return false;
+   }
+
+   int trigCount = (tWick?1:0) + (tEngulf?1:0) + (tDisp?1:0) + (tSweep?1:0);
+   if(trigCount <= 0)
+   {
+      reasonOut = "no_reaction_trigger";
+      return false;
+   }
+
+   int trigger = MathMin(30, trigCount * 8 + (tSweep ? 6 : 0));
+   int riskFilters = 10;
+   if(lossStreak > 0)
+      riskFilters = MathMax(0, riskFilters - lossStreak * 2);
+
+   int score = context + zoneQuality + trigger + riskFilters;
+   if(score > 100) score = 100;
+   if(score < 0) score = 0;
+   scoreOut = score;
+
+   bool gate = false;
+   if(score >= 70)
+      gate = true;
+   else if(score >= 60)
+      gate = (g_rpTradesToday < InpMaxTradesPerDay && (TimeCurrent() - g_rpLastTradeTs) >= InpCooldownMinutes * 60);
+
+   if(sl <= 0.0)
+   {
+      double atr = ATR(PERIOD_M15, 1);
+      if(atr > 0.0)
+      {
+         double buf = atr * InpRiskATRBufferMult;
+         if(wantLong)
+            sl = MathMin(sl <= 0.0 ? DBL_MAX : sl, z.lower - buf);
+         else
+            sl = MathMax(sl <= 0.0 ? -DBL_MAX : sl, z.upper + buf);
+         sl = NormalizePrice(sl);
+      }
+   }
+
+   if(sl <= 0.0)
+   {
+      reasonOut = "risk_safety_no_sl";
+      return false;
+   }
+
+   Print("[RPModel] bias=", (int)bias,
+         " zoneState=", z.state,
+         " trigW=", (int)tWick,
+         " trigE=", (int)tEngulf,
+         " trigD=", (int)tDisp,
+         " trigS=", (int)tSweep,
+         " score=", score,
+         " gate=", (gate ? "ALLOW" : "SKIP"),
+         " zone=", z.key);
+
+   if(!gate)
+   {
+      reasonOut = "score_gate";
+      return false;
+   }
+
+   return true;
 }
+/// REACTION_PROBABILITY END
 
 
-void CheckAndTrade()
+/// INSTITUTIONAL_RISK_ENGINE BEGIN
+void IR_ResetTelemetry()
 {
-    double score = CalculateConfidenceScore();
-    double rr_ratio = 2.0; // default
-    double lot = 0.01; // default lotto minimo
-
-    // Skip se score < 50
-    if(score < 50)
-        return;
-
-    // Aggiustamento dinamico lotto e R:R
-    if(score >= 50 && score < 70)
-    {
-        rr_ratio = 2.0;
-        lot = 0.01;
-    }
-    else if(score >= 70 && score < 90)
-    {
-        rr_ratio = 3.0;
-        lot = 0.015; // aumenta leggermente
-    }
-    else if(score >= 90)
-    {
-        rr_ratio = 4.0;
-        lot = 0.02; // lotto massimo consentito per 100€ iniziali
-    }
-
-    // Calcolo direzione trade (semplificato su RSI)
-    double rsi = iRSI(_Symbol, PERIOD_M5, 14, PRICE_CLOSE, 0);
-    int trade_type = -1;
-
-    if(rsi < 18)
-        trade_type = OP_BUY;
-    else if(rsi > 82)
-        trade_type = OP_SELL;
-    else
-        return;
-
-    // Prezzo corrente
-    double price = (trade_type == OP_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_ASK) : SymbolInfoDouble(_Symbol, SYMBOL_BID);
-
-    // StopLoss e TakeProfit dinamici
-    double atr = iATR(_Symbol, PERIOD_M5, 14, 0);
-    double sl_pips = atr * 1.5;
-    double tp_pips = sl_pips * rr_ratio;
-
-    double sl = (trade_type == OP_BUY) ? price - sl_pips : price + sl_pips;
-    double tp = (trade_type == OP_BUY) ? price + tp_pips : price - tp_pips;
-
-    // Invio ordine
-    if(trade_type == OP_BUY)
-        trade.Buy(lot, _Symbol, price, sl, tp, "AutoTrade by Confidence");
-    else
-        trade.Sell(lot, _Symbol, price, sl, tp, "AutoTrade by Confidence");
+   g_irEntryScore = 0;
+   g_irTier = "NA";
+   g_irRiskBasePct = InpRiskBasePct;
+   g_irScoreMult = 0.0;
+   g_irRegimeMult = 0.0;
+   g_irFearMult = 0.0;
+   g_irFinalRiskPct = 0.0;
+   g_irRiskMoney = 0.0;
+   g_irStopDistancePoints = 0.0;
+   g_irLots = 0.0;
+   g_irSpreadPoints = 0.0;
+   g_irAtrRatio = 0.0;
+   g_irLossStreak = GVGetInt("lossStreak", 0);
+   g_irDailyDD = 0.0;
 }
 
-
-bool IsBullishEngulfing()
+double IR_GetScoreMultiplier(int entryScore, string &tierOut)
 {
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double open0 = iOpen(_Symbol, PERIOD_M5, 0);
-    double close0 = iClose(_Symbol, PERIOD_M5, 0);
-
-    return (close1 < open1 && close0 > open0 && close0 > open1 && open0 < close1);
+   tierOut = "<70";
+   if(entryScore >= 90)
+   {
+      tierOut = ">=90";
+      return MathMin(1.25, InpMaxRiskMultiplier);
+   }
+   if(entryScore >= 85)
+   {
+      tierOut = "85-89";
+      return MathMin(1.00, InpMaxRiskMultiplier);
+   }
+   if(entryScore >= 80)
+   {
+      tierOut = "80-84";
+      return MathMin(0.75, InpMaxRiskMultiplier);
+   }
+   if(entryScore >= 75)
+   {
+      tierOut = "75-79";
+      return MathMin(0.50, InpMaxRiskMultiplier);
+   }
+   if(entryScore >= 70)
+   {
+      tierOut = "70-74";
+      return MathMin(0.25, InpMaxRiskMultiplier);
+   }
+   return 0.0;
 }
 
-bool IsBearishEngulfing()
+double IR_GetAtrRatio()
 {
-    double open1 = iOpen(_Symbol, PERIOD_M5, 1);
-    double close1 = iClose(_Symbol, PERIOD_M5, 1);
-    double open0 = iOpen(_Symbol, PERIOD_M5, 0);
-    double close0 = iClose(_Symbol, PERIOD_M5, 0);
-
-    return (close1 > open1 && close0 < open0 && close0 < open1 && open0 > close1);
+   double atrNow = ATR(PERIOD_M15, 1);
+   if(atrNow <= 0.0)
+      return 1.0;
+   double sum = 0.0;
+   int n = MathMax(1, InpAtrMaPeriod);
+   int used = 0;
+   for(int i = 1; i <= n; i++)
+   {
+      double a = ATR(PERIOD_M15, i);
+      if(a > 0.0)
+      {
+         sum += a;
+         used++;
+      }
+   }
+   if(used <= 0)
+      return 1.0;
+   double atrMa = sum / used;
+   if(atrMa <= 0.0)
+      return 1.0;
+   return atrNow / atrMa;
 }
 
-bool IsPinBar()
+double IR_GetRegimeMultiplier(double spreadPoints, double atrRatio, bool &blockOut)
 {
-    double open = iOpen(_Symbol, PERIOD_M5, 0);
-    double close = iClose(_Symbol, PERIOD_M5, 0);
-    double high = iHigh(_Symbol, PERIOD_M5, 0);
-    double low = iLow(_Symbol, PERIOD_M5, 0);
-
-    double body = MathAbs(close - open);
-    double range = high - low;
-
-    return (body < (range * 0.25)); // corpo molto piccolo
+   blockOut = false;
+   if(spreadPoints > cfg_InpMaxSpreadPoints)
+   {
+      blockOut = true;
+      return 0.0;
+   }
+   double mult = 1.0;
+   if(atrRatio > InpAtrSpikeRatio)
+      mult *= 0.5;
+   if(InpUseSessionRiskMultiplier && !SessionOk())
+      mult *= InpSessionRiskMultiplier;
+   return mult;
 }
 
-
-bool IsCandlestickPatternConfirmed()
+double IR_GetDailyDDPct()
 {
-    return (IsBullishEngulfing() || IsBearishEngulfing() || IsPinBar());
+   double startEquity = GVGetDouble("dayEquityStart", AccountInfoDouble(ACCOUNT_EQUITY));
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   if(startEquity <= 0.0)
+      return 0.0;
+   double dd = (startEquity - equity) / startEquity * 100.0;
+   if(dd < 0.0)
+      dd = 0.0;
+   return dd;
 }
 
-bool RequirePatternConfirmation(double score, ENUM_TIMEFRAMES tf)
+double IR_GetFearMultiplier(int lossStreak, double dailyDrawdownPct, bool &blockOut)
 {
-    // Per operazioni in H4/D1 runner, il pattern è obbligatorio se score < 80
-    if((tf == PERIOD_H4 || tf == PERIOD_D1) && score < 80)
-        return true;
-
-    // Se score è alto, il pattern può essere bypassato
-    return false;
+   blockOut = false;
+   if(dailyDrawdownPct >= InpDailyDDHard)
+   {
+      blockOut = true;
+      return 0.0;
+   }
+   double mult = 1.0;
+   if(lossStreak >= 3)
+      mult *= 0.25;
+   else if(lossStreak >= 2)
+      mult *= 0.5;
+   if(dailyDrawdownPct >= InpDailyDDSoft)
+      mult *= 0.5;
+   return mult;
 }
+
+double IR_ClampRiskPct(double riskPct)
+{
+   double lo = MathMin(InpRiskMinPct, InpRiskMaxPct);
+   double hi = MathMax(InpRiskMinPct, InpRiskMaxPct);
+   return MathMax(lo, MathMin(hi, riskPct));
+}
+
+double IR_CalcLotsFromRiskPct(double entryPrice, double stopPrice, double riskPct, double &riskMoneyOut, double &stopDistancePointsOut)
+{
+   riskMoneyOut = 0.0;
+   stopDistancePointsOut = 0.0;
+   if(entryPrice <= 0.0 || stopPrice <= 0.0 || riskPct <= 0.0)
+      return 0.0;
+
+   double stopDistPrice = MathAbs(entryPrice - stopPrice);
+   if(stopDistPrice <= 0.0 || g_point <= 0.0)
+      return 0.0;
+
+   stopDistancePointsOut = stopDistPrice / g_point;
+   double tickValue = TickValue();
+   double tickSize = TickSize();
+   if(tickValue <= 0.0 || tickSize <= 0.0)
+      return 0.0;
+
+   double moneyPerPointPerLot = (tickValue / tickSize) * g_point;
+   if(moneyPerPointPerLot <= 0.0)
+      return 0.0;
+
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   riskMoneyOut = equity * riskPct;
+   if(riskMoneyOut <= 0.0)
+      return 0.0;
+
+   double lots = riskMoneyOut / (stopDistancePointsOut * moneyPerPointPerLot);
+   return NormalizeVolumeByStep(lots);
+}
+
+bool IR_ComputeLots(TradeDir dir, double entryPrice, double &stopPrice, int entryScore, double &lotsOut, string &tierOut, string &reasonOut)
+{
+   lotsOut = 0.0;
+   reasonOut = "";
+   IR_ResetTelemetry();
+   g_irEntryScore = entryScore;
+   g_irSpreadPoints = SpreadPoints();
+   g_irAtrRatio = IR_GetAtrRatio();
+   g_irLossStreak = GVGetInt("lossStreak", 0);
+   g_irDailyDD = IR_GetDailyDDPct();
+
+   if(stopPrice <= 0.0)
+   {
+      double cat = InpCatastrophicSL_Points * g_point;
+      stopPrice = (dir == DIR_LONG) ? (entryPrice - cat) : (entryPrice + cat);
+      stopPrice = NormalizePrice(stopPrice);
+   }
+
+   g_irScoreMult = IR_GetScoreMultiplier(entryScore, tierOut);
+   g_irTier = tierOut;
+   if(g_irScoreMult <= 0.0)
+   {
+      reasonOut = "score_tier_zero";
+      return false;
+   }
+
+   bool regimeBlock = false;
+   g_irRegimeMult = IR_GetRegimeMultiplier(g_irSpreadPoints, g_irAtrRatio, regimeBlock);
+   if(regimeBlock || g_irRegimeMult <= 0.0)
+   {
+      reasonOut = "regime_block";
+      return false;
+   }
+
+   bool fearBlock = false;
+   g_irFearMult = IR_GetFearMultiplier(g_irLossStreak, g_irDailyDD, fearBlock);
+   if(fearBlock || g_irFearMult <= 0.0)
+   {
+      reasonOut = "fear_block";
+      return false;
+   }
+
+   double riskPctRaw = InpRiskBasePct * g_irScoreMult * g_irRegimeMult * g_irFearMult;
+   if(UseInstitutionalScore)
+      riskPctRaw *= MathMax(0.0, g_instRiskMult);
+   g_irRiskBasePct = InpRiskBasePct;
+   g_irFinalRiskPct = IR_ClampRiskPct(riskPctRaw);
+
+   lotsOut = IR_CalcLotsFromRiskPct(entryPrice, stopPrice, g_irFinalRiskPct, g_irRiskMoney, g_irStopDistancePoints);
+   g_irLots = lotsOut;
+
+   Print("[IREngine] EntryScore=", entryScore,
+         " tier=", g_irTier,
+         " riskBasePct=", DoubleToString(g_irRiskBasePct, 5),
+         " scoreMult=", DoubleToString(g_irScoreMult, 3),
+         " regimeMult=", DoubleToString(g_irRegimeMult, 3),
+         " fearMult=", DoubleToString(g_irFearMult, 3),
+         " finalRiskPct=", DoubleToString(g_irFinalRiskPct, 5),
+         " riskMoney=", DoubleToString(g_irRiskMoney, 2),
+         " stopDistancePoints=", DoubleToString(g_irStopDistancePoints, 1),
+         " lots=", DoubleToString(g_irLots, 2),
+         " spreadPoints=", DoubleToString(g_irSpreadPoints, 1),
+         " atrRatio=", DoubleToString(g_irAtrRatio, 2),
+         " lossStreak=", g_irLossStreak,
+         " dailyDD=", DoubleToString(g_irDailyDD, 2));
+
+   if(lotsOut <= 0.0)
+   {
+      reasonOut = "lots_zero";
+      return false;
+   }
+
+   return true;
+}
+/// INSTITUTIONAL_RISK_ENGINE END
+
+
+/// INSTITUTIONAL_PATTERN_ADAPTER BEGIN
+EPattern50 MapDetectorToEPattern50(int detectorIdOrEnum, bool isBullish)
+{
+   // Default adapter for common detector IDs. Keep existing detector untouched.
+   switch(detectorIdOrEnum)
+   {
+      case 1: return isBullish ? PAT_BULLISH_ENGULFING : PAT_BEARISH_ENGULFING; // Engulfing
+      case 2: return PAT_HAMMER; // Hammer
+      case 3: return PAT_SHOOTING_STAR; // ShootingStar
+      case 4: return PAT_DOJI; // Doji
+      case 5: return PAT_MORNING_STAR; // MorningStar
+      case 6: return PAT_EVENING_STAR; // EveningStar
+      case 7: return PAT_THREE_WHITE_SOLDIERS; // ThreeSoldiers
+      case 8: return PAT_THREE_BLACK_CROWS; // ThreeCrows
+   }
+   return PAT_DOJI;
+}
+
+void ComputeInstitutionalAdapter(int detectorIdOrEnum, bool isBullish, int entryMask, int killzoneActive,
+                                 int &outTotalScore, double &outRiskMult, int &outPatternScore, EPattern50 &outPattern)
+{
+   outPattern = MapDetectorToEPattern50(detectorIdOrEnum, isBullish);
+   outPatternScore = GetPatternScore(outPattern);
+
+   InstFeatures f;
+   ZeroMemory(f);
+
+   double spreadPts = SpreadPoints();
+   f.spreadOK = (spreadPts <= MaxSpreadPoints) || (spreadPts <= cfg_InpMaxSpreadPoints);
+   f.atrOK = !LowVolBlocked();
+   f.breakoutRetest = ((entryMask & ENTRY_BOS_RETEST) != 0);
+
+   TradeDir bias = BiasH1();
+   f.htfTrendAligned = (isBullish && bias == DIR_LONG) || (!isBullish && bias == DIR_SHORT);
+   f.bosOrMss = ((entryMask & ENTRY_MSS) != 0) || ((entryMask & ENTRY_BOS_CLOSE) != 0) || ((entryMask & ENTRY_BOS_RETEST) != 0);
+   f.liquiditySweep = ((entryMask & ENTRY_SWEEP) != 0);
+   f.displacement = ((entryMask & ENTRY_DISPLACEMENT) != 0);
+   f.poiTouched = ((entryMask & ENTRY_OB_RTO) != 0) || ((entryMask & ENTRY_SD) != 0) || ((entryMask & ENTRY_SR) != 0);
+   f.sessionNY = (killzoneActive == 1); // TODO: connect NY-specific session module if available.
+   f.volumeSpike = false; // TODO: connect volume spike module.
+   f.premiumDiscountOK = ((entryMask & ENTRY_PDARRAY) != 0); // TODO: connect explicit PD premium/discount gate.
+   f.avoidHighLow = false; // TODO: connect avoid day high/low sweep module.
+
+   InstWeights w = GetXauScalpPresetWeights();
+   outTotalScore = ComputeInstitutionalScore(outPatternScore, f, w);
+   outRiskMult = ScoreToRiskMultiplier(outTotalScore);
+
+   if(LogInstitutional && outRiskMult > 0.0)
+   {
+      Print("[INST] pat=", GetPatternName(outPattern),
+            " pScore=", outPatternScore,
+            " flags=", (int)f.htfTrendAligned, "|", (int)f.bosOrMss, "|", (int)f.liquiditySweep, "|", (int)f.displacement,
+            "|", (int)f.poiTouched, "|", (int)f.breakoutRetest, "|", (int)f.sessionNY, "|", (int)f.volumeSpike,
+            "|", (int)f.premiumDiscountOK, "|", (int)f.avoidHighLow, "|", (int)f.spreadOK, "|", (int)f.atrOK,
+            " total=", outTotalScore,
+            " riskMult=", DoubleToString(outRiskMult, 2),
+            " spread=", DoubleToString(spreadPts, 1),
+            " atrOK=", (int)f.atrOK);
+   }
+}
+/// INSTITUTIONAL_PATTERN_ADAPTER END

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -22,6 +22,7 @@
 #include <GROK/PatternScores.mqh>
 #include "Strategy_RSIEngulfTouch.mqh"
 #include <GROK/LicenseClient.mqh>
+#include <GROK/PatternEngine.mqh>
 
 CTrade trade;
 
@@ -128,6 +129,23 @@ input int MaxSpreadPoints = 30; // DEPRECATED: use InpMaxSpreadPoints
 input bool UseInstitutionalScore = true;
 input int InstitutionalMinScore = 60;
 input bool LogInstitutional = true;
+
+input bool   UsePatternEngine = true;
+input bool   UsePatternPriors = true;
+input bool   UseBustedLogic = true;
+input string PatternCSVFileName = "pattern_stats.csv";
+input ENUM_TIMEFRAMES InpPatternTF = PERIOD_M15;
+input int    InpPatternLookback = 120;
+input int    InpPatternPivotLR = 2;
+input double InpPatternWeight = 1.20;
+input double InpPatternQualityWeight = 8.0;
+input double InpPattern_kRank = 0.20;
+input double InpPattern_kFail = 18.0;
+input double InpPattern_kTarget = 18.0;
+input double InpPattern_kMove = 14.0;
+input double InpPatternSL_ATR_Buffer = 0.15;
+input int    InpBustedBars = 6;
+input double InpBustedMinATR = 0.30;
 
 input string InpLicenseKey="";
 input string InpLicenseApiBase="https://api.example.com";
@@ -359,6 +377,22 @@ int g_instTotalScore = 0;
 double g_instRiskMult = 1.0;
 int g_instPatternScore = 0;
 EPattern50 g_instPattern = PAT_DOJI;
+
+PatternStats g_patternStats[];
+bool g_patternStatsLoaded = false;
+datetime g_patternCacheBar = 0;
+PatternSignal g_patternSignal;
+double g_patternPriorScore = 50.0;
+double g_patternFinalScore = 0.0;
+double g_patternScoreDelta = 0.0;
+double g_patternOutcomePips = 0.0;
+double g_patternMaxFavorPips = 0.0;
+double g_patternMaxAdversePips = 0.0;
+
+void PatternEngine_Init();
+void PatternEngine_Update();
+double PatternEngine_ComputePrior(const PatternSignal &sig);
+void PatternEngine_UpdateMfeMae();
 
 
 void SMCZ3C_Update();
@@ -3054,7 +3088,9 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
                 "momHit", "rsi1", "rsi2",
                 "irEntryScore", "irTier", "irRiskBasePct", "irScoreMult", "irRegimeMult", "irFearMult", "irFinalRiskPct",
                 "irRiskMoney", "irStopDistancePoints", "irLots", "irSpreadPoints", "irAtrRatio", "irLossStreak", "irDailyDD",
-                "instPattern", "instPatternScore", "instTotalScore", "instRiskMult");
+                "instPattern", "instPatternScore", "instTotalScore", "instRiskMult",
+                "pePatternId", "peDir", "peEntry", "peSL", "peTP1", "pePrior", "peFinalScore", "peDelta",
+                "peOutcomePips", "peMaxFavor", "peMaxAdverse");
    }
 
    int lossStreak = GVGetInt("lossStreak", 0);
@@ -3147,7 +3183,18 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
              GetPatternName(g_instPattern),
              g_instPatternScore,
              g_instTotalScore,
-             DoubleToString(g_instRiskMult, 2));
+             DoubleToString(g_instRiskMult, 2),
+             (g_patternSignal.detected ? g_patternSignal.pattern_id : "NONE"),
+             (g_patternSignal.detected ? g_patternSignal.direction : 0),
+             DoubleToString(g_patternSignal.entry_level, g_digits),
+             DoubleToString(g_patternSignal.invalidation_level, g_digits),
+             DoubleToString(g_patternSignal.target_level, g_digits),
+             DoubleToString(g_patternPriorScore, 2),
+             DoubleToString(g_patternFinalScore, 2),
+             DoubleToString(g_patternScoreDelta, 2),
+             DoubleToString(g_patternOutcomePips, 2),
+             DoubleToString(g_patternMaxFavorPips, 2),
+             DoubleToString(g_patternMaxAdversePips, 2));
 
    FileClose(handle);
 }
@@ -3531,6 +3578,26 @@ void ManagePosition(double riskR)
       return;
    double profitR = (type == POSITION_TYPE_BUY) ? (price - entry) / riskR : (entry - price) / riskR;
 
+   PatternEngine_UpdateMfeMae();
+
+   if(UseBustedLogic)
+   {
+      datetime et = (datetime)GVGetDouble("lastEntryTime", 0.0);
+      int barsFromEntry = (et > 0 ? iBarShift(g_symbol, PERIOD_M15, et, true) : 9999);
+      double breakoutLevel = GVGetDouble("pattern_breakout_level", 0.0);
+      double atrNow = ATR(PERIOD_M15, 1);
+      bool weakMove = (MathAbs(price - entry) < atrNow * InpBustedMinATR);
+      bool busted = false;
+      if(type == POSITION_TYPE_BUY && breakoutLevel > 0.0) busted = (price < breakoutLevel);
+      if(type == POSITION_TYPE_SELL && breakoutLevel > 0.0) busted = (price > breakoutLevel);
+      if(busted && weakMove && barsFromEntry <= InpBustedBars)
+      {
+         trade.PositionClose(ticket);
+         Print("[PatternEngine] BUSTED close executed.");
+         return;
+      }
+   }
+
    bool tp1done = GVGetInt("tp1done", 0) == 1;
    double tp1price = GVGetDouble("tp1price", 0.0);
 
@@ -3667,6 +3734,73 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
    }
 }
 
+
+void PatternEngine_Init()
+{
+   ArrayResize(g_patternStats, 0);
+   g_patternStatsLoaded = PE_LoadPatternStatsCSV(PatternCSVFileName, g_patternStats);
+   if(!g_patternStatsLoaded)
+      Print("[PatternEngine] stats CSV not found, using neutral priors: ", PatternCSVFileName);
+   g_patternSignal.detected = false;
+   g_patternCacheBar = 0;
+   g_patternPriorScore = 50.0;
+   g_patternFinalScore = 0.0;
+   g_patternScoreDelta = 0.0;
+}
+
+double PatternEngine_ComputePrior(const PatternSignal &sig)
+{
+   if(!sig.detected || !UsePatternPriors)
+      return 50.0;
+   PatternStats st;
+   if(g_patternStatsLoaded)
+      st = PE_GetStatsById(g_patternStats, sig.pattern_id, sig.direction);
+   else
+      PE_DefaultStats(st, sig.pattern_id, sig.family, sig.direction);
+
+   return PE_PatternPriorScore(st, InpPattern_kRank, InpPattern_kFail, InpPattern_kTarget, InpPattern_kMove);
+}
+
+void PatternEngine_Update()
+{
+   if(!UsePatternEngine)
+   {
+      g_patternSignal.detected = false;
+      g_patternPriorScore = 50.0;
+      return;
+   }
+   datetime barTime = iTime(g_symbol, InpPatternTF, 1);
+   if(barTime == 0 || barTime == g_patternCacheBar)
+      return;
+
+   g_patternCacheBar = barTime;
+   double atr = ATR(InpPatternTF, 1);
+   if(atr <= 0.0)
+      atr = ATR(PERIOD_M15, 1);
+   g_patternSignal = PE_DetectBestPattern(g_symbol, InpPatternTF, InpPatternLookback, InpPatternPivotLR, g_point, atr);
+   g_patternPriorScore = PatternEngine_ComputePrior(g_patternSignal);
+   if(g_patternSignal.detected)
+   {
+      PrintFormat("[PatternEngine] id=%s dir=%d prior=%.1f q=%.2f entry=%.3f inv=%.3f tp=%.3f",
+                  g_patternSignal.pattern_id, g_patternSignal.direction, g_patternPriorScore, g_patternSignal.quality,
+                  g_patternSignal.entry_level, g_patternSignal.invalidation_level, g_patternSignal.target_level);
+   }
+}
+
+void PatternEngine_UpdateMfeMae()
+{
+   if(!SelectOurPosition())
+      return;
+   int type = (int)PositionGetInteger(POSITION_TYPE);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   double px = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(g_symbol, SYMBOL_BID) : SymbolInfoDouble(g_symbol, SYMBOL_ASK);
+   double pipsNow = (type == POSITION_TYPE_BUY ? (px - entry) : (entry - px)) / MathMax(g_pip, g_point);
+   double mfe = GVGetDouble("pattern_mfe", 0.0);
+   double mae = GVGetDouble("pattern_mae", 0.0);
+   if(pipsNow > mfe) GVSetDouble("pattern_mfe", pipsNow);
+   if(pipsNow < mae) GVSetDouble("pattern_mae", pipsNow);
+}
+
 int OnInit()
 {
    g_symbol = ResolveSymbol();
@@ -3676,6 +3810,7 @@ int OnInit()
    g_profile = DetectSymbolProfile(g_symbol);
 
    ApplyPreset();
+   PatternEngine_Init();
 
    trade.SetExpertMagicNumber((uint)cfg_InpMagic);
    trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
@@ -3733,6 +3868,7 @@ void OnTick()
       g_rsiEngulfTouch.OnTick();
 
    UpdateDailyReset();
+   PatternEngine_Update();
 
    if(IsNewBar(PERIOD_H1, g_lastH1Bar))
       UpdateSpreadEMA();
@@ -3856,6 +3992,19 @@ void OnTick()
    }
 
    int entryScore = totalScore;
+   g_patternScoreDelta = 0.0;
+   g_patternFinalScore = entryScore;
+   if(UsePatternEngine && g_patternSignal.detected)
+   {
+      double prior = (UsePatternPriors ? g_patternPriorScore : 50.0);
+      double qualityPts = InpPatternQualityWeight * g_patternSignal.quality;
+      g_patternScoreDelta = InpPatternWeight * (prior - 50.0) / 10.0 + qualityPts;
+      if(g_patternSignal.direction != 0 && g_patternSignal.direction != (int)dir)
+         g_patternScoreDelta -= 6.0;
+      g_patternFinalScore = entryScore + g_patternScoreDelta;
+      entryScore = (int)MathRound(g_patternFinalScore);
+   }
+
    if(entryScore < InpEntryThreshold)
       return;
 
@@ -3866,6 +4015,24 @@ void OnTick()
    {
       Print("[RPModel] SKIP dir=", (int)dir, " score=", rpScore, " reason=", rpReason);
       return;
+   }
+
+   if(UsePatternEngine && g_patternSignal.detected && g_patternSignal.direction == (int)dir)
+   {
+      double atrPat = ATR(PERIOD_M15, 1);
+      double slBuf = atrPat * InpPatternSL_ATR_Buffer + PriceFromPoints(InpInvalidationBufferPoints);
+      if(dir == DIR_LONG)
+      {
+         double patSL = NormalizePrice(g_patternSignal.invalidation_level - slBuf);
+         if(patSL > 0.0) sl = (sl > 0.0 ? MathMax(sl, patSL) : patSL);
+         if(g_patternSignal.target_level > entry) tp1 = NormalizePrice(g_patternSignal.target_level);
+      }
+      else if(dir == DIR_SHORT)
+      {
+         double patSL = NormalizePrice(g_patternSignal.invalidation_level + slBuf);
+         if(patSL > 0.0) sl = (sl > 0.0 ? MathMin(sl, patSL) : patSL);
+         if(g_patternSignal.target_level < entry) tp1 = NormalizePrice(g_patternSignal.target_level);
+      }
    }
 
    g_instTotalScore = 0;
@@ -3912,10 +4079,15 @@ void OnTick()
    {
       GVSetInt("dayTrades", dayTrades + 1);
       GVSetDouble("lastEntryTime", (double)iTime(g_symbol, PERIOD_M15, 0));
+      GVSetDouble("lastEntryPrice", entry);
+      GVSetInt("lastDir", (int)dir);
       GVSetDouble("origRisk", riskR);
       GVSetInt("tp1done", 0);
       GVSetDouble("tp1price", tp1);
       GVSetDouble("tp1FillPrice", 0.0);
+      GVSetDouble("pattern_breakout_level", (UsePatternEngine && g_patternSignal.detected ? g_patternSignal.entry_level : entry));
+      GVSetDouble("pattern_mfe", 0.0);
+      GVSetDouble("pattern_mae", 0.0);
       GVSetInt("addCount", 0);
       GVSetDouble("lastAddPrice", entry);
       if(InpUseReactionProbabilityModel)
@@ -3954,6 +4126,15 @@ void OnTradeTransaction(const MqlTradeTransaction &trans, const MqlTradeRequest 
          lossStreak = 0;
       GVSetInt("lossStreak", lossStreak);
       UpdateLossBlock(lossStreak);
+
+      double entryPx = GVGetDouble("lastEntryPrice", 0.0);
+      int lastDir = GVGetInt("lastDir", 0);
+      if(entryPx > 0.0 && lastDir != 0)
+         g_patternOutcomePips = ((lastDir > 0 ? (trans.price - entryPx) : (entryPx - trans.price)) / MathMax(g_pip, g_point));
+      else
+         g_patternOutcomePips = 0.0;
+      g_patternMaxFavorPips = GVGetDouble("pattern_mfe", 0.0);
+      g_patternMaxAdversePips = GVGetDouble("pattern_mae", 0.0);
 
       double bosLevel = 0.0;
       int bosAgeBars = BOSAgeBars(bosLevel);

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -23,6 +23,9 @@
 #include "Strategy_RSIEngulfTouch.mqh"
 #include <GROK/LicenseClient.mqh>
 #include <GROK/PatternEngine.mqh>
+#include <GROK/Core/Config.mqh>
+#include <GROK/Core/Utils.mqh>
+#include <GROK/Stats/ProbabilityEngine.mqh>
 
 CTrade trade;
 
@@ -146,6 +149,8 @@ input double InpPattern_kMove = 14.0;
 input double InpPatternSL_ATR_Buffer = 0.15;
 input int    InpBustedBars = 6;
 input double InpBustedMinATR = 0.30;
+
+input bool   InpRunSelfTestOnInit = true;
 
 input string InpLicenseKey="";
 input string InpLicenseApiBase="https://api.example.com";
@@ -388,6 +393,11 @@ double g_patternScoreDelta = 0.0;
 double g_patternOutcomePips = 0.0;
 double g_patternMaxFavorPips = 0.0;
 double g_patternMaxAdversePips = 0.0;
+
+PatternContextFeatures g_patternCtx;
+string g_patternBreakdown = "";
+
+bool SelfTest();
 
 void PatternEngine_Init();
 void PatternEngine_Update();
@@ -3090,7 +3100,7 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
                 "irRiskMoney", "irStopDistancePoints", "irLots", "irSpreadPoints", "irAtrRatio", "irLossStreak", "irDailyDD",
                 "instPattern", "instPatternScore", "instTotalScore", "instRiskMult",
                 "pePatternId", "peDir", "peEntry", "peSL", "peTP1", "pePrior", "peFinalScore", "peDelta",
-                "peOutcomePips", "peMaxFavor", "peMaxAdverse");
+                "peOutcomePips", "peMaxFavor", "peMaxAdverse", "peBreakdown");
    }
 
    int lossStreak = GVGetInt("lossStreak", 0);
@@ -3194,7 +3204,8 @@ void LogCSVEx(const string event, TradeDir dir, double entry, double sl, double 
              DoubleToString(g_patternScoreDelta, 2),
              DoubleToString(g_patternOutcomePips, 2),
              DoubleToString(g_patternMaxFavorPips, 2),
-             DoubleToString(g_patternMaxAdversePips, 2));
+             DoubleToString(g_patternMaxAdversePips, 2),
+             g_patternBreakdown);
 
    FileClose(handle);
 }
@@ -3779,11 +3790,32 @@ void PatternEngine_Update()
       atr = ATR(PERIOD_M15, 1);
    g_patternSignal = PE_DetectBestPattern(g_symbol, InpPatternTF, InpPatternLookback, InpPatternPivotLR, g_point, atr);
    g_patternPriorScore = PatternEngine_ComputePrior(g_patternSignal);
+
+   ZeroMemory(g_patternCtx);
+   double dayOpen = iOpen(g_symbol, PERIOD_D1, 0);
+   double prevClose = iClose(g_symbol, PERIOD_D1, 1);
+   g_patternCtx.breakoutGap = (MathAbs(dayOpen - prevClose) > atr * 0.10);
+   long v1 = iVolume(g_symbol, InpPatternTF, 1);
+   double vma = 0.0; int vn = 0;
+   for(int i=2;i<=31;i++){ long vi=iVolume(g_symbol, InpPatternTF, i); if(vi>0){ vma += (double)vi; vn++; } }
+   if(vn>0) vma /= vn;
+   g_patternCtx.breakoutVolHigh = (vma > 0.0 && (double)v1 > vma * 1.2);
+   double span = (g_patternSignal.detected ? MathAbs(g_patternSignal.entry_level - g_patternSignal.invalidation_level) : 0.0);
+   g_patternCtx.patternTall = (span > atr * 1.2);
+   g_patternCtx.patternWide = (InpPatternLookback >= 80);
+   double c1 = iClose(g_symbol, InpPatternTF, 1);
+   g_patternCtx.throwbackRisk = (g_patternSignal.detected && g_patternSignal.direction > 0 && c1 < g_patternSignal.entry_level);
+   g_patternCtx.pullbackRisk = (g_patternSignal.detected && g_patternSignal.direction < 0 && c1 > g_patternSignal.entry_level);
+
+   double ctxAdj = PE_ContextAdjustment(g_patternCtx);
+   g_patternPriorScore = MathMax(0.0, MathMin(100.0, g_patternPriorScore + ctxAdj));
+   g_patternBreakdown = StringFormat("gap=%d vol=%d tall=%d wide=%d throwback=%d pullback=%d adj=%.1f", (int)g_patternCtx.breakoutGap, (int)g_patternCtx.breakoutVolHigh, (int)g_patternCtx.patternTall, (int)g_patternCtx.patternWide, (int)g_patternCtx.throwbackRisk, (int)g_patternCtx.pullbackRisk, ctxAdj);
+
    if(g_patternSignal.detected)
    {
-      PrintFormat("[PatternEngine] id=%s dir=%d prior=%.1f q=%.2f entry=%.3f inv=%.3f tp=%.3f",
+      PrintFormat("[PatternEngine] id=%s dir=%d prior=%.1f q=%.2f entry=%.3f inv=%.3f tp=%.3f %s",
                   g_patternSignal.pattern_id, g_patternSignal.direction, g_patternPriorScore, g_patternSignal.quality,
-                  g_patternSignal.entry_level, g_patternSignal.invalidation_level, g_patternSignal.target_level);
+                  g_patternSignal.entry_level, g_patternSignal.invalidation_level, g_patternSignal.target_level, g_patternBreakdown);
    }
 }
 
@@ -3811,6 +3843,7 @@ int OnInit()
 
    ApplyPreset();
    PatternEngine_Init();
+   if(InpRunSelfTestOnInit) SelfTest();
 
    trade.SetExpertMagicNumber((uint)cfg_InpMagic);
    trade.SetDeviationInPoints(cfg_InpMaxSlippagePoints);
@@ -4055,11 +4088,14 @@ void OnTick()
    string irTier = "NA";
    string irReason = "";
    double lots = 0.0;
+   double scoreRiskScale = Prob_ToRiskScale(entryScore);
    if(!IR_ComputeLots(dir, entry, sl, entryScore, lots, irTier, irReason))
    {
       Print("[IREngine] SKIP reason=", irReason, " entryScore=", entryScore);
       return;
    }
+
+   lots = NormalizeVolumeByStep(lots * scoreRiskScale);
 
    if(!StopsOk(dir, entry, sl, tp))
    {

--- a/Grok3xAI.mq5
+++ b/Grok3xAI.mq5
@@ -21,7 +21,7 @@
 #include <Trade/Trade.mqh>
 #include <GROK/PatternScores.mqh>
 #include "Strategy_RSIEngulfTouch.mqh"
-#include "mql5/LicenseClient.mqh"
+#include <GROK/LicenseClient.mqh>
 
 CTrade trade;
 
@@ -39,6 +39,8 @@ enum TradeDir
    DIR_LONG = 1,
    DIR_SHORT = -1
 };
+
+#include <GROK/OrderGate.mqh>
 
 enum PresetMode
 {
@@ -126,6 +128,18 @@ input int MaxSpreadPoints = 30;
 input bool UseInstitutionalScore = true;
 input int InstitutionalMinScore = 60;
 input bool LogInstitutional = true;
+
+input string InpLicenseKey="";
+input string InpLicenseApiBase="https://api.example.com";
+input string InpEaId="Grok3xAI";
+input string InpEaVersion="3.13";
+input int    InpVerifyHours=6;
+input int    InpGraceHours=48;
+input bool   InpAllowManageOpenPositionsWhenInvalid=true;
+input bool   InpBypassLicensingInStrategyTester=true;
+input bool   InpHardFailIfNoValidEver=true;
+input bool   InpShowLicensePanel=true;
+input bool   InpLogLicenseToFile=true;
 
 input bool   InpUseSpreadMultiple = true;
 input double InpSpreadMultiple = 3.0;
@@ -2425,7 +2439,7 @@ bool FreezeOkForClose()
    return MathAbs(price - entry) > freezeLevel * g_point;
 }
 
-bool SendOrderWithRetry(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+bool SendOrderCore(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
 {
    retcode = 0;
    lasterr = 0;
@@ -3542,7 +3556,7 @@ void TryPyramiding(double riskR, bool pyramidAllowed, RegimeState regime)
    bool result = false;
    int retcode = 0;
    int lasterr = 0;
-   result = SendOrderWithRetry(dir, addLots, sl, addTp, "PYR", retcode, lasterr);
+   result = TryOpenByDir(dir, addLots, sl, addTp, "PYR", retcode, lasterr);
 
    if(result)
    {
@@ -3590,8 +3604,9 @@ int OnInit()
       g_rsiEngulfTouchReady = false;
    }
 
+   License_Init();
+   License_Refresh(true);
    EventSetTimer(60);
-   License_Refresh();
 
    return INIT_SUCCEEDED;
 }
@@ -3599,6 +3614,7 @@ int OnInit()
 void OnDeinit(const int reason)
 {
    EventKillTimer();
+   License_Deinit();
    g_rsiEngulfTouch.Deinit();
    g_rsiEngulfTouchReady = false;
    ReleaseIndicatorsCache();
@@ -3606,15 +3622,13 @@ void OnDeinit(const int reason)
 
 void OnTimer()
 {
-   License_Refresh();
+   License_OnTimer();
 }
 
 void OnTick()
 {
    if(g_symbol == "")
       return;
-
-   License_Refresh();
 
    if(InpUseSMCZ3C) SMCZ3C_Update();
 
@@ -3633,7 +3647,7 @@ void OnTick()
 
    if(HasPosition())
    {
-      if(!License_CanManageOpenTrades())
+      if(!CanManageOpenTrades())
          return;
 
       double entryPrice = PositionGetDouble(POSITION_PRICE_OPEN);
@@ -3702,7 +3716,7 @@ void OnTick()
       return;
    }
 
-   if(!License_CanOpenNewTrades())
+   if(!CanOpenNewTrades())
       return;
 
    TradeDir dir;
@@ -3792,7 +3806,7 @@ void OnTick()
 
    int retcode = 0;
    int lasterr = 0;
-   bool sent = SendOrderWithRetry(dir, lots, sl, tp, "ENTRY", retcode, lasterr);
+   bool sent = TryOpenByDir(dir, lots, sl, tp, "ENTRY", retcode, lasterr);
 
    if(sent)
    {

--- a/MQL5/Include/GROK/Core/Config.mqh
+++ b/MQL5/Include/GROK/Core/Config.mqh
@@ -1,0 +1,18 @@
+#pragma once
+#property strict
+
+struct GrokRiskConfig
+{
+   double baseRiskPct;
+   int maxTradesPerDay;
+   double maxDailyDDPct;
+};
+
+inline GrokRiskConfig Grok_DefaultRiskConfig()
+{
+   GrokRiskConfig c;
+   c.baseRiskPct = 0.5;
+   c.maxTradesPerDay = 3;
+   c.maxDailyDDPct = 4.0;
+   return c;
+}

--- a/MQL5/Include/GROK/Core/Utils.mqh
+++ b/MQL5/Include/GROK/Core/Utils.mqh
@@ -1,0 +1,5 @@
+#pragma once
+#property strict
+
+inline double Grok_Clamp(double v,double lo,double hi){ return MathMax(lo,MathMin(hi,v)); }
+inline bool Grok_IsValidPrice(double p){ return (p>0.0 && p<DBL_MAX); }

--- a/MQL5/Include/GROK/LicenseClient.mqh
+++ b/MQL5/Include/GROK/LicenseClient.mqh
@@ -1,0 +1,315 @@
+#pragma once
+#property strict
+
+/*
+Expected API examples:
+VALID:
+{"status":"VALID","expires_at":"2026-03-18T12:00:00.000Z","seats_used":1,"seats_max":2,"grace_seconds":172800,"code":"OK","message":"License valid"}
+EXPIRED:
+{"status":"INVALID","expires_at":"2026-02-10T12:00:00.000Z","seats_used":0,"seats_max":2,"grace_seconds":172800,"code":"EXPIRED","message":"Subscription expired"}
+SEATS_FULL:
+{"status":"INVALID","expires_at":"2026-03-18T12:00:00.000Z","seats_used":0,"seats_max":2,"grace_seconds":172800,"code":"SEATS_FULL","message":"Seats full (max 2 MT5 accounts)"}
+NOT_FOUND:
+{"status":"INVALID","expires_at":null,"seats_used":0,"seats_max":2,"grace_seconds":172800,"code":"NOT_FOUND","message":"License not found"}
+SUSPENDED:
+{"status":"INVALID","expires_at":"2026-03-18T12:00:00.000Z","seats_used":0,"seats_max":2,"grace_seconds":172800,"code":"SUSPENDED","message":"Subscription suspended (payment issue)"}
+*/
+
+extern string InpLicenseKey;
+extern string InpLicenseApiBase;
+extern string InpEaId;
+extern string InpEaVersion;
+extern int    InpVerifyHours;
+extern int    InpGraceHours;
+extern bool   InpAllowManageOpenPositionsWhenInvalid;
+extern bool   InpBypassLicensingInStrategyTester;
+extern bool   InpHardFailIfNoValidEver;
+extern bool   InpShowLicensePanel;
+extern bool   InpLogLicenseToFile;
+
+bool   g_license_ok = false;
+datetime g_last_ok = 0;
+int    g_grace_seconds = 172800;
+string g_last_code = "INIT";
+string g_last_message = "";
+string g_expires_at = "";
+int    g_seats_used = 0;
+int    g_seats_max = 2;
+
+datetime g_license_last_check = 0;
+string g_license_log_file = "Grok3xAI_license.log";
+string g_license_gv_key = "Grok3xAI_LicenseLastOK";
+string g_license_panel_bg = "Grok3xAI_LIC_BG";
+string g_license_panel_text = "Grok3xAI_LIC_TXT";
+
+string JsonEscape(const string s)
+{
+   string out = s;
+   StringReplace(out, "\\", "\\\\");
+   StringReplace(out, "\"", "\\\"");
+   return out;
+}
+
+string JsonGetString(const string json, const string key)
+{
+   string pattern = "\"" + key + "\":\"";
+   int p = StringFind(json, pattern);
+   if(p < 0)
+      return "";
+   p += StringLen(pattern);
+   int e = StringFind(json, "\"", p);
+   if(e < 0)
+      return "";
+   return StringSubstr(json, p, e - p);
+}
+
+long JsonGetInt(const string json, const string key, const long defVal)
+{
+   string pattern = "\"" + key + "\":";
+   int p = StringFind(json, pattern);
+   if(p < 0)
+      return defVal;
+   p += StringLen(pattern);
+   while(p < StringLen(json) && StringGetCharacter(json, p) == ' ')
+      p++;
+   int e = p;
+   while(e < StringLen(json))
+   {
+      ushort c = (ushort)StringGetCharacter(json, e);
+      if((c >= '0' && c <= '9') || c == '-')
+      {
+         e++;
+         continue;
+      }
+      break;
+   }
+   if(e <= p)
+      return defVal;
+   return (long)StringToInteger(StringSubstr(json, p, e - p));
+}
+
+void License_LogDiag(const string reason)
+{
+   string msg = StringFormat("[LICENSE] %s | status=%s code=%s message=%s expires=%s seats=%d/%d last_ok=%s grace=%d",
+                             reason,
+                             (g_license_ok ? "VALID" : "INVALID"),
+                             g_last_code,
+                             g_last_message,
+                             g_expires_at,
+                             g_seats_used,
+                             g_seats_max,
+                             TimeToString(g_last_ok, TIME_DATE | TIME_SECONDS),
+                             g_grace_seconds);
+   Print(msg);
+
+   if(!InpLogLicenseToFile)
+      return;
+
+   int h = FileOpen(g_license_log_file, FILE_READ | FILE_WRITE | FILE_TXT | FILE_ANSI);
+   if(h == INVALID_HANDLE)
+      h = FileOpen(g_license_log_file, FILE_WRITE | FILE_TXT | FILE_ANSI);
+   if(h == INVALID_HANDLE)
+      return;
+   FileSeek(h, 0, SEEK_END);
+   FileWriteString(h, TimeToString(TimeCurrent(), TIME_DATE | TIME_SECONDS) + " " + msg + "\r\n");
+   FileClose(h);
+}
+
+string License_StatusText()
+{
+   if(g_license_ok)
+      return "LICENSE: VALID " + g_last_code;
+
+   datetime now = TimeCurrent();
+   if(g_last_ok > 0 && (now - g_last_ok) <= g_grace_seconds)
+   {
+      int left = (int)(g_grace_seconds - (now - g_last_ok));
+      return "LICENSE: GRACE " + (string)left + "s";
+   }
+   return "LICENSE: INVALID " + g_last_code;
+}
+
+void License_DrawPanel()
+{
+   if(!InpShowLicensePanel)
+      return;
+
+   if(ObjectFind(0, g_license_panel_bg) < 0)
+      ObjectCreate(0, g_license_panel_bg, OBJ_RECTANGLE_LABEL, 0, 0, 0);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_XDISTANCE, 10);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_YDISTANCE, 20);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_XSIZE, 340);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_YSIZE, 64);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_BGCOLOR, clrBlack);
+   ObjectSetInteger(0, g_license_panel_bg, OBJPROP_COLOR, g_license_ok ? clrLime : clrTomato);
+
+   if(ObjectFind(0, g_license_panel_text) < 0)
+      ObjectCreate(0, g_license_panel_text, OBJ_LABEL, 0, 0, 0);
+
+   string txt = License_StatusText() +
+                "\ncode=" + g_last_code + " seats=" + (string)g_seats_used + "/" + (string)g_seats_max +
+                " expires=" + g_expires_at;
+
+   ObjectSetInteger(0, g_license_panel_text, OBJPROP_XDISTANCE, 18);
+   ObjectSetInteger(0, g_license_panel_text, OBJPROP_YDISTANCE, 28);
+   ObjectSetString(0, g_license_panel_text, OBJPROP_TEXT, txt);
+   ObjectSetInteger(0, g_license_panel_text, OBJPROP_COLOR, g_license_ok ? clrLime : clrTomato);
+}
+
+bool License_VerifyOnline()
+{
+   if(MQLInfoInteger(MQL_TESTER) && InpBypassLicensingInStrategyTester)
+   {
+      g_license_ok = true;
+      g_last_code = "TESTER_BYPASS";
+      g_last_message = "Bypass in strategy tester";
+      return true;
+   }
+
+   if(StringLen(InpLicenseKey) < 10)
+   {
+      g_license_ok = false;
+      g_last_code = "NO_KEY";
+      g_last_message = "License key missing";
+      return false;
+   }
+
+   string url = InpLicenseApiBase + "/api/v1/license/verify";
+   long login = (long)AccountInfoInteger(ACCOUNT_LOGIN);
+   string server = AccountInfoString(ACCOUNT_SERVER);
+
+   string body = "{" +
+                 "\"license_key\":\"" + JsonEscape(InpLicenseKey) + "\"," +
+                 "\"account_login\":" + (string)login + "," +
+                 "\"account_server\":\"" + JsonEscape(server) + "\"," +
+                 "\"ea_id\":\"" + JsonEscape(InpEaId) + "\"," +
+                 "\"ea_version\":\"" + JsonEscape(InpEaVersion) + "\"" +
+                 "}";
+
+   char post[];
+   StringToCharArray(body, post, 0, WHOLE_ARRAY, CP_UTF8);
+   int postSize = ArraySize(post);
+   if(postSize > 0 && post[postSize - 1] == 0)
+      postSize--;
+
+   char result[];
+   string headers;
+   string reqHeaders = "Content-Type: application/json\r\n";
+
+   ResetLastError();
+   int res = WebRequest("POST", url, reqHeaders, 8000, post, postSize, result, headers);
+   if(res == -1)
+   {
+      g_last_code = "WEBREQUEST_FAIL";
+      g_last_message = "err=" + (string)GetLastError();
+      return false;
+   }
+
+   string resp = CharArrayToString(result, 0, -1, CP_UTF8);
+   bool ok = (StringFind(resp, "\"status\":\"VALID\"") >= 0);
+
+   g_last_code = JsonGetString(resp, "code");
+   g_last_message = JsonGetString(resp, "message");
+   g_expires_at = JsonGetString(resp, "expires_at");
+   g_seats_used = (int)JsonGetInt(resp, "seats_used", 0);
+   g_seats_max = (int)JsonGetInt(resp, "seats_max", 2);
+   g_grace_seconds = (int)JsonGetInt(resp, "grace_seconds", InpGraceHours * 3600);
+
+   if(ok)
+   {
+      g_license_ok = true;
+      g_last_ok = TimeCurrent();
+      GlobalVariableSet(g_license_gv_key, (double)g_last_ok);
+   }
+   else
+   {
+      g_license_ok = false;
+   }
+   return ok;
+}
+
+void License_Refresh(bool force = false)
+{
+   if(MQLInfoInteger(MQL_TESTER) && InpBypassLicensingInStrategyTester)
+   {
+      g_license_ok = true;
+      g_last_code = "TESTER_BYPASS";
+      return;
+   }
+
+   datetime now = TimeCurrent();
+   int intervalSec = MathMax(1, InpVerifyHours) * 3600;
+   if(!force && g_license_last_check > 0 && (now - g_license_last_check) < intervalSec)
+      return;
+
+   g_license_last_check = now;
+
+   bool okOnline = License_VerifyOnline();
+   if(okOnline)
+   {
+      License_LogDiag("verify_ok");
+      return;
+   }
+
+   if(g_last_ok == 0 && GlobalVariableCheck(g_license_gv_key))
+      g_last_ok = (datetime)GlobalVariableGet(g_license_gv_key);
+
+   if(g_last_ok == 0 && InpHardFailIfNoValidEver)
+   {
+      g_license_ok = false;
+      g_last_code = "NO_VALID_EVER";
+      License_LogDiag("hard_fail_no_valid_ever");
+      return;
+   }
+
+   int graceSec = MathMax(1, InpGraceHours) * 3600;
+   if(g_grace_seconds <= 0)
+      g_grace_seconds = graceSec;
+
+   if(g_last_ok > 0 && (now - g_last_ok) <= g_grace_seconds)
+   {
+      g_license_ok = true;
+      g_last_code = "GRACE";
+      License_LogDiag("grace_continue");
+   }
+   else
+   {
+      g_license_ok = false;
+      if(g_last_code == "")
+         g_last_code = "GRACE_EXCEEDED";
+      License_LogDiag("grace_expired");
+   }
+}
+
+void License_Init()
+{
+   g_grace_seconds = MathMax(1, InpGraceHours) * 3600;
+   g_license_last_check = 0;
+   if(GlobalVariableCheck(g_license_gv_key))
+      g_last_ok = (datetime)GlobalVariableGet(g_license_gv_key);
+   else
+      g_last_ok = 0;
+}
+
+void License_OnTimer()
+{
+   License_Refresh(false);
+   if(InpShowLicensePanel)
+      License_DrawPanel();
+}
+
+bool License_CanOpenNewTrades()
+{
+   return g_license_ok;
+}
+
+bool License_CanManageOpenTrades()
+{
+   return (g_license_ok || InpAllowManageOpenPositionsWhenInvalid);
+}
+
+void License_Deinit()
+{
+   ObjectDelete(0, g_license_panel_bg);
+   ObjectDelete(0, g_license_panel_text);
+}

--- a/MQL5/Include/GROK/Market/Structure.mqh
+++ b/MQL5/Include/GROK/Market/Structure.mqh
@@ -1,0 +1,4 @@
+#pragma once
+#property strict
+
+struct SwingPoint { int shift; double price; bool isHigh; };

--- a/MQL5/Include/GROK/OrderGate.mqh
+++ b/MQL5/Include/GROK/OrderGate.mqh
@@ -1,0 +1,41 @@
+#pragma once
+#property strict
+
+bool License_CanOpenNewTrades();
+bool License_CanManageOpenTrades();
+bool SendOrderCore(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr);
+
+bool CanOpenNewTrades()
+{
+   return License_CanOpenNewTrades();
+}
+
+bool CanManageOpenTrades()
+{
+   return License_CanManageOpenTrades();
+}
+
+bool TryOpenBuy(double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+{
+   if(!CanOpenNewTrades())
+      return false;
+   return SendOrderCore(DIR_LONG, lots, sl, tp, comment, retcode, lasterr);
+}
+
+bool TryOpenSell(double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+{
+   if(!CanOpenNewTrades())
+      return false;
+   return SendOrderCore(DIR_SHORT, lots, sl, tp, comment, retcode, lasterr);
+}
+
+bool TryOpenByDir(TradeDir dir, double lots, double sl, double tp, const string comment, int &retcode, int &lasterr)
+{
+   if(dir == DIR_LONG)
+      return TryOpenBuy(lots, sl, tp, comment, retcode, lasterr);
+   if(dir == DIR_SHORT)
+      return TryOpenSell(lots, sl, tp, comment, retcode, lasterr);
+   retcode = 0;
+   lasterr = 0;
+   return false;
+}

--- a/MQL5/Include/GROK/PatternEngine.mqh
+++ b/MQL5/Include/GROK/PatternEngine.mqh
@@ -1,0 +1,444 @@
+#pragma once
+#property strict
+
+struct PatternStats
+{
+   string pattern_id;
+   string family;
+   int direction; // 1 bull, -1 bear, 0 both
+   double rank;
+   double failure_rate;
+   double target_hit_pct;
+   double avg_move;
+   int sample_size;
+   string notes;
+};
+
+struct PatternSignal
+{
+   bool detected;
+   string pattern_id;
+   string family;
+   int direction;
+   double entry_level;
+   double invalidation_level;
+   double target_level;
+   double quality; // 0..1
+   string notes;
+};
+
+void PE_DefaultStats(PatternStats &s, const string id, const string family, int dir)
+{
+   s.pattern_id = id;
+   s.family = family;
+   s.direction = dir;
+   s.rank = 50;
+   s.failure_rate = 0.5;
+   s.target_hit_pct = 0.5;
+   s.avg_move = 0.0;
+   s.sample_size = 30;
+   s.notes = "default";
+}
+
+bool PE_IsPivotHigh(const string sym, ENUM_TIMEFRAMES tf, int shift, int lr)
+{
+   if(shift < lr + 1)
+      return false;
+   double h = iHigh(sym, tf, shift);
+   for(int i = 1; i <= lr; i++)
+   {
+      if(iHigh(sym, tf, shift - i) >= h) return false;
+      if(iHigh(sym, tf, shift + i) > h) return false;
+   }
+   return true;
+}
+
+bool PE_IsPivotLow(const string sym, ENUM_TIMEFRAMES tf, int shift, int lr)
+{
+   if(shift < lr + 1)
+      return false;
+   double l = iLow(sym, tf, shift);
+   for(int i = 1; i <= lr; i++)
+   {
+      if(iLow(sym, tf, shift - i) <= l) return false;
+      if(iLow(sym, tf, shift + i) < l) return false;
+   }
+   return true;
+}
+
+bool PE_DetectCandles(const string sym, ENUM_TIMEFRAMES tf, double point, double atr, PatternSignal &out)
+{
+   out.detected = false;
+   int s1 = 1, s2 = 2;
+   double h1 = iHigh(sym, tf, s1), l1 = iLow(sym, tf, s1), o1 = iOpen(sym, tf, s1), c1 = iClose(sym, tf, s1);
+   double h2 = iHigh(sym, tf, s2), l2 = iLow(sym, tf, s2), o2 = iOpen(sym, tf, s2), c2 = iClose(sym, tf, s2);
+   double body1 = MathAbs(c1 - o1);
+   double range1 = MathMax(point, h1 - l1);
+   double upW = h1 - MathMax(o1, c1);
+   double dnW = MathMin(o1, c1) - l1;
+
+   if(h1 < h2 && l1 > l2)
+   {
+      out.detected = true;
+      out.pattern_id = "INSIDE_DAY";
+      out.family = "CANDLE";
+      out.direction = (c1 >= o1 ? 1 : -1);
+      out.entry_level = (out.direction > 0 ? h1 : l1);
+      out.invalidation_level = (out.direction > 0 ? l1 : h1);
+      out.target_level = out.entry_level + out.direction * (h1 - l1);
+      out.quality = 0.55;
+      out.notes = "inside";
+      return true;
+   }
+
+   if(h1 > h2 && l1 < l2)
+   {
+      out.detected = true;
+      out.pattern_id = "OUTSIDE_DAY";
+      out.family = "CANDLE";
+      out.direction = (c1 >= o1 ? 1 : -1);
+      out.entry_level = (out.direction > 0 ? h1 : l1);
+      out.invalidation_level = (out.direction > 0 ? l1 : h1);
+      out.target_level = out.entry_level + out.direction * (h1 - l1);
+      out.quality = 0.52;
+      out.notes = "outside";
+      return true;
+   }
+
+   bool bullEng = (c2 < o2 && c1 > o1 && c1 >= o2 && o1 <= c2);
+   bool bearEng = (c2 > o2 && c1 < o1 && c1 <= o2 && o1 >= c2);
+   if(bullEng || bearEng)
+   {
+      out.detected = true;
+      out.pattern_id = bullEng ? "BULL_ENGULF" : "BEAR_ENGULF";
+      out.family = "CANDLE";
+      out.direction = bullEng ? 1 : -1;
+      out.entry_level = (out.direction > 0 ? h1 : l1);
+      out.invalidation_level = (out.direction > 0 ? l1 : h1);
+      out.target_level = out.entry_level + out.direction * (h1 - l1) * 1.2;
+      out.quality = 0.60;
+      out.notes = "engulf";
+      return true;
+   }
+
+   double wickRatio = (body1 > point ? (MathMax(upW, dnW) / body1) : 0.0);
+   if(body1 / range1 <= 0.35 && wickRatio >= 2.0)
+   {
+      bool hammer = (dnW > upW * 1.5);
+      out.detected = true;
+      out.pattern_id = hammer ? "HAMMER" : "SHOOTING_STAR";
+      out.family = "CANDLE";
+      out.direction = hammer ? 1 : -1;
+      out.entry_level = (out.direction > 0 ? h1 : l1);
+      out.invalidation_level = (out.direction > 0 ? l1 : h1);
+      out.target_level = out.entry_level + out.direction * MathMax(range1, atr * 0.8);
+      out.quality = 0.58;
+      out.notes = "pinbar";
+      return true;
+   }
+   return false;
+}
+
+bool PE_DetectRectangle(const string sym, ENUM_TIMEFRAMES tf, int lookback, double point, PatternSignal &out)
+{
+   out.detected = false;
+   int start = MathMax(5, lookback);
+   double hi = -DBL_MAX, lo = DBL_MAX;
+   for(int i = 2; i <= start; i++)
+   {
+      hi = MathMax(hi, iHigh(sym, tf, i));
+      lo = MathMin(lo, iLow(sym, tf, i));
+   }
+   if(hi <= lo)
+      return false;
+   double tol = MathMax(point * 20.0, (hi - lo) * 0.12);
+   int touchesHi = 0, touchesLo = 0;
+   for(int i = 2; i <= start; i++)
+   {
+      if(MathAbs(iHigh(sym, tf, i) - hi) <= tol) touchesHi++;
+      if(MathAbs(iLow(sym, tf, i) - lo) <= tol) touchesLo++;
+   }
+   if(touchesHi < 2 || touchesLo < 2)
+      return false;
+
+   double c1 = iClose(sym, tf, 1);
+   if(c1 > hi + point * 2)
+   {
+      out.detected = true;
+      out.pattern_id = "RECT_BOTTOM";
+      out.family = "CHART";
+      out.direction = 1;
+      out.entry_level = hi;
+      out.invalidation_level = lo;
+      out.target_level = hi + (hi - lo);
+      out.quality = 0.62;
+      out.notes = "rect_up";
+      return true;
+   }
+   if(c1 < lo - point * 2)
+   {
+      out.detected = true;
+      out.pattern_id = "RECT_TOP";
+      out.family = "CHART";
+      out.direction = -1;
+      out.entry_level = lo;
+      out.invalidation_level = hi;
+      out.target_level = lo - (hi - lo);
+      out.quality = 0.62;
+      out.notes = "rect_dn";
+      return true;
+   }
+   return false;
+}
+
+bool PE_DetectDoubleTopBottom(const string sym, ENUM_TIMEFRAMES tf, int lookback, int lr, double point, PatternSignal &out)
+{
+   out.detected = false;
+   int hiShift1 = -1, hiShift2 = -1;
+   int loShift1 = -1, loShift2 = -1;
+   for(int i = lr + 2; i < lookback; i++)
+   {
+      if(hiShift1 < 0 && PE_IsPivotHigh(sym, tf, i, lr)) hiShift1 = i;
+      else if(hiShift1 > 0 && hiShift2 < 0 && PE_IsPivotHigh(sym, tf, i, lr)) { hiShift2 = i; break; }
+   }
+   for(int i = lr + 2; i < lookback; i++)
+   {
+      if(loShift1 < 0 && PE_IsPivotLow(sym, tf, i, lr)) loShift1 = i;
+      else if(loShift1 > 0 && loShift2 < 0 && PE_IsPivotLow(sym, tf, i, lr)) { loShift2 = i; break; }
+   }
+
+   double c1 = iClose(sym, tf, 1);
+   if(hiShift1 > 0 && hiShift2 > 0)
+   {
+      double h1 = iHigh(sym, tf, hiShift1), h2 = iHigh(sym, tf, hiShift2);
+      double tol = MathMax(point * 25.0, MathAbs(h1) * 0.0008);
+      if(MathAbs(h1 - h2) <= tol)
+      {
+         int a = MathMin(hiShift1, hiShift2), b = MathMax(hiShift1, hiShift2);
+         double neck = DBL_MAX;
+         for(int k = a; k <= b; k++) neck = MathMin(neck, iLow(sym, tf, k));
+         if(c1 < neck - point * 2)
+         {
+            out.detected = true;
+            out.pattern_id = "DOUBLE_TOP";
+            out.family = "CHART";
+            out.direction = -1;
+            out.entry_level = neck;
+            out.invalidation_level = MathMax(h1, h2);
+            out.target_level = neck - (MathMax(h1, h2) - neck);
+            out.quality = 0.66;
+            out.notes = "dtop";
+            return true;
+         }
+      }
+   }
+
+   if(loShift1 > 0 && loShift2 > 0)
+   {
+      double l1 = iLow(sym, tf, loShift1), l2 = iLow(sym, tf, loShift2);
+      double tol = MathMax(point * 25.0, MathAbs(l1) * 0.0008);
+      if(MathAbs(l1 - l2) <= tol)
+      {
+         int a = MathMin(loShift1, loShift2), b = MathMax(loShift1, loShift2);
+         double neck = -DBL_MAX;
+         for(int k = a; k <= b; k++) neck = MathMax(neck, iHigh(sym, tf, k));
+         if(c1 > neck + point * 2)
+         {
+            out.detected = true;
+            out.pattern_id = "DOUBLE_BOTTOM";
+            out.family = "CHART";
+            out.direction = 1;
+            out.entry_level = neck;
+            out.invalidation_level = MathMin(l1, l2);
+            out.target_level = neck + (neck - MathMin(l1, l2));
+            out.quality = 0.66;
+            out.notes = "dbot";
+            return true;
+         }
+      }
+   }
+   return false;
+}
+
+bool PE_DetectSimpleTriangle(const string sym, ENUM_TIMEFRAMES tf, int lookback, double point, PatternSignal &out)
+{
+   out.detected = false;
+   int w = MathMax(20, lookback / 2);
+   double hiA = -DBL_MAX, hiB = -DBL_MAX, loA = DBL_MAX, loB = DBL_MAX;
+   for(int i = w; i >= 2; --i)
+   {
+      double h = iHigh(sym, tf, i), l = iLow(sym, tf, i);
+      if(h > hiA) { hiB = hiA; hiA = h; }
+      else if(h > hiB) hiB = h;
+      if(l < loA) { loB = loA; loA = l; }
+      else if(l < loB) loB = l;
+   }
+   if(hiA <= loA || hiB <= 0 || loB <= 0) return false;
+   double topSlope = hiA - hiB;
+   double botSlope = loB - loA;
+   double c1 = iClose(sym, tf, 1);
+
+   if(MathAbs(topSlope) <= point * 20 && botSlope > point * 25)
+   {
+      if(c1 > hiA + point * 2)
+      {
+         out.detected = true;
+         out.pattern_id = "ASC_TRIANGLE";
+         out.family = "CHART";
+         out.direction = 1;
+         out.entry_level = hiA;
+         out.invalidation_level = loA;
+         out.target_level = hiA + (hiA - loA);
+         out.quality = 0.61;
+         out.notes = "asc_tri";
+         return true;
+      }
+   }
+   if(MathAbs(botSlope) <= point * 20 && topSlope > point * 25)
+   {
+      if(c1 < loA - point * 2)
+      {
+         out.detected = true;
+         out.pattern_id = "DESC_TRIANGLE";
+         out.family = "CHART";
+         out.direction = -1;
+         out.entry_level = loA;
+         out.invalidation_level = hiA;
+         out.target_level = loA - (hiA - loA);
+         out.quality = 0.61;
+         out.notes = "desc_tri";
+         return true;
+      }
+   }
+   return false;
+}
+
+bool PE_DetectFlagPennant(const string sym, ENUM_TIMEFRAMES tf, double atr, double point, PatternSignal &out)
+{
+   out.detected = false;
+   double move = iClose(sym, tf, 6) - iClose(sym, tf, 16);
+   double impulse = MathAbs(move);
+   if(impulse < atr * 1.2)
+      return false;
+   double hi = -DBL_MAX, lo = DBL_MAX;
+   for(int i = 2; i <= 6; i++)
+   {
+      hi = MathMax(hi, iHigh(sym, tf, i));
+      lo = MathMin(lo, iLow(sym, tf, i));
+   }
+   if((hi - lo) > impulse * 0.6)
+      return false;
+   double c1 = iClose(sym, tf, 1);
+   int dir = (move > 0 ? 1 : -1);
+   if((dir > 0 && c1 > hi + point * 2) || (dir < 0 && c1 < lo - point * 2))
+   {
+      out.detected = true;
+      out.pattern_id = (MathAbs(iHigh(sym, tf, 2) - iLow(sym, tf, 2)) < (hi - lo) * 0.75) ? "PENNANT" : "FLAG";
+      out.family = "CHART";
+      out.direction = dir;
+      out.entry_level = (dir > 0 ? hi : lo);
+      out.invalidation_level = (dir > 0 ? lo : hi);
+      out.target_level = out.entry_level + dir * impulse;
+      out.quality = 0.63;
+      out.notes = "flag_like";
+      return true;
+   }
+   return false;
+}
+
+PatternSignal PE_DetectBestPattern(const string sym, ENUM_TIMEFRAMES tf, int lookback, int pivotLR, double point, double atr)
+{
+   PatternSignal s, best;
+   best.detected = false;
+   if(PE_DetectDoubleTopBottom(sym, tf, lookback, pivotLR, point, s)) best = s;
+   if(!best.detected && PE_DetectRectangle(sym, tf, lookback, point, s)) best = s;
+   if(!best.detected && PE_DetectSimpleTriangle(sym, tf, lookback, point, s)) best = s;
+   if(!best.detected && PE_DetectFlagPennant(sym, tf, atr, point, s)) best = s;
+   if(!best.detected && PE_DetectCandles(sym, tf, point, atr, s)) best = s;
+   return best;
+}
+
+bool PE_LoadPatternStatsCSV(const string fileName, PatternStats &arr[])
+{
+   ArrayResize(arr, 0);
+   int h = FileOpen(fileName, FILE_READ | FILE_CSV | FILE_ANSI, ';');
+   if(h == INVALID_HANDLE)
+      return false;
+
+   // header
+   if(!FileIsEnding(h))
+   {
+      FileReadString(h); FileReadString(h); FileReadString(h); FileReadString(h);
+      FileReadString(h); FileReadString(h); FileReadString(h); FileReadString(h);
+      FileReadString(h);
+   }
+
+   while(!FileIsEnding(h))
+   {
+      PatternStats s;
+      s.pattern_id = FileReadString(h);
+      if(StringLen(s.pattern_id) == 0)
+      {
+         if(!FileIsEnding(h))
+            FileReadString(h);
+         continue;
+      }
+      s.family = FileReadString(h);
+      s.direction = (int)StringToInteger(FileReadString(h));
+      s.rank = StringToDouble(FileReadString(h));
+      s.failure_rate = StringToDouble(FileReadString(h));
+      s.target_hit_pct = StringToDouble(FileReadString(h));
+      s.avg_move = StringToDouble(FileReadString(h));
+      s.sample_size = (int)StringToInteger(FileReadString(h));
+      s.notes = FileReadString(h);
+
+      int sz = ArraySize(arr);
+      ArrayResize(arr, sz + 1);
+      arr[sz] = s;
+   }
+   FileClose(h);
+   return ArraySize(arr) > 0;
+}
+
+PatternStats PE_GetStatsById(const PatternStats &arr[], const string id, int direction)
+{
+   for(int i = 0; i < ArraySize(arr); i++)
+   {
+      if(arr[i].pattern_id == id)
+      {
+         if(arr[i].direction == 0 || arr[i].direction == direction)
+            return arr[i];
+      }
+   }
+   PatternStats d;
+   PE_DefaultStats(d, id, "UNKNOWN", direction);
+   return d;
+}
+
+double PE_NormalizeAvgMove(double avg_move)
+{
+   if(avg_move <= 0.0) return 0.0;
+   return MathMin(1.0, avg_move / 3.0);
+}
+
+double PE_Clamp01(double v)
+{
+   if(v < 0.0) return 0.0;
+   if(v > 1.0) return 1.0;
+   return v;
+}
+
+double PE_PatternPriorScore(const PatternStats &s, double kRank, double kFail, double kTarget, double kMove)
+{
+   double score = 50.0;
+   score += (50.0 - s.rank) * kRank;
+   score += (1.0 - PE_Clamp01(s.failure_rate)) * kFail;
+   score += PE_Clamp01(s.target_hit_pct) * kTarget;
+   score += PE_NormalizeAvgMove(s.avg_move) * kMove;
+   double n = MathMax(1.0, (double)s.sample_size);
+   double alpha = MathMin(1.0, n / 200.0);
+   score = 50.0 + (score - 50.0) * alpha;
+   if(score < 0.0) score = 0.0;
+   if(score > 100.0) score = 100.0;
+   return score;
+}

--- a/MQL5/Include/GROK/PatternEngine.mqh
+++ b/MQL5/Include/GROK/PatternEngine.mqh
@@ -14,6 +14,29 @@ struct PatternStats
    string notes;
 };
 
+
+struct PatternContextFeatures
+{
+   bool breakoutGap;
+   bool breakoutVolHigh;
+   bool throwbackRisk;
+   bool pullbackRisk;
+   bool patternTall;
+   bool patternWide;
+};
+
+inline double PE_ContextAdjustment(const PatternContextFeatures &f)
+{
+   double adj = 0.0;
+   if(f.breakoutGap) adj += 5.0;
+   if(f.breakoutVolHigh) adj += 4.0;
+   if(f.patternTall) adj += 4.0;
+   if(f.patternWide) adj += 3.0;
+   if(f.throwbackRisk) adj -= 7.0;
+   if(f.pullbackRisk) adj -= 5.0;
+   return adj;
+}
+
 struct PatternSignal
 {
    bool detected;

--- a/MQL5/Include/GROK/PatternScores.mqh
+++ b/MQL5/Include/GROK/PatternScores.mqh
@@ -1,0 +1,208 @@
+#pragma once
+#property strict
+
+enum EPattern50
+{
+   PAT_THREE_LINE_STRIKE = 0,
+   PAT_CONCEALING_BABY_SWALLOW,
+   PAT_ABANDONED_BABY,
+   PAT_MORNING_STAR,
+   PAT_EVENING_STAR,
+   PAT_THREE_WHITE_SOLDIERS,
+   PAT_THREE_BLACK_CROWS,
+   PAT_BULLISH_ENGULFING,
+   PAT_BEARISH_ENGULFING,
+   PAT_KICKING,
+   PAT_PIERCING_LINE,
+   PAT_DARK_CLOUD_COVER,
+   PAT_THREE_INSIDE_UP,
+   PAT_THREE_INSIDE_DOWN,
+   PAT_THREE_OUTSIDE_UP,
+   PAT_THREE_OUTSIDE_DOWN,
+   PAT_INVERTED_HAMMER,
+   PAT_SHOOTING_STAR,
+   PAT_BELT_HOLD_BULLISH,
+   PAT_BELT_HOLD_BEARISH,
+   PAT_HAMMER,
+   PAT_HANGING_MAN,
+   PAT_HARAMI_BULLISH,
+   PAT_HARAMI_BEARISH,
+   PAT_TWEEZER_BOTTOM,
+   PAT_TWEEZER_TOP,
+   PAT_DELIBERATION,
+   PAT_ADVANCE_BLOCK,
+   PAT_LADDER_BOTTOM,
+   PAT_MATCHING_LOW,
+   PAT_DOJI,
+   PAT_LONG_LEGGED_DOJI,
+   PAT_GRAVESTONE_DOJI,
+   PAT_DRAGONFLY_DOJI,
+   PAT_SPINNING_TOP,
+   PAT_TASUKI_GAP,
+   PAT_UPSIDE_GAP_TWO_CROWS,
+   PAT_DOWNSIDE_GAP_THREE_METHODS,
+   PAT_RISING_THREE_METHODS,
+   PAT_FALLING_THREE_METHODS,
+   PAT_HEAD_SHOULDERS,
+   PAT_INVERSE_HEAD_SHOULDERS,
+   PAT_DOUBLE_TOP,
+   PAT_DOUBLE_BOTTOM,
+   PAT_ASCENDING_TRIANGLE,
+   PAT_DESCENDING_TRIANGLE,
+   PAT_SYMMETRICAL_TRIANGLE,
+   PAT_FLAG,
+   PAT_PENNANT,
+   PAT_RECTANGLE_RANGE_BREAKOUT,
+   PAT__COUNT
+};
+
+struct PatternInfo
+{
+   EPattern50 id;
+   string name;
+   int tier;
+   int baseScore;
+   bool isCandles;
+};
+
+static const PatternInfo g_patterns[PAT__COUNT] =
+{
+   {PAT_THREE_LINE_STRIKE, "Three Line Strike", 3, 85, true},
+   {PAT_CONCEALING_BABY_SWALLOW, "Concealing Baby Swallow", 3, 84, true},
+   {PAT_ABANDONED_BABY, "Abandoned Baby", 3, 82, true},
+   {PAT_MORNING_STAR, "Morning Star", 3, 80, true},
+   {PAT_EVENING_STAR, "Evening Star", 3, 80, true},
+   {PAT_THREE_WHITE_SOLDIERS, "Three White Soldiers", 3, 78, true},
+   {PAT_THREE_BLACK_CROWS, "Three Black Crows", 3, 78, true},
+   {PAT_BULLISH_ENGULFING, "Bullish Engulfing", 3, 75, true},
+   {PAT_BEARISH_ENGULFING, "Bearish Engulfing", 3, 75, true},
+   {PAT_KICKING, "Kicking", 3, 75, true},
+
+   {PAT_PIERCING_LINE, "Piercing Line", 2, 70, true},
+   {PAT_DARK_CLOUD_COVER, "Dark Cloud Cover", 2, 70, true},
+   {PAT_THREE_INSIDE_UP, "Three Inside Up", 2, 68, true},
+   {PAT_THREE_INSIDE_DOWN, "Three Inside Down", 2, 68, true},
+   {PAT_THREE_OUTSIDE_UP, "Three Outside Up", 2, 68, true},
+   {PAT_THREE_OUTSIDE_DOWN, "Three Outside Down", 2, 68, true},
+   {PAT_INVERTED_HAMMER, "Inverted Hammer", 2, 65, true},
+   {PAT_SHOOTING_STAR, "Shooting Star", 2, 65, true},
+   {PAT_BELT_HOLD_BULLISH, "Belt Hold Bullish", 2, 66, true},
+   {PAT_BELT_HOLD_BEARISH, "Belt Hold Bearish", 2, 66, true},
+
+   {PAT_HAMMER, "Hammer", 1, 60, true},
+   {PAT_HANGING_MAN, "Hanging Man", 1, 60, true},
+   {PAT_HARAMI_BULLISH, "Harami Bullish", 1, 55, true},
+   {PAT_HARAMI_BEARISH, "Harami Bearish", 1, 55, true},
+   {PAT_TWEEZER_BOTTOM, "Tweezer Bottom", 1, 58, true},
+   {PAT_TWEEZER_TOP, "Tweezer Top", 1, 58, true},
+   {PAT_DELIBERATION, "Deliberation", 1, 58, true},
+   {PAT_ADVANCE_BLOCK, "Advance Block", 1, 58, true},
+   {PAT_LADDER_BOTTOM, "Ladder Bottom", 1, 57, true},
+   {PAT_MATCHING_LOW, "Matching Low", 1, 56, true},
+
+   {PAT_DOJI, "Doji", 0, 35, true},
+   {PAT_LONG_LEGGED_DOJI, "Long-Legged Doji", 0, 38, true},
+   {PAT_GRAVESTONE_DOJI, "Gravestone Doji", 0, 40, true},
+   {PAT_DRAGONFLY_DOJI, "Dragonfly Doji", 0, 40, true},
+   {PAT_SPINNING_TOP, "Spinning Top", 0, 37, true},
+   {PAT_TASUKI_GAP, "Tasuki Gap", 0, 45, true},
+   {PAT_UPSIDE_GAP_TWO_CROWS, "Upside Gap Two Crows", 0, 48, true},
+   {PAT_DOWNSIDE_GAP_THREE_METHODS, "Downside Gap Three Methods", 0, 50, true},
+   {PAT_RISING_THREE_METHODS, "Rising Three Methods", 0, 52, true},
+   {PAT_FALLING_THREE_METHODS, "Falling Three Methods", 0, 52, true},
+
+   {PAT_HEAD_SHOULDERS, "Head & Shoulders", 2, 72, false},
+   {PAT_INVERSE_HEAD_SHOULDERS, "Inverse Head & Shoulders", 2, 72, false},
+   {PAT_DOUBLE_TOP, "Double Top", 2, 70, false},
+   {PAT_DOUBLE_BOTTOM, "Double Bottom", 2, 70, false},
+   {PAT_ASCENDING_TRIANGLE, "Ascending Triangle", 2, 68, false},
+   {PAT_DESCENDING_TRIANGLE, "Descending Triangle", 2, 68, false},
+   {PAT_SYMMETRICAL_TRIANGLE, "Symmetrical Triangle", 1, 64, false},
+   {PAT_FLAG, "Flag", 1, 66, false},
+   {PAT_PENNANT, "Pennant", 1, 66, false},
+   {PAT_RECTANGLE_RANGE_BREAKOUT, "Rectangle Range Breakout", 1, 62, false}
+};
+
+int GetPatternScore(EPattern50 pat)
+{
+   int i = (int)pat;
+   if(i < 0 || i >= PAT__COUNT)
+      return 0;
+   return g_patterns[i].baseScore;
+}
+
+string GetPatternName(EPattern50 pat)
+{
+   int i = (int)pat;
+   if(i < 0 || i >= PAT__COUNT)
+      return "UNKNOWN";
+   return g_patterns[i].name;
+}
+
+struct InstFeatures
+{
+   bool htfTrendAligned;
+   bool bosOrMss;
+   bool liquiditySweep;
+   bool displacement;
+   bool poiTouched;
+   bool breakoutRetest;
+   bool sessionNY;
+   bool volumeSpike;
+   bool premiumDiscountOK;
+   bool avoidHighLow;
+   bool spreadOK;
+   bool atrOK;
+};
+
+struct InstWeights
+{
+   int wTrend, wBOS, wSweep, wDisp, wPOI, wRetest, wNY, wVol, wPD, wAvoidHL, wSpreadOK, wATROK;
+};
+
+InstWeights GetXauScalpPresetWeights()
+{
+   InstWeights w;
+   w.wTrend = 10;
+   w.wBOS = 10;
+   w.wSweep = 8;
+   w.wDisp = 8;
+   w.wPOI = 7;
+   w.wRetest = 7;
+   w.wNY = 5;
+   w.wVol = 5;
+   w.wPD = 5;
+   w.wAvoidHL = 5;
+   w.wSpreadOK = 5;
+   w.wATROK = 5;
+   return w;
+}
+
+int ComputeInstitutionalScore(int patternScore, const InstFeatures &f, const InstWeights &w)
+{
+   int score = patternScore;
+   if(f.htfTrendAligned) score += w.wTrend;
+   if(f.bosOrMss) score += w.wBOS;
+   if(f.liquiditySweep) score += w.wSweep;
+   if(f.displacement) score += w.wDisp;
+   if(f.poiTouched) score += w.wPOI;
+   if(f.breakoutRetest) score += w.wRetest;
+   if(f.sessionNY) score += w.wNY;
+   if(f.volumeSpike) score += w.wVol;
+   if(f.premiumDiscountOK) score += w.wPD;
+   if(f.avoidHighLow) score += w.wAvoidHL;
+   if(f.spreadOK) score += w.wSpreadOK;
+   if(f.atrOK) score += w.wATROK;
+
+   if(score < 0) score = 0;
+   if(score > 150) score = 150;
+   return score;
+}
+
+double ScoreToRiskMultiplier(int totalScore)
+{
+   if(totalScore < 60) return 0.0;
+   if(totalScore < 80) return 0.5;
+   if(totalScore < 100) return 1.0;
+   return 1.5;
+}

--- a/MQL5/Include/GROK/Patterns/InstitutionalPA.mqh
+++ b/MQL5/Include/GROK/Patterns/InstitutionalPA.mqh
@@ -1,0 +1,3 @@
+#pragma once
+#property strict
+#include <GROK/PatternEngine.mqh>

--- a/MQL5/Include/GROK/SMC/POI.mqh
+++ b/MQL5/Include/GROK/SMC/POI.mqh
@@ -1,0 +1,4 @@
+#pragma once
+#property strict
+
+struct POIZone { double top; double bottom; int dir; bool valid; };

--- a/MQL5/Include/GROK/Stats/ProbabilityEngine.mqh
+++ b/MQL5/Include/GROK/Stats/ProbabilityEngine.mqh
@@ -1,0 +1,4 @@
+#pragma once
+#property strict
+
+inline double Prob_ToRiskScale(double score){ if(score<70) return 0.6; if(score<80) return 0.8; if(score<90) return 1.0; return 1.2; }

--- a/MQL5/Include/GROK/Trade/Execution.mqh
+++ b/MQL5/Include/GROK/Trade/Execution.mqh
@@ -1,0 +1,4 @@
+#pragma once
+#property strict
+
+struct ExecutionDecision { bool allow; string reason; double score; };

--- a/Strategy_RSIEngulfTouch.mqh
+++ b/Strategy_RSIEngulfTouch.mqh
@@ -1,0 +1,484 @@
+#ifndef __STRATEGY_RSI_ENGULF_TOUCH_MQH__
+#define __STRATEGY_RSI_ENGULF_TOUCH_MQH__
+
+#include <Trade/Trade.mqh>
+
+enum RSITrendMode
+{
+   TRENDMODE_DISABLED = 0,
+   TRENDMODE_DIRECTIONAL_FILTER_ONLY = 1,
+   TRENDMODE_RUNNER_UPGRADE = 2
+};
+
+enum SigState
+{
+   SIG_NONE = 0,
+   SIG_LONG_ACTIVE = 1,
+   SIG_SHORT_ACTIVE = 2,
+   SIG_LONG_TREND = 3,
+   SIG_SHORT_TREND = 4
+};
+
+// Inputs declared in main EA, consumed here via extern.
+extern bool            Enable_RSIEngulfTouch;
+extern int             RSI_Length;
+extern double          RSI_OB;
+extern double          RSI_OS;
+extern double          Lots;
+extern double          PipSize;
+extern double          SL_Pips;
+extern double          TP1_Pips;
+extern double          TP2_Pips;
+extern double          MaxSpreadPips;
+extern bool            OneSetPerBar;
+extern int             CooldownSeconds;
+extern long            MagicBase;
+extern ENUM_TIMEFRAMES SignalTF;
+extern double          TrendThresholdMultiplier;
+extern RSITrendMode    TrendMode;
+
+class RSIEngulfTouchStrategy
+{
+public:
+   RSIEngulfTouchStrategy()
+   {
+      m_symbol = "";
+      m_tf = PERIOD_CURRENT;
+      m_rsiHandle = INVALID_HANDLE;
+      m_lastBarTime = 0;
+      m_lastTradeTime = 0;
+      m_lastAsk = 0.0;
+      m_lastBid = 0.0;
+      m_readyCross = false;
+      m_state = SIG_NONE;
+      m_stateStartTime = 0;
+   }
+
+   bool Init(string symbol, ENUM_TIMEFRAMES tf)
+   {
+      m_symbol = symbol;
+      m_tf = tf;
+      m_lastBarTime = 0;
+      m_lastTradeTime = 0;
+      m_lastAsk = 0.0;
+      m_lastBid = 0.0;
+      m_readyCross = false;
+      m_state = SIG_NONE;
+      m_stateStartTime = 0;
+
+      if(m_rsiHandle != INVALID_HANDLE)
+         IndicatorRelease(m_rsiHandle);
+
+      m_rsiHandle = iRSI(m_symbol, m_tf, RSI_Length, PRICE_CLOSE);
+      if(m_rsiHandle == INVALID_HANDLE)
+      {
+         Print("[RSIEngulfTouch] Init failed: iRSI handle invalid. err=", GetLastError());
+         return false;
+      }
+
+      long marginMode = AccountInfoInteger(ACCOUNT_MARGIN_MODE);
+      if(marginMode != ACCOUNT_MARGIN_MODE_RETAIL_HEDGING)
+         Print("[RSIEngulfTouch] Warning: account is not hedging mode; dual-position behavior may be limited.");
+
+      return true;
+   }
+
+   void Deinit()
+   {
+      if(m_rsiHandle != INVALID_HANDLE)
+      {
+         IndicatorRelease(m_rsiHandle);
+         m_rsiHandle = INVALID_HANDLE;
+      }
+   }
+
+   void OnTick()
+   {
+      if(!Enable_RSIEngulfTouch || m_rsiHandle == INVALID_HANDLE)
+         return;
+
+      MqlTick tick;
+      if(!SymbolInfoTick(m_symbol, tick))
+         return;
+
+      double ask = tick.ask;
+      double bid = tick.bid;
+      if(ask <= 0.0 || bid <= 0.0)
+         return;
+
+      double rsiCur = 0.0;
+      double rsiPrev = 0.0;
+      if(!GetRSI(0, rsiCur) || !GetRSI(1, rsiPrev))
+         return;
+
+      UpdateTrendState(rsiCur, rsiPrev);
+      if(TrendMode == TRENDMODE_RUNNER_UPGRADE)
+         ManageRunnerPositions(ask, bid);
+
+      if(!m_readyCross)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         m_readyCross = true;
+         return;
+      }
+
+      if(SpreadInPips(ask, bid) > MaxSpreadPips)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      datetime bar0 = iTime(m_symbol, m_tf, 0);
+      if(bar0 <= 0)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      double prevOpen = iOpen(m_symbol, m_tf, 1);
+      double prevClose = iClose(m_symbol, m_tf, 1);
+      if(prevOpen <= 0.0 || prevClose <= 0.0)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      bool prevRed = (prevClose < prevOpen);
+      bool prevGreen = (prevClose > prevOpen);
+
+      bool rsiOS_now_or_prev = (rsiCur <= RSI_OS) || (rsiPrev <= RSI_OS);
+      bool rsiOB_now_or_prev = (rsiCur >= RSI_OB) || (rsiPrev >= RSI_OB);
+
+      bool crossUp = (m_lastAsk <= prevOpen) && (ask > prevOpen);
+      bool crossDown = (m_lastBid >= prevOpen) && (bid < prevOpen);
+
+      bool rawLongSignal = rsiOS_now_or_prev && prevRed && crossUp;
+      bool rawShortSignal = rsiOB_now_or_prev && prevGreen && crossDown;
+
+      if(rawLongSignal)
+         SetState(SIG_LONG_ACTIVE, TimeCurrent());
+      else if(rawShortSignal)
+         SetState(SIG_SHORT_ACTIVE, TimeCurrent());
+
+      bool longSignal = rawLongSignal;
+      bool shortSignal = rawShortSignal;
+      if(TrendMode == TRENDMODE_DIRECTIONAL_FILTER_ONLY)
+      {
+         if(m_state == SIG_LONG_TREND)
+            shortSignal = false;
+         else if(m_state == SIG_SHORT_TREND)
+            longSignal = false;
+      }
+
+      if(CountMyPositions() > 0)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      if(OneSetPerBar && m_lastBarTime == bar0)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      datetime nowTs = TimeCurrent();
+      if(m_lastTradeTime > 0 && (nowTs - m_lastTradeTime) < CooldownSeconds)
+      {
+         m_lastAsk = ask;
+         m_lastBid = bid;
+         return;
+      }
+
+      bool entered = false;
+      bool isBuy = false;
+      if(longSignal)
+      {
+         isBuy = true;
+         entered = OpenTwoPositions(true, ask, bid);
+      }
+      else if(shortSignal)
+      {
+         isBuy = false;
+         entered = OpenTwoPositions(false, ask, bid);
+      }
+
+      if(entered)
+      {
+         m_lastBarTime = bar0;
+         m_lastTradeTime = nowTs;
+         Print("[RSIEngulfTouch] ENTRY symbol=", m_symbol,
+               " pipSize=", DoubleToString(PipSize, 5),
+               " spreadPips=", DoubleToString(SpreadInPips(ask, bid), 2),
+               " prev_open=", DoubleToString(prevOpen, (int)SymbolInfoInteger(m_symbol, SYMBOL_DIGITS)),
+               " rsi_cur=", DoubleToString(rsiCur, 2),
+               " rsi_prev=", DoubleToString(rsiPrev, 2),
+               " side=", (isBuy ? "BUY" : "SELL"),
+               " state=", (int)m_state);
+      }
+
+      m_lastAsk = ask;
+      m_lastBid = bid;
+   }
+
+private:
+   string m_symbol;
+   ENUM_TIMEFRAMES m_tf;
+   int m_rsiHandle;
+   datetime m_lastBarTime;
+   datetime m_lastTradeTime;
+   double m_lastAsk;
+   double m_lastBid;
+   bool m_readyCross;
+   SigState m_state;
+   datetime m_stateStartTime;
+   CTrade m_trade;
+
+   void SetState(SigState newState, datetime startTs)
+   {
+      if(newState == SIG_NONE)
+      {
+         m_state = SIG_NONE;
+         m_stateStartTime = 0;
+         return;
+      }
+      m_state = newState;
+      m_stateStartTime = startTs;
+   }
+
+   double PipsToPrice(double pips) const
+   {
+      return pips * PipSize;
+   }
+
+   double SpreadInPips(double ask, double bid) const
+   {
+      if(PipSize <= 0.0)
+         return 0.0;
+      return (ask - bid) / PipSize;
+   }
+
+   bool GetRSI(int shift, double &value)
+   {
+      double buf[1];
+      int copied = CopyBuffer(m_rsiHandle, 0, shift, 1, buf);
+      if(copied < 1)
+         return false;
+      value = buf[0];
+      return true;
+   }
+
+   void UpdateTrendState(double rsiCur, double rsiPrev)
+   {
+      bool longState = (m_state == SIG_LONG_ACTIVE || m_state == SIG_LONG_TREND);
+      bool shortState = (m_state == SIG_SHORT_ACTIVE || m_state == SIG_SHORT_TREND);
+
+      if(longState && (rsiCur < 50.0 && rsiPrev >= 50.0))
+      {
+         SetState(SIG_NONE, 0);
+         return;
+      }
+      if(shortState && (rsiCur > 50.0 && rsiPrev <= 50.0))
+      {
+         SetState(SIG_NONE, 0);
+         return;
+      }
+
+      if(TrendMode == TRENDMODE_DISABLED || m_stateStartTime <= 0)
+         return;
+
+      int tfSec = PeriodSeconds(m_tf);
+      if(tfSec <= 0)
+         return;
+
+      double threshold = TrendThresholdMultiplier * (double)tfSec;
+      double age = (double)(TimeCurrent() - m_stateStartTime);
+      if(age <= threshold)
+         return;
+
+      if(m_state == SIG_LONG_ACTIVE)
+         m_state = SIG_LONG_TREND;
+      else if(m_state == SIG_SHORT_ACTIVE)
+         m_state = SIG_SHORT_TREND;
+   }
+
+   int CountMyPositions() const
+   {
+      int count = 0;
+      int total = PositionsTotal();
+      for(int i = 0; i < total; i++)
+      {
+         if(!PositionSelectByIndex(i))
+            continue;
+
+         string sym = PositionGetString(POSITION_SYMBOL);
+         long magic = PositionGetInteger(POSITION_MAGIC);
+         if(sym == m_symbol && (magic == MagicBase || magic == (MagicBase + 1)))
+            count++;
+      }
+      return count;
+   }
+
+   double NormalizeLots(double lots) const
+   {
+      double step = SymbolInfoDouble(m_symbol, SYMBOL_VOLUME_STEP);
+      double minLot = SymbolInfoDouble(m_symbol, SYMBOL_VOLUME_MIN);
+      double maxLot = SymbolInfoDouble(m_symbol, SYMBOL_VOLUME_MAX);
+      if(step <= 0.0 || minLot <= 0.0 || maxLot <= 0.0)
+         return 0.0;
+
+      double v = MathMax(minLot, MathMin(maxLot, lots));
+      v = MathFloor(v / step) * step;
+
+      int decimals = 0;
+      double scaled = step;
+      while(decimals < 8 && MathAbs(scaled - MathRound(scaled)) > 1e-8)
+      {
+         scaled *= 10.0;
+         decimals++;
+      }
+      return NormalizeDouble(v, decimals);
+   }
+
+   bool IsTradeAllowedOnSymbol() const
+   {
+      long mode = SymbolInfoInteger(m_symbol, SYMBOL_TRADE_MODE);
+      return (mode != SYMBOL_TRADE_MODE_DISABLED && mode != SYMBOL_TRADE_MODE_CLOSEONLY);
+   }
+
+   bool OpenOne(bool isBuy, long magic, double lots, double sl, double tp)
+   {
+      m_trade.SetExpertMagicNumber((ulong)magic);
+      bool ok = false;
+      if(isBuy)
+         ok = m_trade.Buy(lots, m_symbol, 0.0, sl, tp, "RSIEngulfTouch");
+      else
+         ok = m_trade.Sell(lots, m_symbol, 0.0, sl, tp, "RSIEngulfTouch");
+
+      if(!ok)
+      {
+         Print("[RSIEngulfTouch] order failed magic=", magic,
+               " retcode=", m_trade.ResultRetcode(),
+               " err=", GetLastError());
+      }
+      return ok;
+   }
+
+   void ClosePositionByMagic(long magic)
+   {
+      int total = PositionsTotal();
+      for(int i = total - 1; i >= 0; i--)
+      {
+         if(!PositionSelectByIndex(i))
+            continue;
+         string sym = PositionGetString(POSITION_SYMBOL);
+         long mg = PositionGetInteger(POSITION_MAGIC);
+         if(sym != m_symbol || mg != magic)
+            continue;
+         ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+         m_trade.PositionClose(ticket);
+      }
+   }
+
+   bool OpenTwoPositions(bool isBuy, double ask, double bid)
+   {
+      if(Lots <= 0.0 || PipSize <= 0.0 || !IsTradeAllowedOnSymbol())
+         return false;
+
+      double lots = NormalizeLots(Lots);
+      if(lots <= 0.0)
+         return false;
+
+      double ref = isBuy ? ask : bid;
+      int digits = (int)SymbolInfoInteger(m_symbol, SYMBOL_DIGITS);
+
+      double slDist = PipsToPrice(SL_Pips);
+      double tp1Dist = PipsToPrice(TP1_Pips);
+      double tp2Dist = PipsToPrice(TP2_Pips);
+
+      double sl = isBuy ? (ref - slDist) : (ref + slDist);
+      double tp1 = isBuy ? (ref + tp1Dist) : (ref - tp1Dist);
+      double tp2 = isBuy ? (ref + tp2Dist) : (ref - tp2Dist);
+
+      bool useRunner = (TrendMode == TRENDMODE_RUNNER_UPGRADE) &&
+                       (m_state == SIG_LONG_TREND || m_state == SIG_SHORT_TREND);
+
+      sl = NormalizeDouble(sl, digits);
+      tp1 = NormalizeDouble(tp1, digits);
+      if(!useRunner)
+         tp2 = NormalizeDouble(tp2, digits);
+      else
+         tp2 = 0.0;
+
+      bool ok1 = OpenOne(isBuy, MagicBase, lots, sl, tp1);
+      bool ok2 = OpenOne(isBuy, MagicBase + 1, lots, sl, tp2);
+
+      if(ok1 && !ok2)
+         ClosePositionByMagic(MagicBase);
+      else if(!ok1 && ok2)
+         ClosePositionByMagic(MagicBase + 1);
+
+      return (ok1 && ok2);
+   }
+
+   void ManageRunnerPositions(double ask, double bid)
+   {
+      if(!(m_state == SIG_LONG_TREND || m_state == SIG_SHORT_TREND) || PipSize <= 0.0)
+         return;
+
+      int total = PositionsTotal();
+      for(int i = 0; i < total; i++)
+      {
+         if(!PositionSelectByIndex(i))
+            continue;
+
+         string sym = PositionGetString(POSITION_SYMBOL);
+         long magic = PositionGetInteger(POSITION_MAGIC);
+         if(sym != m_symbol || magic != (MagicBase + 1))
+            continue;
+
+         int type = (int)PositionGetInteger(POSITION_TYPE);
+         double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+         double sl = PositionGetDouble(POSITION_SL);
+         double tp = PositionGetDouble(POSITION_TP);
+         ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+
+         double price = (type == POSITION_TYPE_BUY) ? bid : ask;
+         double profitPips = (type == POSITION_TYPE_BUY) ? ((price - entry) / PipSize)
+                                                         : ((entry - price) / PipSize);
+
+         double beTrigger = TP1_Pips;
+         double trailDistPips = MathMax(1.0, TP1_Pips * 0.5);
+         int digits = (int)SymbolInfoInteger(m_symbol, SYMBOL_DIGITS);
+
+         if(profitPips < beTrigger)
+            continue;
+
+         double newSl = entry;
+         if(type == POSITION_TYPE_BUY)
+         {
+            double tr = price - PipsToPrice(trailDistPips);
+            if(tr > newSl)
+               newSl = tr;
+            if(newSl > sl + 0.1 * PipSize)
+               m_trade.PositionModify(ticket, NormalizeDouble(newSl, digits), tp);
+         }
+         else
+         {
+            double tr = price + PipsToPrice(trailDistPips);
+            if(tr < newSl)
+               newSl = tr;
+            if(sl <= 0.0 || newSl < sl - 0.1 * PipSize)
+               m_trade.PositionModify(ticket, NormalizeDouble(newSl, digits), tp);
+         }
+      }
+   }
+};
+
+#endif

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: licensing
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  server-api:
+    build: ./server-api
+    depends_on:
+      - postgres
+    env_file:
+      - ./server-api/.env
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/licensing?schema=public
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./webapp:/webapp:ro
+
+  telegram-bot:
+    build: ./telegram-bot
+    depends_on:
+      - server-api
+    env_file:
+      - ./server-api/.env
+    environment:
+      WEBAPP_URL: ${WEBAPP_URL:-http://localhost:8080/webapp}
+      BOT_ENV_FILE: /app/../server-api/.env
+
+volumes:
+  pgdata:

--- a/mql5/LicenseClient.mqh
+++ b/mql5/LicenseClient.mqh
@@ -1,0 +1,175 @@
+#pragma once
+#property strict
+
+input string InpLicenseKey = "";
+input string InpLicenseApiBase = "https://YOUR_DOMAIN_HERE";
+input int    InpVerifyHours = 6;
+input bool   InpAllowManageOpenPositionsWhenInvalid = true;
+input bool   InpLicenseLog = true;
+
+static bool   g_license_ok = false;
+static datetime g_last_ok = 0;
+static datetime g_last_check = 0;
+static int    g_grace_seconds = 172800;
+static string g_last_code = "";
+static string g_last_message = "";
+static string g_last_expires = "";
+
+static void LicLog(const string s)
+{
+  if(InpLicenseLog) Print("[LICENSE] ", s);
+}
+
+static string JsonEscape(const string s)
+{
+  string out = s;
+  StringReplace(out, "\\", "\\\\");
+  StringReplace(out, "\"", "\\\"");
+  return out;
+}
+
+static string JsonGetString(const string json, const string key)
+{
+  string pattern = "\"" + key + "\":\"";
+  int p = StringFind(json, pattern);
+  if(p < 0) return "";
+  p += StringLen(pattern);
+  int e = StringFind(json, "\"", p);
+  if(e < 0) return "";
+  return StringSubstr(json, p, e - p);
+}
+
+static long JsonGetInt(const string json, const string key, const long defVal)
+{
+  string pattern = "\"" + key + "\":";
+  int p = StringFind(json, pattern);
+  if(p < 0) return defVal;
+  p += StringLen(pattern);
+
+  while(p < StringLen(json) && (StringGetCharacter(json, p) == ' ')) p++;
+
+  int e = p;
+  while(e < StringLen(json))
+  {
+    ushort c = (ushort)StringGetCharacter(json, e);
+    if((c >= '0' && c <= '9') || c == '-') { e++; continue; }
+    break;
+  }
+  if(e <= p) return defVal;
+
+  string num = StringSubstr(json, p, e - p);
+  return (long)StringToInteger(num);
+}
+
+static bool JsonHasStatusValid(const string json)
+{
+  return (StringFind(json, "\"status\":\"VALID\"") >= 0);
+}
+
+bool License_VerifyOnline()
+{
+  if(StringLen(InpLicenseKey) < 10)
+  {
+    g_license_ok = false;
+    g_last_code = "NO_KEY";
+    g_last_message = "License key missing";
+    return false;
+  }
+
+  string url = InpLicenseApiBase + "/api/v1/license/verify";
+
+  long login = (long)AccountInfoInteger(ACCOUNT_LOGIN);
+  string server = AccountInfoString(ACCOUNT_SERVER);
+
+  string body =
+    "{"
+    "\"license_key\":\"" + JsonEscape(InpLicenseKey) + "\"," 
+    "\"account_login\":" + (string)login + ","
+    "\"account_server\":\"" + JsonEscape(server) + "\"," 
+    "\"ea_id\":\"MarketKiller\"," 
+    "\"ea_version\":\"3.13\""
+    "}";
+
+  char post[];
+  StringToCharArray(body, post, 0, WHOLE_ARRAY, CP_UTF8);
+
+  int postSize = ArraySize(post);
+  if(postSize > 0 && post[postSize - 1] == 0) postSize--;
+
+  char result[];
+  string headers;
+  ResetLastError();
+
+  int timeoutMs = 8000;
+  string reqHeaders = "Content-Type: application/json\r\n";
+
+  int res = WebRequest("POST", url, reqHeaders, timeoutMs, post, postSize, result, headers);
+
+  if(res == -1)
+  {
+    int err = GetLastError();
+    LicLog("WebRequest failed. err=" + (string)err + " (using grace if available)");
+    return false;
+  }
+
+  string resp = CharArrayToString(result, 0, -1, CP_UTF8);
+
+  bool ok = JsonHasStatusValid(resp);
+
+  g_grace_seconds = (int)JsonGetInt(resp, "grace_seconds", 172800);
+  g_last_code = JsonGetString(resp, "code");
+  g_last_message = JsonGetString(resp, "message");
+  g_last_expires = JsonGetString(resp, "expires_at");
+
+  if(ok)
+  {
+    g_license_ok = true;
+    g_last_ok = TimeCurrent();
+    LicLog("VALID. code=" + g_last_code + " expires_at=" + g_last_expires);
+    return true;
+  }
+  else
+  {
+    g_license_ok = false;
+    LicLog("INVALID. code=" + g_last_code + " msg=" + g_last_message);
+    return false;
+  }
+}
+
+void License_Refresh()
+{
+  datetime now = TimeCurrent();
+
+  int interval = MathMax(1, InpVerifyHours) * 3600;
+  if(g_last_check != 0 && (now - g_last_check) < interval) return;
+
+  g_last_check = now;
+
+  bool onlineOk = License_VerifyOnline();
+  if(onlineOk) return;
+
+  if(g_last_ok > 0 && (now - g_last_ok) <= g_grace_seconds)
+  {
+    g_license_ok = true;
+    LicLog("API unreachable but within grace. seconds_left=" + (string)(g_grace_seconds - (now - g_last_ok)));
+  }
+  else
+  {
+    g_license_ok = false;
+    LicLog("Grace exceeded. Blocking new trades.");
+  }
+}
+
+bool License_CanOpenNewTrades()
+{
+  return g_license_ok;
+}
+
+bool License_CanManageOpenTrades()
+{
+  return (g_license_ok || InpAllowManageOpenPositionsWhenInvalid);
+}
+
+string License_LastCode() { return g_last_code; }
+string License_LastMessage() { return g_last_message; }
+string License_LastExpiresAt() { return g_last_expires; }

--- a/mql5/README_MQL5.md
+++ b/mql5/README_MQL5.md
@@ -1,0 +1,21 @@
+# MT5 License Client Integration
+
+## Install
+Copy `mql5/LicenseClient.mqh` into your include path and include from EA.
+
+## MT5 WebRequest whitelist
+Tools -> Options -> Expert Advisors -> Allow WebRequest
+Add your tunnel URL, e.g.:
+`https://xxxx.ngrok-free.app`
+
+## EA hooks
+- OnInit: `EventSetTimer(60); License_Refresh();`
+- OnTimer: `License_Refresh();`
+- OnDeinit: `EventKillTimer();`
+- Before new entries: `if(!License_CanOpenNewTrades()) return;`
+- For management path: `if(!License_CanManageOpenTrades()) return;`
+
+## Behavior
+- Verify only on startup + periodic interval (`InpVerifyHours`, default 6h)
+- Grace period default 48h if API unreachable
+- When grace expires, block only new openings

--- a/mql5/pattern_stats_example.csv
+++ b/mql5/pattern_stats_example.csv
@@ -1,0 +1,15 @@
+pattern_id;family;direction;rank;failure_rate;target_hit_pct;avg_move;sample_size;notes
+RECT_BOTTOM;CHART;1;23;0.28;0.64;1.70;420;bulkowski_like
+RECT_TOP;CHART;-1;27;0.31;0.61;1.55;390;bulkowski_like
+INSIDE_DAY;CANDLE;0;48;0.46;0.53;0.80;980;neutral
+OUTSIDE_DAY;CANDLE;0;45;0.43;0.56;0.95;760;neutral
+BULL_ENGULF;CANDLE;1;38;0.37;0.59;1.10;1150;bull engulf
+BEAR_ENGULF;CANDLE;-1;40;0.39;0.57;1.05;1090;bear engulf
+HAMMER;CANDLE;1;42;0.41;0.56;1.00;840;pinbar bull
+SHOOTING_STAR;CANDLE;-1;41;0.40;0.56;1.00;800;pinbar bear
+DOUBLE_BOTTOM;CHART;1;21;0.27;0.65;1.85;610;classic reversal
+DOUBLE_TOP;CHART;-1;22;0.29;0.63;1.78;600;classic reversal
+ASC_TRIANGLE;CHART;1;26;0.32;0.60;1.45;510;continuation
+DESC_TRIANGLE;CHART;-1;28;0.34;0.58;1.42;500;continuation
+FLAG;CHART;0;19;0.24;0.68;2.10;720;strong continuation
+PENNANT;CHART;0;24;0.30;0.62;1.65;530;continuation

--- a/server-api/.env.example
+++ b/server-api/.env.example
@@ -1,0 +1,16 @@
+PORT=8080
+BASE_URL=http://localhost:8080
+NODE_ENV=development
+
+DATABASE_URL=postgresql://postgres:postgres@db:5432/licensing?schema=public
+
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+PRICE_ID_PRO_199=price_xxx
+
+ADMIN_API_KEY=change_me_super_secret
+BOT_TOKEN=change_me_bot_token
+DEV_BYPASS_INITDATA=true
+
+RL_PER_LICENSE_PER_MIN=30
+RL_PER_IP_PER_MIN=60

--- a/server-api/Dockerfile
+++ b/server-api/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run prisma:generate
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/package.json ./package.json
+EXPOSE 8080
+CMD ["sh","-c","npx prisma migrate deploy && node dist/index.js"]

--- a/server-api/README.md
+++ b/server-api/README.md
@@ -1,0 +1,55 @@
+# EA Licensing Server API + Telegram WebApp auth
+
+## Features
+- Stripe-ready licensing backend (optional in local dev)
+- Max 2 seats per license (bind by MT5 login+server)
+- Verify endpoint for EA with bind-on-first-use
+- Admin unbind endpoint
+- WebApp read-only status endpoint protected by Telegram initData signature
+- DEV bypass for initData via `DEV_BYPASS_INITDATA=true`
+
+## Setup
+1. Copy env:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit secrets (`ADMIN_API_KEY`, `BOT_TOKEN`, Stripe vars optional for now).
+3. Start stack from repo root:
+   ```bash
+   docker compose up --build
+   ```
+4. Seed a license:
+   ```bash
+   docker compose exec server-api npm run seed
+   ```
+
+## ngrok local tunnel
+```bash
+ngrok http 8080
+```
+Use the HTTPS URL as:
+- Telegram WebApp URL: `https://xxxx.ngrok-free.app/webapp`
+- MT5 `InpLicenseApiBase`: `https://xxxx.ngrok-free.app`
+
+## Curl tests
+Verify bind:
+```bash
+curl -s http://localhost:8080/api/v1/license/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"license_key":"EDL-AB12-CD34-EF56","account_login":123456,"account_server":"Broker-Server","ea_id":"MarketKiller","ea_version":"3.13"}'
+```
+
+Admin unbind:
+```bash
+curl -s http://localhost:8080/api/v1/admin/license/unbind \
+  -H 'Content-Type: application/json' \
+  -H 'x-admin-key: change_me_super_secret' \
+  -d '{"license_key":"EDL-AB12-CD34-EF56","seat_index":0}'
+```
+
+Create checkout (optional now):
+```bash
+curl -s http://localhost:8080/api/v1/checkout/create-session \
+  -H 'Content-Type: application/json' \
+  -d '{"license_key":"EDL-AB12-CD34-EF56"}'
+```

--- a/server-api/package.json
+++ b/server-api/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "ea-licensing-server-api",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:deploy": "prisma migrate deploy",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.4.0",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0",
+    "stripe": "^16.8.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.10",
+    "prisma": "^5.18.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/server-api/prisma/schema.prisma
+++ b/server-api/prisma/schema.prisma
@@ -1,0 +1,58 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum LicenseStatus {
+  ACTIVE
+  SUSPENDED
+  CANCELED
+  EXPIRED
+}
+
+model License {
+  id                  String        @id @default(uuid())
+  licenseKey          String        @unique
+  plan                String
+  status              LicenseStatus
+  stripeCustomerId    String?
+  stripeSubscriptionId String?
+  currentPeriodEnd    DateTime?
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
+
+  seats               LicenseSeat[]
+  events              LicenseEvent[]
+}
+
+model LicenseSeat {
+  id            String   @id @default(uuid())
+  licenseId     String
+  seatIndex     Int
+  accountLogin  BigInt?
+  accountServer String?
+  boundAt       DateTime?
+  lastSeenAt    DateTime?
+
+  license       License  @relation(fields: [licenseId], references: [id], onDelete: Cascade)
+
+  @@unique([licenseId, seatIndex])
+  @@index([accountLogin, accountServer])
+}
+
+model LicenseEvent {
+  id        String   @id @default(uuid())
+  licenseId String?
+  eventType String
+  payload   Json
+  createdAt DateTime @default(now())
+
+  license   License? @relation(fields: [licenseId], references: [id], onDelete: SetNull)
+
+  @@index([licenseId])
+  @@index([createdAt])
+}

--- a/server-api/prisma/seed.ts
+++ b/server-api/prisma/seed.ts
@@ -1,0 +1,32 @@
+import { PrismaClient, LicenseStatus } from "@prisma/client";
+import { generateLicenseKey } from "../src/utils/licenseKey";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const key = generateLicenseKey();
+
+  const license = await prisma.license.create({
+    data: {
+      licenseKey: key,
+      plan: "PRO_199",
+      status: LicenseStatus.ACTIVE,
+      currentPeriodEnd: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+      seats: {
+        create: [{ seatIndex: 0 }, { seatIndex: 1 }]
+      }
+    },
+    include: { seats: true }
+  });
+
+  console.log("Seeded license:", license.licenseKey);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server-api/src/app.ts
+++ b/server-api/src/app.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import helmet from "helmet";
+import cors from "cors";
+import morgan from "morgan";
+import path from "path";
+import { ipLimiter } from "./middleware/rateLimit";
+import { errorHandler } from "./middleware/errorHandler";
+
+import licenseRoutes from "./routes/license";
+import adminRoutes from "./routes/admin";
+import stripeRoutes from "./routes/stripe";
+import checkoutRoutes from "./routes/checkout";
+import webappRoutes from "./routes/webapp";
+
+export const app = express();
+
+app.use(helmet());
+app.use(cors());
+
+app.use("/api/v1/stripe/webhook", express.raw({ type: "application/json" }));
+app.use(express.json({ limit: "1mb" }));
+
+app.use(morgan("combined"));
+app.use("/api/", ipLimiter);
+
+const webappPath = path.resolve(process.cwd(), "../webapp");
+app.use("/webapp", express.static(webappPath));
+
+app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.use("/api/v1/license", licenseRoutes);
+app.use("/api/v1/admin", adminRoutes);
+app.use("/api/v1/stripe", stripeRoutes);
+app.use("/api/v1/checkout", checkoutRoutes);
+app.use("/api/v1/webapp", webappRoutes);
+
+app.use(errorHandler);

--- a/server-api/src/config.ts
+++ b/server-api/src/config.ts
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+function must(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env var: ${name}`);
+  return v;
+}
+
+export const config = {
+  port: parseInt(process.env.PORT || "8080", 10),
+  baseUrl: process.env.BASE_URL || "http://localhost:8080",
+  nodeEnv: process.env.NODE_ENV || "development",
+
+  databaseUrl: must("DATABASE_URL"),
+
+  stripeSecretKey: process.env.STRIPE_SECRET_KEY || "",
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET || "",
+  priceIdPro199: process.env.PRICE_ID_PRO_199 || "",
+
+  adminApiKey: must("ADMIN_API_KEY"),
+  botToken: must("BOT_TOKEN"),
+  devBypassInitData: (process.env.DEV_BYPASS_INITDATA || "false").toLowerCase() === "true",
+
+  rlPerLicensePerMin: parseInt(process.env.RL_PER_LICENSE_PER_MIN || "30", 10),
+  rlPerIpPerMin: parseInt(process.env.RL_PER_IP_PER_MIN || "60", 10),
+
+  graceSeconds: 48 * 3600,
+};

--- a/server-api/src/index.ts
+++ b/server-api/src/index.ts
@@ -1,0 +1,6 @@
+import { app } from "./app";
+import { config } from "./config";
+
+app.listen(config.port, () => {
+  console.log(`Server API listening on :${config.port}`);
+});

--- a/server-api/src/middleware/adminAuth.ts
+++ b/server-api/src/middleware/adminAuth.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from "express";
+import { config } from "../config";
+
+export function adminAuth(req: Request, res: Response, next: NextFunction) {
+  const k = req.header("x-admin-key");
+  if (!k || k !== config.adminApiKey) {
+    return res.status(401).json({ error: "UNAUTHORIZED" });
+  }
+  next();
+}

--- a/server-api/src/middleware/errorHandler.ts
+++ b/server-api/src/middleware/errorHandler.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from "express";
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  console.error("Unhandled error:", err?.message || err);
+  res.status(500).json({ error: "INTERNAL_ERROR" });
+}

--- a/server-api/src/middleware/rateLimit.ts
+++ b/server-api/src/middleware/rateLimit.ts
@@ -1,0 +1,20 @@
+import rateLimit from "express-rate-limit";
+import { config } from "../config";
+
+export const ipLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: config.rlPerIpPerMin,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const licenseLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: config.rlPerLicensePerMin,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const lk = (req.body?.license_key || req.query?.license_key || "").toString();
+    return lk ? `LK:${lk}` : `LK:__missing__:${req.ip}`;
+  }
+});

--- a/server-api/src/middleware/tgAuth.ts
+++ b/server-api/src/middleware/tgAuth.ts
@@ -1,0 +1,33 @@
+import crypto from "crypto";
+import { Request, Response, NextFunction } from "express";
+import { config } from "../config";
+
+function verifyInitData(initData: string, botToken: string): boolean {
+  if (!initData) return false;
+  const params = new URLSearchParams(initData);
+  const hash = params.get("hash");
+  if (!hash) return false;
+
+  params.delete("hash");
+  const dataCheckString = Array.from(params.keys())
+    .sort()
+    .map((k) => `${k}=${params.get(k)}`)
+    .join("\n");
+
+  const secretKey = crypto.createHash("sha256").update(botToken).digest();
+  const calc = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex");
+  return calc === hash;
+}
+
+export function tgInitDataAuth(req: Request, res: Response, next: NextFunction) {
+  if (config.devBypassInitData) return next();
+  const initData = (req.header("x-tg-initdata") || "").toString();
+  const ok = verifyInitData(initData, config.botToken);
+  if (!ok) return res.status(401).json({ error: "UNAUTHORIZED_INITDATA" });
+  next();
+}
+
+export function verifyInitDataRaw(initData: string): boolean {
+  if (config.devBypassInitData) return true;
+  return verifyInitData(initData, config.botToken);
+}

--- a/server-api/src/middleware/validate.ts
+++ b/server-api/src/middleware/validate.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express";
+import { ZodSchema } from "zod";
+
+export function validateBody(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "BAD_REQUEST", details: parsed.error.flatten() });
+    }
+    req.body = parsed.data;
+    next();
+  };
+}

--- a/server-api/src/prisma.ts
+++ b/server-api/src/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/server-api/src/routes/admin.ts
+++ b/server-api/src/routes/admin.ts
@@ -1,0 +1,44 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { adminAuth } from "../middleware/adminAuth";
+import { adminUnbindSeat } from "../services/licenseService";
+import { prisma } from "../prisma";
+
+const router = Router();
+
+const UnbindSchema = z.object({
+  license_key: z.string().min(10),
+  seat_index: z.number().int().min(0).max(1)
+});
+
+router.post("/license/unbind", adminAuth, validateBody(UnbindSchema), async (req, res) => {
+  const r = await adminUnbindSeat(req.body);
+  if (!r.ok) return res.status(404).json({ ok: false, error: r.error });
+  res.json({ ok: true });
+});
+
+router.get("/license/status/:license_key", adminAuth, async (req, res) => {
+  const key = req.params.license_key.toUpperCase();
+  const lic = await prisma.license.findUnique({
+    where: { licenseKey: key },
+    include: { seats: true }
+  });
+  if (!lic) return res.status(404).json({ error: "NOT_FOUND" });
+
+  res.json({
+    license_key: lic.licenseKey,
+    plan: lic.plan,
+    status: lic.status,
+    current_period_end: lic.currentPeriodEnd?.toISOString() ?? null,
+    seats: lic.seats.map((s) => ({
+      seat_index: s.seatIndex,
+      account_login: s.accountLogin ? s.accountLogin.toString() : null,
+      account_server: s.accountServer ?? null,
+      bound_at: s.boundAt?.toISOString() ?? null,
+      last_seen_at: s.lastSeenAt?.toISOString() ?? null
+    }))
+  });
+});
+
+export default router;

--- a/server-api/src/routes/checkout.ts
+++ b/server-api/src/routes/checkout.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { createCheckoutSession } from "../services/stripeService";
+
+const router = Router();
+
+const CreateSessionSchema = z.object({
+  license_key: z.string().min(10)
+});
+
+router.post("/create-session", validateBody(CreateSessionSchema), async (req, res, next) => {
+  try {
+    const r = await createCheckoutSession(req.body);
+    res.json(r);
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default router;

--- a/server-api/src/routes/license.ts
+++ b/server-api/src/routes/license.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { licenseLimiter } from "../middleware/rateLimit";
+import { verifyAndBindSeat } from "../services/licenseService";
+
+const router = Router();
+
+const VerifySchema = z.object({
+  license_key: z.string().min(10),
+  account_login: z.union([z.number().int().nonnegative(), z.string()]).transform((v) => BigInt(v)),
+  account_server: z.string().min(3).max(128),
+  ea_id: z.string().min(2).max(64),
+  ea_version: z.string().min(1).max(32)
+});
+
+router.post(
+  "/verify",
+  licenseLimiter,
+  validateBody(VerifySchema),
+  async (req, res, next) => {
+    try {
+      const r = await verifyAndBindSeat(req.body);
+      res.json(r);
+    } catch (e) {
+      next(e);
+    }
+  }
+);
+
+export default router;

--- a/server-api/src/routes/stripe.ts
+++ b/server-api/src/routes/stripe.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import { stripe, handleStripeWebhook } from "../services/stripeService";
+import { config } from "../config";
+
+const router = Router();
+
+router.post("/webhook", async (req, res) => {
+  const sig = req.headers["stripe-signature"];
+  if (!sig || typeof sig !== "string") {
+    return res.status(400).send("Missing stripe-signature");
+  }
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, config.stripeWebhookSecret);
+  } catch (err: any) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  try {
+    await handleStripeWebhook(event);
+    res.json({ received: true });
+  } catch (e) {
+    console.error("Webhook handler error:", e);
+    res.status(500).send("Webhook handler failed");
+  }
+});
+
+export default router;

--- a/server-api/src/routes/webapp.ts
+++ b/server-api/src/routes/webapp.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { z } from "zod";
+import { getLicenseStatusReadOnly } from "../services/licenseService";
+import { tgInitDataAuth, verifyInitDataRaw } from "../middleware/tgAuth";
+
+const router = Router();
+
+router.get("/license/status", tgInitDataAuth, async (req, res) => {
+  const q = z.object({ license_key: z.string().min(10) }).safeParse(req.query);
+  if (!q.success) return res.status(400).json({ error: "BAD_REQUEST" });
+
+  const r = await getLicenseStatusReadOnly(q.data.license_key);
+  if (!r) return res.status(404).json({ error: "NOT_FOUND" });
+  return res.json(r);
+});
+
+router.post("/auth/verify", (req, res) => {
+  const initData = (req.header("x-tg-initdata") || "").toString();
+  const ok = verifyInitDataRaw(initData);
+  if (!ok) return res.status(401).json({ ok: false });
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server-api/src/services/licenseService.ts
+++ b/server-api/src/services/licenseService.ts
@@ -1,0 +1,189 @@
+import { prisma } from "../prisma";
+import { LicenseStatus } from "@prisma/client";
+import { normalizeLicenseKey } from "../utils/licenseKey";
+import { config } from "../config";
+
+export type VerifyResult = {
+  status: "VALID" | "INVALID";
+  expires_at: string | null;
+  seats_used: number;
+  seats_max: number;
+  grace_seconds: number;
+  code: string;
+  message: string;
+};
+
+function seatsUsed(seats: { accountLogin: bigint | null }[]): number {
+  return seats.filter(s => s.accountLogin !== null).length;
+}
+
+function valid(currentPeriodEnd: Date | null, used: number, code: string, message: string): VerifyResult {
+  return {
+    status: "VALID",
+    expires_at: currentPeriodEnd ? currentPeriodEnd.toISOString() : null,
+    seats_used: used,
+    seats_max: 2,
+    grace_seconds: config.graceSeconds,
+    code,
+    message
+  };
+}
+
+function invalid(currentPeriodEnd: Date | null, code: string, message: string): VerifyResult {
+  return {
+    status: "INVALID",
+    expires_at: currentPeriodEnd ? currentPeriodEnd.toISOString() : null,
+    seats_used: 0,
+    seats_max: 2,
+    grace_seconds: config.graceSeconds,
+    code,
+    message
+  };
+}
+
+async function logEvent(licenseId: string | null, eventType: string, payload: any) {
+  await prisma.licenseEvent.create({
+    data: { licenseId, eventType, payload }
+  });
+}
+
+function safeParams(p: any) {
+  return {
+    license_key: p.license_key,
+    account_login: p.account_login?.toString?.() ?? p.account_login,
+    account_server: p.account_server,
+    ea_id: p.ea_id,
+    ea_version: p.ea_version
+  };
+}
+
+export async function verifyAndBindSeat(params: {
+  license_key: string;
+  account_login: bigint;
+  account_server: string;
+  ea_id: string;
+  ea_version: string;
+}): Promise<VerifyResult> {
+  const licenseKey = normalizeLicenseKey(params.license_key);
+  const now = new Date();
+
+  const lic = await prisma.license.findUnique({
+    where: { licenseKey },
+    include: { seats: true }
+  });
+
+  if (!lic) {
+    await logEvent(null, "VERIFY_DENY", { code: "NOT_FOUND", licenseKey, ...safeParams(params) });
+    return invalid(null, "NOT_FOUND", "License not found");
+  }
+
+  if (lic.status === LicenseStatus.SUSPENDED) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "SUSPENDED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "SUSPENDED", "Subscription suspended (payment issue)");
+  }
+  if (lic.status === LicenseStatus.CANCELED) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "CANCELED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "CANCELED", "Subscription canceled");
+  }
+  if (!lic.currentPeriodEnd || lic.currentPeriodEnd <= now) {
+    if (lic.status !== LicenseStatus.EXPIRED) {
+      await prisma.license.update({ where: { id: lic.id }, data: { status: LicenseStatus.EXPIRED } });
+    }
+    await logEvent(lic.id, "VERIFY_DENY", { code: "EXPIRED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "EXPIRED", "Subscription expired");
+  }
+  if (lic.status !== LicenseStatus.ACTIVE) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "INVALID_STATUS", status: lic.status, ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "INVALID_STATUS", "License not active");
+  }
+
+  const existing = lic.seats.find(
+    (s) => s.accountLogin === params.account_login && (s.accountServer || "") === params.account_server
+  );
+
+  if (existing) {
+    await prisma.licenseSeat.update({ where: { id: existing.id }, data: { lastSeenAt: now } });
+    await logEvent(lic.id, "VERIFY_OK", { bound: true, seatIndex: existing.seatIndex, ...safeParams(params) });
+    return valid(lic.currentPeriodEnd, seatsUsed(lic.seats), "OK", "License valid (seat already bound)");
+  }
+
+  const freeSeat = lic.seats.find((s) => s.accountLogin === null);
+  if (!freeSeat) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "SEATS_FULL", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "SEATS_FULL", "Seats full (max 2 MT5 accounts)");
+  }
+
+  const updated = await prisma.licenseSeat.updateMany({
+    where: { id: freeSeat.id, accountLogin: null },
+    data: {
+      accountLogin: params.account_login,
+      accountServer: params.account_server,
+      boundAt: now,
+      lastSeenAt: now
+    }
+  });
+
+  if (updated.count !== 1) {
+    const lic2 = await prisma.license.findUnique({ where: { licenseKey }, include: { seats: true } });
+    if (!lic2) return invalid(null, "NOT_FOUND", "License not found");
+
+    const ex2 = lic2.seats.find(
+      (s) => s.accountLogin === params.account_login && (s.accountServer || "") === params.account_server
+    );
+    if (ex2) {
+      await logEvent(lic.id, "VERIFY_OK", { bound: true, seatIndex: ex2.seatIndex, race: true, ...safeParams(params) });
+      return valid(lic.currentPeriodEnd, seatsUsed(lic2.seats), "OK", "License valid (seat already bound)");
+    }
+
+    const free2 = lic2.seats.find((s) => s.accountLogin === null);
+    if (!free2) {
+      await logEvent(lic.id, "VERIFY_DENY", { code: "SEATS_FULL", race: true, ...safeParams(params) });
+      return invalid(lic.currentPeriodEnd, "SEATS_FULL", "Seats full (max 2 MT5 accounts)");
+    }
+
+    await prisma.licenseSeat.update({
+      where: { id: free2.id },
+      data: {
+        accountLogin: params.account_login,
+        accountServer: params.account_server,
+        boundAt: now,
+        lastSeenAt: now
+      }
+    });
+
+    await logEvent(lic.id, "BIND_SEAT", { seatIndex: free2.seatIndex, ...safeParams(params) });
+    return valid(lic.currentPeriodEnd, seatsUsed(lic2.seats) + 1, "OK", "License valid (seat bound)");
+  }
+
+  await logEvent(lic.id, "BIND_SEAT", { seatIndex: freeSeat.seatIndex, ...safeParams(params) });
+  return valid(lic.currentPeriodEnd, seatsUsed(lic.seats) + 1, "OK", "License valid (seat bound)");
+}
+
+export async function adminUnbindSeat(params: { license_key: string; seat_index: number }) {
+  const licenseKey = normalizeLicenseKey(params.license_key);
+  const lic = await prisma.license.findUnique({ where: { licenseKey }, include: { seats: true } });
+  if (!lic) return { ok: false, error: "NOT_FOUND" };
+
+  const seat = lic.seats.find((s) => s.seatIndex === params.seat_index);
+  if (!seat) return { ok: false, error: "SEAT_NOT_FOUND" };
+
+  await prisma.licenseSeat.update({
+    where: { id: seat.id },
+    data: { accountLogin: null, accountServer: null, boundAt: null, lastSeenAt: null }
+  });
+  await logEvent(lic.id, "ADMIN_UNBIND", { seatIndex: params.seat_index });
+
+  return { ok: true };
+}
+
+export async function getLicenseStatusReadOnly(license_key: string): Promise<VerifyResult | null> {
+  const licenseKey = normalizeLicenseKey(license_key);
+  const lic = await prisma.license.findUnique({ where: { licenseKey }, include: { seats: true } });
+  if (!lic) return null;
+
+  const now = new Date();
+  if (!lic.currentPeriodEnd || lic.currentPeriodEnd <= now || lic.status !== LicenseStatus.ACTIVE) {
+    return invalid(lic.currentPeriodEnd, lic.status === LicenseStatus.ACTIVE ? "EXPIRED" : lic.status, "License not active");
+  }
+  return valid(lic.currentPeriodEnd, seatsUsed(lic.seats), "OK", "License valid");
+}

--- a/server-api/src/services/stripeService.ts
+++ b/server-api/src/services/stripeService.ts
@@ -1,0 +1,137 @@
+import Stripe from "stripe";
+import { config } from "../config";
+import { prisma } from "../prisma";
+import { LicenseStatus } from "@prisma/client";
+import { normalizeLicenseKey } from "../utils/licenseKey";
+
+export const stripe = new Stripe(config.stripeSecretKey || "sk_test_placeholder", {
+  apiVersion: "2024-06-20"
+});
+
+function mapSubStatusToLicenseStatus(subStatus: Stripe.Subscription.Status): LicenseStatus {
+  if (subStatus === "active" || subStatus === "trialing") return LicenseStatus.ACTIVE;
+  if (subStatus === "past_due" || subStatus === "unpaid") return LicenseStatus.SUSPENDED;
+  if (subStatus === "canceled") return LicenseStatus.CANCELED;
+  return LicenseStatus.SUSPENDED;
+}
+
+export async function handleStripeWebhook(event: Stripe.Event) {
+  switch (event.type) {
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      const sub = event.data.object as Stripe.Subscription;
+      await upsertSubscription(sub);
+      break;
+    }
+    case "invoice.paid":
+    case "invoice.payment_failed": {
+      const inv = event.data.object as Stripe.Invoice;
+      if (inv.subscription) {
+        const sub = await stripe.subscriptions.retrieve(inv.subscription as string);
+        await upsertSubscription(sub);
+      }
+      break;
+    }
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      await handleCheckoutCompleted(session);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+async function upsertSubscription(sub: Stripe.Subscription) {
+  const currentPeriodEnd = sub.current_period_end ? new Date(sub.current_period_end * 1000) : null;
+  const status = mapSubStatusToLicenseStatus(sub.status);
+
+  const licBySub = await prisma.license.findFirst({ where: { stripeSubscriptionId: sub.id } });
+  if (licBySub) {
+    await prisma.license.update({
+      where: { id: licBySub.id },
+      data: {
+        stripeCustomerId: (sub.customer as string) || licBySub.stripeCustomerId,
+        status,
+        currentPeriodEnd
+      }
+    });
+    await prisma.licenseEvent.create({
+      data: {
+        licenseId: licBySub.id,
+        eventType: "WEBHOOK_UPDATE",
+        payload: { type: "subscription", subId: sub.id, status: sub.status, currentPeriodEnd }
+      }
+    });
+    return;
+  }
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: null,
+      eventType: "WEBHOOK_UPDATE",
+      payload: { type: "subscription_unlinked", subId: sub.id, status: sub.status, currentPeriodEnd }
+    }
+  });
+}
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
+  const licenseKey = normalizeLicenseKey((session.metadata?.license_key || "").toString());
+  if (!licenseKey) return;
+
+  const customerId = (session.customer as string) || null;
+  const subId = (session.subscription as string) || null;
+  if (!subId) return;
+
+  const sub = await stripe.subscriptions.retrieve(subId);
+  const currentPeriodEnd = sub.current_period_end ? new Date(sub.current_period_end * 1000) : null;
+  const status = mapSubStatusToLicenseStatus(sub.status);
+
+  const lic = await prisma.license.findUnique({ where: { licenseKey } });
+  if (!lic) return;
+
+  await prisma.license.update({
+    where: { id: lic.id },
+    data: {
+      stripeCustomerId: customerId || lic.stripeCustomerId,
+      stripeSubscriptionId: subId,
+      status,
+      currentPeriodEnd
+    }
+  });
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: lic.id,
+      eventType: "WEBHOOK_UPDATE",
+      payload: { type: "checkout_completed_linked", licenseKey, customerId, subId, status: sub.status, currentPeriodEnd }
+    }
+  });
+}
+
+export async function createCheckoutSession(params: { license_key: string }) {
+  if (!config.priceIdPro199) throw new Error("PRICE_ID_MISSING");
+  const licenseKey = normalizeLicenseKey(params.license_key);
+
+  const lic = await prisma.license.findUnique({ where: { licenseKey } });
+  if (!lic) throw new Error("LICENSE_NOT_FOUND");
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    line_items: [{ price: config.priceIdPro199, quantity: 1 }],
+    success_url: `${config.baseUrl}/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${config.baseUrl}/cancel`,
+    metadata: { license_key: licenseKey }
+  });
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: lic.id,
+      eventType: "CHECKOUT_CREATED",
+      payload: { sessionId: session.id }
+    }
+  });
+
+  return { url: session.url };
+}

--- a/server-api/src/utils/licenseKey.ts
+++ b/server-api/src/utils/licenseKey.ts
@@ -1,0 +1,10 @@
+import crypto from "crypto";
+
+export function generateLicenseKey(): string {
+  const chunk = () => crypto.randomBytes(2).toString("hex").toUpperCase().slice(0, 4);
+  return `EDL-${chunk()}-${chunk()}-${chunk()}`.replace(/[^A-Z0-9-]/g, "X");
+}
+
+export function normalizeLicenseKey(key: string): string {
+  return key.trim().toUpperCase();
+}

--- a/server-api/tsconfig.json
+++ b/server-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  }
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,19 @@
+# Server
+PORT=8080
+BASE_URL=http://localhost:8080
+NODE_ENV=development
+
+# DB
+DATABASE_URL=postgresql://postgres:postgres@db:5432/licensing?schema=public
+
+# Stripe
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+PRICE_ID_PRO_199=price_xxx
+
+# Admin
+ADMIN_API_KEY=change_me_super_secret
+
+# Rate limits
+RL_PER_LICENSE_PER_MIN=30
+RL_PER_IP_PER_MIN=60

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run prisma:generate
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/package.json ./package.json
+EXPOSE 8080
+CMD ["node","dist/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,73 @@
+# EA Licensing Server (MT5) - Stripe subscription + 2 seats
+
+## Features
+- Stripe subscription 199 EUR/month (Checkout mode subscription)
+- License verify endpoint: bind max 2 MT5 accounts (login+server)
+- Verify at EA startup and every 6 hours (EA side)
+- Grace period 48h if API unreachable (EA side)
+- Admin unbind seat endpoint (x-admin-key)
+- Audit log in LicenseEvent
+- Rate limiting per IP + per license_key
+
+## Setup
+1) Copy env:
+   cp .env.example .env
+   Edit STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, PRICE_ID_PRO_199, ADMIN_API_KEY
+
+2) Start:
+   docker compose up --build
+
+3) Seed demo license:
+   (in another terminal)
+   docker compose exec api npm run seed
+
+It will print a key like: EDL-AB12-CD34-EF56
+
+## Stripe setup
+- Create Product: "EA PRO"
+- Create Price: 199 EUR / month
+- Put PRICE_ID_PRO_199=price_xxx in .env
+
+## Webhooks (local) via Stripe CLI
+stripe login
+stripe listen --forward-to localhost:8080/api/v1/stripe/webhook
+Copy the shown webhook secret into STRIPE_WEBHOOK_SECRET.
+
+Also enable events:
+- customer.subscription.created
+- customer.subscription.updated
+- customer.subscription.deleted
+- invoice.paid
+- invoice.payment_failed
+- checkout.session.completed
+
+## Create Checkout Session
+POST /api/v1/checkout/create-session
+Body:
+{"license_key":"EDL-...."}
+
+Response:
+{"url":"https://checkout.stripe.com/..."}
+Open url, pay.
+
+Webhook checkout.session.completed will link the subscription to the license (using metadata.license_key).
+
+## Verify license (MT5 EA calls this)
+POST /api/v1/license/verify
+Body:
+{
+  "license_key":"EDL-....",
+  "account_login":123456,
+  "account_server":"Broker-Server",
+  "ea_id":"MarketKiller",
+  "ea_version":"3.13"
+}
+
+## Admin unbind
+POST /api/v1/admin/license/unbind
+Header: x-admin-key: ADMIN_API_KEY
+Body: {"license_key":"EDL-....","seat_index":0}
+
+## Notes
+- This server trusts DB fields updated by Stripe webhooks as source-of-truth.
+- Put behind HTTPS in production (reverse proxy like Nginx / Cloudflare).

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: licensing
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  api:
+    build: .
+    depends_on:
+      - db
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+    command: sh -c "npx prisma migrate deploy && node dist/index.js"
+
+volumes:
+  pgdata:

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ea-licensing-server",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:deploy": "prisma migrate deploy",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.4.0",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0",
+    "pino": "^9.3.2",
+    "pino-http": "^10.3.0",
+    "stripe": "^16.8.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.10",
+    "prisma": "^5.18.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,58 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum LicenseStatus {
+  ACTIVE
+  SUSPENDED
+  CANCELED
+  EXPIRED
+}
+
+model License {
+  id                  String        @id @default(uuid())
+  licenseKey          String        @unique
+  plan                String
+  status              LicenseStatus
+  stripeCustomerId     String?
+  stripeSubscriptionId String?
+  currentPeriodEnd     DateTime?
+  createdAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
+
+  seats                LicenseSeat[]
+  events               LicenseEvent[]
+}
+
+model LicenseSeat {
+  id            String   @id @default(uuid())
+  licenseId     String
+  seatIndex     Int
+  accountLogin  BigInt?
+  accountServer String?
+  boundAt       DateTime?
+  lastSeenAt    DateTime?
+
+  license       License  @relation(fields: [licenseId], references: [id], onDelete: Cascade)
+
+  @@unique([licenseId, seatIndex])
+  @@index([accountLogin, accountServer])
+}
+
+model LicenseEvent {
+  id        String   @id @default(uuid())
+  licenseId String?
+  eventType String
+  payload   Json
+  createdAt DateTime @default(now())
+
+  license   License? @relation(fields: [licenseId], references: [id], onDelete: SetNull)
+
+  @@index([licenseId])
+  @@index([createdAt])
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,0 +1,35 @@
+import { PrismaClient, LicenseStatus } from "@prisma/client";
+import { generateLicenseKey } from "../src/utils/licenseKey";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const key = generateLicenseKey();
+
+  const license = await prisma.license.create({
+    data: {
+      licenseKey: key,
+      plan: "PRO_199",
+      status: LicenseStatus.ACTIVE,
+      currentPeriodEnd: new Date(Date.now() + 30 * 24 * 3600 * 1000),
+      seats: {
+        create: [
+          { seatIndex: 0 },
+          { seatIndex: 1 }
+        ]
+      }
+    },
+    include: { seats: true }
+  });
+
+  console.log("Seeded license:", license.licenseKey);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import helmet from "helmet";
+import cors from "cors";
+import morgan from "morgan";
+import { ipLimiter } from "./middleware/rateLimit";
+import { errorHandler } from "./middleware/errorHandler";
+
+import licenseRoutes from "./routes/license";
+import adminRoutes from "./routes/admin";
+import stripeRoutes from "./routes/stripe";
+import checkoutRoutes from "./routes/checkout";
+
+export const app = express();
+
+app.use(helmet());
+app.use(cors());
+
+app.use("/api/v1/stripe/webhook", express.raw({ type: "application/json" }));
+app.use(express.json({ limit: "1mb" }));
+
+app.use(morgan("combined"));
+app.use("/api/", ipLimiter);
+
+app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.use("/api/v1/license", licenseRoutes);
+app.use("/api/v1/admin", adminRoutes);
+app.use("/api/v1/stripe", stripeRoutes);
+app.use("/api/v1/checkout", checkoutRoutes);
+
+app.use(errorHandler);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,27 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+function must(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env var: ${name}`);
+  return v;
+}
+
+export const config = {
+  port: parseInt(process.env.PORT || "8080", 10),
+  baseUrl: process.env.BASE_URL || "http://localhost:8080",
+  nodeEnv: process.env.NODE_ENV || "development",
+
+  databaseUrl: must("DATABASE_URL"),
+
+  stripeSecretKey: must("STRIPE_SECRET_KEY"),
+  stripeWebhookSecret: must("STRIPE_WEBHOOK_SECRET"),
+  priceIdPro199: must("PRICE_ID_PRO_199"),
+
+  adminApiKey: must("ADMIN_API_KEY"),
+
+  rlPerLicensePerMin: parseInt(process.env.RL_PER_LICENSE_PER_MIN || "30", 10),
+  rlPerIpPerMin: parseInt(process.env.RL_PER_IP_PER_MIN || "60", 10),
+
+  graceSeconds: 48 * 3600,
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,6 @@
+import { app } from "./app";
+import { config } from "./config";
+
+app.listen(config.port, () => {
+  console.log(`Licensing API listening on :${config.port}`);
+});

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from "express";
+import { config } from "../config";
+
+export function adminAuth(req: Request, res: Response, next: NextFunction) {
+  const k = req.header("x-admin-key");
+  if (!k || k !== config.adminApiKey) {
+    return res.status(401).json({ error: "UNAUTHORIZED" });
+  }
+  next();
+}

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from "express";
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  console.error("Unhandled error:", err?.message || err);
+  res.status(500).json({ error: "INTERNAL_ERROR" });
+}

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -1,0 +1,20 @@
+import rateLimit from "express-rate-limit";
+import { config } from "../config";
+
+export const ipLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: config.rlPerIpPerMin,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const licenseLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: config.rlPerLicensePerMin,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const lk = (req.body?.license_key || req.body?.licenseKey || "").toString();
+    return lk ? `LK:${lk}` : `LK:__missing__:${req.ip}`;
+  }
+});

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express";
+import { ZodSchema } from "zod";
+
+export function validateBody(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "BAD_REQUEST", details: parsed.error.flatten() });
+    }
+    req.body = parsed.data;
+    next();
+  };
+}

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,44 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { adminAuth } from "../middleware/adminAuth";
+import { adminUnbindSeat } from "../services/licenseService";
+import { prisma } from "../prisma";
+
+const router = Router();
+
+const UnbindSchema = z.object({
+  license_key: z.string().min(10),
+  seat_index: z.number().int().min(0).max(1)
+});
+
+router.post("/license/unbind", adminAuth, validateBody(UnbindSchema), async (req, res) => {
+  const r = await adminUnbindSeat(req.body);
+  if (!r.ok) return res.status(404).json({ ok: false, error: r.error });
+  res.json({ ok: true });
+});
+
+router.get("/license/status/:license_key", adminAuth, async (req, res) => {
+  const key = req.params.license_key.toUpperCase();
+  const lic = await prisma.license.findUnique({
+    where: { licenseKey: key },
+    include: { seats: true }
+  });
+  if (!lic) return res.status(404).json({ error: "NOT_FOUND" });
+
+  res.json({
+    license_key: lic.licenseKey,
+    plan: lic.plan,
+    status: lic.status,
+    current_period_end: lic.currentPeriodEnd?.toISOString() ?? null,
+    seats: lic.seats.map(s => ({
+      seat_index: s.seatIndex,
+      account_login: s.accountLogin ? s.accountLogin.toString() : null,
+      account_server: s.accountServer ?? null,
+      bound_at: s.boundAt?.toISOString() ?? null,
+      last_seen_at: s.lastSeenAt?.toISOString() ?? null
+    }))
+  });
+});
+
+export default router;

--- a/server/src/routes/checkout.ts
+++ b/server/src/routes/checkout.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { createCheckoutSession } from "../services/stripeService";
+
+const router = Router();
+
+const CreateSessionSchema = z.object({
+  license_key: z.string().min(10)
+});
+
+router.post("/create-session", validateBody(CreateSessionSchema), async (req, res, next) => {
+  try {
+    const r = await createCheckoutSession(req.body);
+    res.json(r);
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default router;

--- a/server/src/routes/license.ts
+++ b/server/src/routes/license.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validateBody } from "../middleware/validate";
+import { licenseLimiter } from "../middleware/rateLimit";
+import { verifyAndBindSeat } from "../services/licenseService";
+
+const router = Router();
+
+const VerifySchema = z.object({
+  license_key: z.string().min(10),
+  account_login: z.union([z.number().int().nonnegative(), z.string()]).transform((v) => BigInt(v)),
+  account_server: z.string().min(3).max(128),
+  ea_id: z.string().min(2).max(64),
+  ea_version: z.string().min(1).max(32)
+});
+
+router.post(
+  "/verify",
+  licenseLimiter,
+  validateBody(VerifySchema),
+  async (req, res, next) => {
+    try {
+      const r = await verifyAndBindSeat(req.body);
+      res.json(r);
+    } catch (e) {
+      next(e);
+    }
+  }
+);
+
+export default router;

--- a/server/src/routes/stripe.ts
+++ b/server/src/routes/stripe.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import { stripe, handleStripeWebhook } from "../services/stripeService";
+import { config } from "../config";
+
+const router = Router();
+
+router.post("/webhook", async (req, res) => {
+  const sig = req.headers["stripe-signature"];
+  if (!sig || typeof sig !== "string") {
+    return res.status(400).send("Missing stripe-signature");
+  }
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, config.stripeWebhookSecret);
+  } catch (err: any) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  try {
+    await handleStripeWebhook(event);
+    res.json({ received: true });
+  } catch (e) {
+    console.error("Webhook handler error:", e);
+    res.status(500).send("Webhook handler failed");
+  }
+});
+
+export default router;

--- a/server/src/services/licenseService.ts
+++ b/server/src/services/licenseService.ts
@@ -1,0 +1,194 @@
+import { prisma } from "../prisma";
+import { LicenseStatus } from "@prisma/client";
+import { normalizeLicenseKey } from "../utils/licenseKey";
+import { config } from "../config";
+
+export type VerifyResult = {
+  status: "VALID" | "INVALID";
+  expires_at: string | null;
+  seats_used: number;
+  seats_max: number;
+  grace_seconds: number;
+  code: string;
+  message: string;
+};
+
+function seatsUsed(seats: { accountLogin: bigint | null }[]): number {
+  return seats.filter(s => s.accountLogin !== null).length;
+}
+
+export async function verifyAndBindSeat(params: {
+  license_key: string;
+  account_login: bigint;
+  account_server: string;
+  ea_id: string;
+  ea_version: string;
+}): Promise<VerifyResult> {
+  const licenseKey = normalizeLicenseKey(params.license_key);
+  const now = new Date();
+
+  const lic = await prisma.license.findUnique({
+    where: { licenseKey },
+    include: { seats: true }
+  });
+
+  if (!lic) {
+    await prisma.licenseEvent.create({
+      data: {
+        licenseId: null,
+        eventType: "VERIFY_DENY",
+        payload: { code: "NOT_FOUND", licenseKey, ...safeParams(params) }
+      }
+    });
+    return invalid(null, "NOT_FOUND", "License not found");
+  }
+
+  if (lic.status === LicenseStatus.SUSPENDED) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "SUSPENDED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "SUSPENDED", "Subscription suspended (payment issue)");
+  }
+  if (lic.status === LicenseStatus.CANCELED) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "CANCELED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "CANCELED", "Subscription canceled");
+  }
+  if (!lic.currentPeriodEnd || lic.currentPeriodEnd <= now) {
+    if (lic.status !== LicenseStatus.EXPIRED) {
+      await prisma.license.update({
+        where: { id: lic.id },
+        data: { status: LicenseStatus.EXPIRED }
+      });
+    }
+    await logEvent(lic.id, "VERIFY_DENY", { code: "EXPIRED", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "EXPIRED", "Subscription expired");
+  }
+  if (lic.status !== LicenseStatus.ACTIVE) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "INVALID_STATUS", status: lic.status, ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "INVALID_STATUS", "License not active");
+  }
+
+  const existing = lic.seats.find(s =>
+    s.accountLogin === params.account_login && (s.accountServer || "") === params.account_server
+  );
+
+  if (existing) {
+    await prisma.licenseSeat.update({
+      where: { id: existing.id },
+      data: { lastSeenAt: now }
+    });
+    await logEvent(lic.id, "VERIFY_OK", { bound: true, seatIndex: existing.seatIndex, ...safeParams(params) });
+
+    const used = seatsUsed(lic.seats);
+    return valid(lic.currentPeriodEnd, used, "OK", "License valid (seat already bound)");
+  }
+
+  const freeSeat = lic.seats.find(s => s.accountLogin === null);
+
+  if (!freeSeat) {
+    await logEvent(lic.id, "VERIFY_DENY", { code: "SEATS_FULL", ...safeParams(params) });
+    return invalid(lic.currentPeriodEnd, "SEATS_FULL", "Seats full (max 2 MT5 accounts)");
+  }
+
+  const updated = await prisma.licenseSeat.updateMany({
+    where: { id: freeSeat.id, accountLogin: null },
+    data: {
+      accountLogin: params.account_login,
+      accountServer: params.account_server,
+      boundAt: now,
+      lastSeenAt: now
+    }
+  });
+
+  if (updated.count !== 1) {
+    const lic2 = await prisma.license.findUnique({
+      where: { licenseKey },
+      include: { seats: true }
+    });
+    if (!lic2) return invalid(null, "NOT_FOUND", "License not found");
+    const ex2 = lic2.seats.find(s => s.accountLogin === params.account_login && (s.accountServer || "") === params.account_server);
+    if (ex2) {
+      await logEvent(lic.id, "VERIFY_OK", { bound: true, seatIndex: ex2.seatIndex, race: true, ...safeParams(params) });
+      return valid(lic.currentPeriodEnd, seatsUsed(lic2.seats), "OK", "License valid (seat already bound)");
+    }
+    const free2 = lic2.seats.find(s => s.accountLogin === null);
+    if (!free2) {
+      await logEvent(lic.id, "VERIFY_DENY", { code: "SEATS_FULL", race: true, ...safeParams(params) });
+      return invalid(lic.currentPeriodEnd, "SEATS_FULL", "Seats full (max 2 MT5 accounts)");
+    }
+    await prisma.licenseSeat.update({
+      where: { id: free2.id },
+      data: {
+        accountLogin: params.account_login,
+        accountServer: params.account_server,
+        boundAt: now,
+        lastSeenAt: now
+      }
+    });
+    await logEvent(lic.id, "BIND_SEAT", { seatIndex: free2.seatIndex, ...safeParams(params) });
+    return valid(lic.currentPeriodEnd, seatsUsed(lic2.seats) + 1, "OK", "License valid (seat bound)");
+  }
+
+  await logEvent(lic.id, "BIND_SEAT", { seatIndex: freeSeat.seatIndex, ...safeParams(params) });
+
+  const used = seatsUsed(lic.seats) + 1;
+  return valid(lic.currentPeriodEnd, used, "OK", "License valid (seat bound)");
+}
+
+export async function adminUnbindSeat(params: { license_key: string; seat_index: number }) {
+  const licenseKey = normalizeLicenseKey(params.license_key);
+  const lic = await prisma.license.findUnique({
+    where: { licenseKey },
+    include: { seats: true }
+  });
+  if (!lic) return { ok: false, error: "NOT_FOUND" };
+
+  const seat = lic.seats.find(s => s.seatIndex === params.seat_index);
+  if (!seat) return { ok: false, error: "SEAT_NOT_FOUND" };
+
+  await prisma.licenseSeat.update({
+    where: { id: seat.id },
+    data: { accountLogin: null, accountServer: null, boundAt: null, lastSeenAt: null }
+  });
+  await logEvent(lic.id, "ADMIN_UNBIND", { seatIndex: params.seat_index });
+
+  return { ok: true };
+}
+
+function valid(currentPeriodEnd: Date | null, used: number, code: string, message: string): VerifyResult {
+  return {
+    status: "VALID",
+    expires_at: currentPeriodEnd ? currentPeriodEnd.toISOString() : null,
+    seats_used: used,
+    seats_max: 2,
+    grace_seconds: config.graceSeconds,
+    code,
+    message
+  };
+}
+
+function invalid(currentPeriodEnd: Date | null, code: string, message: string): VerifyResult {
+  return {
+    status: "INVALID",
+    expires_at: currentPeriodEnd ? currentPeriodEnd.toISOString() : null,
+    seats_used: 0,
+    seats_max: 2,
+    grace_seconds: config.graceSeconds,
+    code,
+    message
+  };
+}
+
+async function logEvent(licenseId: string, eventType: string, payload: any) {
+  await prisma.licenseEvent.create({
+    data: { licenseId, eventType, payload }
+  });
+}
+
+function safeParams(p: any) {
+  return {
+    license_key: p.license_key,
+    account_login: p.account_login?.toString?.() ?? p.account_login,
+    account_server: p.account_server,
+    ea_id: p.ea_id,
+    ea_version: p.ea_version
+  };
+}

--- a/server/src/services/stripeService.ts
+++ b/server/src/services/stripeService.ts
@@ -1,0 +1,159 @@
+import Stripe from "stripe";
+import { config } from "../config";
+import { prisma } from "../prisma";
+import { LicenseStatus } from "@prisma/client";
+import { normalizeLicenseKey } from "../utils/licenseKey";
+
+export const stripe = new Stripe(config.stripeSecretKey, {
+  apiVersion: "2024-06-20"
+});
+
+function mapSubStatusToLicenseStatus(subStatus: Stripe.Subscription.Status): LicenseStatus {
+  if (subStatus === "active" || subStatus === "trialing") return LicenseStatus.ACTIVE;
+  if (subStatus === "past_due" || subStatus === "unpaid") return LicenseStatus.SUSPENDED;
+  if (subStatus === "canceled") return LicenseStatus.CANCELED;
+  return LicenseStatus.SUSPENDED;
+}
+
+export async function handleStripeWebhook(event: Stripe.Event) {
+  switch (event.type) {
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      const sub = event.data.object as Stripe.Subscription;
+      await upsertSubscription(sub);
+      break;
+    }
+
+    case "invoice.paid": {
+      const inv = event.data.object as Stripe.Invoice;
+      if (inv.subscription) {
+        const sub = await stripe.subscriptions.retrieve(inv.subscription as string);
+        await upsertSubscription(sub);
+      }
+      break;
+    }
+
+    case "invoice.payment_failed": {
+      const inv = event.data.object as Stripe.Invoice;
+      if (inv.subscription) {
+        const sub = await stripe.subscriptions.retrieve(inv.subscription as string);
+        await upsertSubscription(sub);
+      }
+      break;
+    }
+
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      await handleCheckoutCompleted(session);
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+async function upsertSubscription(sub: Stripe.Subscription) {
+  const currentPeriodEnd = sub.current_period_end ? new Date(sub.current_period_end * 1000) : null;
+  const status = mapSubStatusToLicenseStatus(sub.status);
+
+  const licBySub = await prisma.license.findFirst({
+    where: { stripeSubscriptionId: sub.id }
+  });
+
+  if (licBySub) {
+    await prisma.license.update({
+      where: { id: licBySub.id },
+      data: {
+        stripeCustomerId: (sub.customer as string) || licBySub.stripeCustomerId,
+        status,
+        currentPeriodEnd
+      }
+    });
+    await prisma.licenseEvent.create({
+      data: {
+        licenseId: licBySub.id,
+        eventType: "WEBHOOK_UPDATE",
+        payload: { type: "subscription", subId: sub.id, status: sub.status, currentPeriodEnd }
+      }
+    });
+    return;
+  }
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: null,
+      eventType: "WEBHOOK_UPDATE",
+      payload: { type: "subscription_unlinked", subId: sub.id, status: sub.status, currentPeriodEnd }
+    }
+  });
+}
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
+  const licenseKey = normalizeLicenseKey((session.metadata?.license_key || "").toString());
+  if (!licenseKey) return;
+
+  const customerId = (session.customer as string) || null;
+  const subId = (session.subscription as string) || null;
+  if (!subId) return;
+
+  const sub = await stripe.subscriptions.retrieve(subId);
+  const currentPeriodEnd = sub.current_period_end ? new Date(sub.current_period_end * 1000) : null;
+  const status = mapSubStatusToLicenseStatus(sub.status);
+
+  const lic = await prisma.license.findUnique({ where: { licenseKey } });
+  if (!lic) {
+    await prisma.licenseEvent.create({
+      data: {
+        licenseId: null,
+        eventType: "WEBHOOK_UPDATE",
+        payload: { type: "checkout_completed_license_not_found", licenseKey, customerId, subId }
+      }
+    });
+    return;
+  }
+
+  await prisma.license.update({
+    where: { id: lic.id },
+    data: {
+      stripeCustomerId: customerId || lic.stripeCustomerId,
+      stripeSubscriptionId: subId,
+      status,
+      currentPeriodEnd
+    }
+  });
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: lic.id,
+      eventType: "WEBHOOK_UPDATE",
+      payload: { type: "checkout_completed_linked", licenseKey, customerId, subId, status: sub.status, currentPeriodEnd }
+    }
+  });
+}
+
+export async function createCheckoutSession(params: { license_key: string }) {
+  const licenseKey = normalizeLicenseKey(params.license_key);
+
+  const lic = await prisma.license.findUnique({ where: { licenseKey } });
+  if (!lic) throw new Error("LICENSE_NOT_FOUND");
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    line_items: [{ price: config.priceIdPro199, quantity: 1 }],
+    success_url: `${config.baseUrl}/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${config.baseUrl}/cancel`,
+    metadata: { license_key: licenseKey }
+  });
+
+  await prisma.licenseEvent.create({
+    data: {
+      licenseId: lic.id,
+      eventType: "CHECKOUT_CREATED",
+      payload: { sessionId: session.id }
+    }
+  });
+
+  return { url: session.url };
+}

--- a/server/src/utils/licenseKey.ts
+++ b/server/src/utils/licenseKey.ts
@@ -1,0 +1,10 @@
+import crypto from "crypto";
+
+export function generateLicenseKey(): string {
+  const chunk = () => crypto.randomBytes(2).toString("hex").toUpperCase().slice(0,4);
+  return `EDL-${chunk()}-${chunk()}-${chunk()}`.replace(/[^A-Z0-9-]/g, "X");
+}
+
+export function normalizeLicenseKey(key: string): string {
+  return key.trim().toUpperCase();
+}

--- a/server/src/utils/time.ts
+++ b/server/src/utils/time.ts
@@ -1,0 +1,3 @@
+export function toIso(d: Date | null): string | null {
+  return d ? d.toISOString() : null;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  }
+}

--- a/telegram-bot/Dockerfile
+++ b/telegram-bot/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["node", "dist/index.js"]

--- a/telegram-bot/README.md
+++ b/telegram-bot/README.md
@@ -1,0 +1,13 @@
+# Telegram Bot
+
+## Setup
+- Create bot via BotFather
+- Put `BOT_TOKEN` in `server-api/.env`
+- Set `WEBAPP_URL` env to your tunnel URL + `/webapp`
+
+## Run standalone
+npm install
+npm run dev
+
+## In Docker Compose
+Service `telegram-bot` uses `BOT_TOKEN` and `WEBAPP_URL` env vars.

--- a/telegram-bot/package.json
+++ b/telegram-bot/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ea-telegram-bot",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "grammy": "^1.28.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/telegram-bot/src/index.ts
+++ b/telegram-bot/src/index.ts
@@ -1,0 +1,28 @@
+import dotenv from "dotenv";
+import { Bot, Keyboard } from "grammy";
+
+dotenv.config({ path: process.env.BOT_ENV_FILE || "../server-api/.env" });
+
+const token = process.env.BOT_TOKEN;
+const webAppUrl = process.env.WEBAPP_URL || "http://localhost:8080/webapp";
+
+if (!token) throw new Error("Missing BOT_TOKEN");
+
+const bot = new Bot(token);
+
+bot.command("start", async (ctx) => {
+  const kb = new Keyboard().text("🚀 Apri App", { web_app: { url: webAppUrl } }).resized();
+  await ctx.reply("Benvenuto nel pannello licenze EA.", { reply_markup: kb });
+});
+
+bot.command("menu", async (ctx) => {
+  const kb = new Keyboard().text("🚀 Apri App", { web_app: { url: webAppUrl } }).resized();
+  await ctx.reply("Menu pronto.", { reply_markup: kb });
+});
+
+bot.catch((err) => {
+  console.error("Bot error", err.error);
+});
+
+bot.start();
+console.log("Telegram bot started");

--- a/telegram-bot/tsconfig.json
+++ b/telegram-bot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -1,0 +1,37 @@
+const tg = window.Telegram?.WebApp;
+if (tg) tg.ready();
+
+const initData = tg?.initData || "";
+const out = document.getElementById("out");
+const adminMode = new URLSearchParams(location.search).get("admin") === "1";
+if (adminMode) document.getElementById("adminBox").style.display = "block";
+
+async function refresh() {
+  const licenseKey = document.getElementById("licenseKey").value.trim();
+  if (!licenseKey) return;
+  const res = await fetch(`/api/v1/webapp/license/status?license_key=${encodeURIComponent(licenseKey)}`, {
+    headers: { "x-tg-initdata": initData }
+  });
+  const data = await res.json();
+  out.textContent = JSON.stringify(data, null, 2);
+}
+
+async function unbind() {
+  const licenseKey = document.getElementById("licenseKey").value.trim();
+  const seat_index = parseInt(document.getElementById("seatIdx").value, 10);
+  const adminKey = document.getElementById("adminKey").value.trim();
+  const res = await fetch("/api/v1/admin/license/unbind", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-admin-key": adminKey,
+      "x-tg-initdata": initData
+    },
+    body: JSON.stringify({ license_key: licenseKey, seat_index })
+  });
+  const data = await res.json();
+  out.textContent = JSON.stringify(data, null, 2);
+}
+
+document.getElementById("refreshBtn").addEventListener("click", refresh);
+document.getElementById("unbindBtn")?.addEventListener("click", unbind);

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>EA License Panel</title>
+  <link rel="stylesheet" href="/webapp/style.css" />
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+</head>
+<body>
+  <div class="card">
+    <h1>EA License Panel</h1>
+    <label>License Key</label>
+    <input id="licenseKey" placeholder="EDL-XXXX-XXXX-XXXX" />
+    <button id="refreshBtn">Refresh</button>
+
+    <pre id="out"></pre>
+
+    <div id="adminBox" style="display:none;">
+      <h3>Admin Unbind</h3>
+      <input id="seatIdx" type="number" min="0" max="1" value="0" />
+      <input id="adminKey" placeholder="x-admin-key" />
+      <button id="unbindBtn">Unbind Seat</button>
+    </div>
+  </div>
+
+  <script src="/webapp/app.js"></script>
+</body>
+</html>

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; background:#111; color:#eee; margin:0; padding:20px; }
+.card { max-width: 640px; margin:0 auto; background:#1a1a1a; border-radius:12px; padding:20px; }
+input,button { width:100%; margin-top:8px; padding:10px; border-radius:8px; border:1px solid #444; background:#222; color:#fff; }
+button { cursor:pointer; background:#2b6ef2; border:none; }
+pre { background:#0f0f0f; padding:12px; border-radius:8px; overflow:auto; }


### PR DESCRIPTION
### Motivation
- Provide a local-first, tunnel-ready monorepo so the EA, a Telegram WebApp and a licensing backend can be developed and tested without a VPS or domain (use ngrok/Cloudflare Tunnel). 
- Enforce a server-driven 2-seat subscription model with a 48h grace period and allow future Stripe integration while keeping local seed-based operation. 
- Give the EA a simple server-side license check that binds seats on first use and blocks only new entries when license invalid or grace expired. 

### Description
- Added a complete `server-api/` service (Node.js + TypeScript + Express + Prisma) with routes `license`, `admin`, `stripe`, `checkout`, and `webapp`, middleware for rate-limiting/admin auth/Telegram initData verification, and services for license logic and Stripe webhook/checkout handling. 
- Implemented Prisma schema and seed that create `License`, `LicenseSeat`, and `LicenseEvent` models and a demo ACTIVE license with two empty seats, plus `verifyAndBindSeat` logic (race-safe bind, status checks, audit events) and admin `unbind` endpoints. 
- Included a static `webapp/` UI that calls `/api/v1/webapp/*` (Telegram WebApp initData validated server-side with dev bypass), a `telegram-bot/` service (grammy) that exposes the WebApp button, and root `docker-compose.yml` to run `postgres`, `server-api`, and `telegram-bot` locally. 
- Delivered an MT5 module `mql5/LicenseClient.mqh` and updated EA hooks so the EA calls the API at startup + periodic interval (default 6h), honors `grace_seconds` = 48h, and exposes `License_CanOpenNewTrades()` and `License_CanManageOpenTrades()` gates; added strategy/PatternScores modules used by the EA. 

### Testing
- Ran repository consistency checks with `git diff --check` which reported no whitespace/index issues. 
- Verified presence and wiring of key integration points via ripgrep searches for `api/v1/webapp`, `tgInitDataAuth`, `verifyAndBindSeat`, `createCheckoutSession`, `License_CanOpenNewTrades`, `EventSetTimer(` and `ngrok http 8080` which matched the expected files. 
- Committed the new files and confirmed repository state with `git status -sb` and the changes were successfully committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a4758bc88323afc59fcbc5932479)